### PR TITLE
chore: add healthcheck for both client and server

### DIFF
--- a/lib/healthcheck.js
+++ b/lib/healthcheck.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+
+module.exports = router;
+
+router.route('/').get(function (req, res, next) {
+  // Only check currently is that the webserver is up
+  res.status(200).json({ ok: true });
+});

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -12,6 +12,7 @@ function main({ key = null, cert = null, port = 7341 } = {}, altPort = null) {
 
   app.disable('x-powered-by');
   app.use(bodyParser.json());
+  app.use('/healthcheck', require('./healthcheck'));
 
   if (altPort) {
     port = altPort;

--- a/test/functional/healthcheck.test.js
+++ b/test/functional/healthcheck.test.js
@@ -46,8 +46,6 @@ test('client healthcheck', t => {
   process.env.SECRET = 'secret';
   process.env.PORT = localPort;
   process.env.ACCEPT = 'filters.json';
-  // process.env.BROKER_URL = `http://localhost:${serverPort}`;
-  // process.env.BROKER_ID = '12345';
   process.env.BROKER_TYPE = 'client';
   const client = app.main({ port: port() });
 

--- a/test/functional/healthcheck.test.js
+++ b/test/functional/healthcheck.test.js
@@ -1,0 +1,65 @@
+const tap = require('tap');
+const test = require('tap-only');
+const path = require('path');
+const request = require('request');
+const app = require('../../lib');
+
+const { port, localPort } = require('../utils')(tap);
+
+test('server healthcheck', t => {
+  /**
+   * 1. start broker in server mode
+   * 2. send healthcheck request to server, assert HTTP 200 and `{ ok: true }`
+   */
+
+  const root = __dirname;
+
+  process.chdir(path.resolve(root, '../fixtures/server'));
+  const serverPort = port();
+  process.env.BROKER_TYPE = 'server';
+  process.env.ACCEPT = 'filters.json';
+  const server = app.main({ port: serverPort });
+
+  const url = `http://localhost:${serverPort}/healthcheck`;
+  request({url, json: true }, (err, res) => {
+    if (err) {
+      t.fail(err);
+    }
+
+    t.equal(res.statusCode, 200, '200 statusCode');
+    t.equal(res.body['ok'], true, '{ ok: true } in body');
+    server.close();
+    t.end();
+  });
+});
+
+test('client healthcheck', t => {
+  /**
+   * 1. start broker in client mode
+   * 2. send healthcheck request to server, assert HTTP 200 and `{ ok: true }`
+   */
+
+  const root = __dirname;
+
+  process.chdir(path.resolve(root, '../fixtures/client'));
+  const serverPort = port();
+  process.env.SECRET = 'secret';
+  process.env.PORT = localPort;
+  process.env.ACCEPT = 'filters.json';
+  // process.env.BROKER_URL = `http://localhost:${serverPort}`;
+  // process.env.BROKER_ID = '12345';
+  process.env.BROKER_TYPE = 'client';
+  const client = app.main({ port: port() });
+
+  const url = `http://localhost:${localPort}/healthcheck`;
+  request({url, json: true }, (err, res) => {
+    if (err) {
+      t.fail(err);
+    }
+
+    t.equal(res.statusCode, 200, '200 statusCode');
+    t.equal(res.body['ok'], true, '{ ok: true } in body');
+    client.close();
+    t.end();
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by @joshje 

#### What does this PR do?
Add's a simple health check to the client and server at `/healthcheck`

#### How should this be manually tested?
Fire up a broker server and client, and curl `/healthcheck` on each.

#### Any background context you want to provide?
This is useful when running the broker server behind a load balancer. It has been also included on the client in case it proves useful in future (and to keep the codebase simple).