### PR TITLE
test: multiple clients connecting

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -25,7 +25,8 @@ module.exports = ({ config = {}, port = null, filters = {} }) => {
       return res.status(404).send();
     }
 
-    res.locals.io = connections.get(id);
+    // Grab a first (newest) client from the pool
+    res.locals.io = connections.get(id)[0];
 
      // strip the leading url
     req.url = req.url.slice(`/broker/${id}`.length);

--- a/lib/server/socket.js
+++ b/lib/server/socket.js
@@ -21,7 +21,13 @@ module.exports = ({ server, filters, config }) => {
     const close = () => {
       if (token) {
         debug('client %s closed', token);
-        connections.delete(token);
+        const clientPool = connections.get(token).filter(_ => _ !== socket);
+        if (clientPool.length) {
+          debug('client %s still have %s connection/s', token, clientPool.length);
+          return connections.set(token, clientPool);
+        }
+        debug('removing client %s', token);
+        return connections.delete(token);
       }
     };
 
@@ -30,7 +36,9 @@ module.exports = ({ server, filters, config }) => {
     socket.on('identify', _ => {
       token = _;
       debug('client identified as %s', token);
-      connections.set(token, socket);
+      const clientPool = connections.get(token) || [];
+      clientPool.unshift(socket);
+      connections.set(token, clientPool);
       socket.on('request', response(token));
     });
     socket.on('close', close);

--- a/test/functional/client-pool.test.js
+++ b/test/functional/client-pool.test.js
@@ -1,0 +1,95 @@
+const tap = require('tap');
+const test = require('tap-only');
+const path = require('path');
+const request = require('request');
+const app = require('../../lib');
+const root = __dirname;
+
+const { port, echoServerPort } = require('../utils')(tap);
+
+test('correctly handle pool of multiple clients with same BROKER_TOKEN', t => {
+  /**
+   * 1. start broker in server mode
+   * 2. start broker in client mode and join
+   * 3. run local http server that replicates "private server"
+   * 4. send request to the server
+   * 5. start a 2nd broker in client mode and join (2nd client becomes primary)
+   * 6. send request to the server
+   * 7. disconnect 1st client
+   * 8. connection through server should still work through 2nd client
+   *
+   */
+
+  t.plan(6);
+
+  process.env.ACCEPT = 'filters.json';
+
+  process.chdir(path.resolve(root, '../fixtures/server'));
+  process.env.BROKER_TYPE = 'server';
+  const serverPort = port();
+  const server = app.main({ port: serverPort });
+
+  process.chdir(path.resolve(root, '../fixtures/client'));
+  process.env.BROKER_TYPE = 'client';
+  process.env.BROKER_TOKEN = '12345';
+  process.env.BROKER_SERVER_URL = `http://localhost:${serverPort}`;
+  process.env.ORIGIN_PORT = echoServerPort;
+  const client = app.main({ port: port() });
+
+  let secondClient = {};
+
+  // wait for the client to successfully connect to the server and identify itself
+  server.io.once('connection', socket => {
+    socket.on('identify', token => {
+      t.test('successfully broker POST with 1st connected client', t => {
+        const url = `http://localhost:${serverPort}/broker/${token}/echo-body`;
+        request({ url, method: 'post', json: true }, (err, res) => {
+          t.equal(res.statusCode, 200, '200 statusCode');
+          t.end();
+        });
+      });
+
+      t.test('launch a 2nd client', t => {
+        server.io.on('connection', socket => {
+          socket.once('identify', () => {
+            t.ok('2nd client connected');
+            t.end();
+          });
+        });
+
+        secondClient = app.main({ port: (port() - 1) }); // Run it on a different port
+      });
+
+      t.test('successfully broker POST with 2nd client', t => {
+        const url = `http://localhost:${serverPort}/broker/${token}/echo-body`;
+        request({ url, method: 'post', json: true }, (err, res) => {
+          t.equal(res.statusCode, 200, '200 statusCode');
+          t.end();
+        });
+      });
+
+      t.test('close 1st client', t => {
+        client.close();
+        t.ok('1st client closed');
+        t.end();
+      });
+
+      t.test('successfully broker POST with 2nd client', t => {
+        const url = `http://localhost:${serverPort}/broker/${token}/echo-body`;
+        request({ url, method: 'post', json: true }, (err, res) => {
+          t.equal(res.statusCode, 200, '200 statusCode');
+          t.end();
+        });
+      });
+
+      t.test('clean up', t => {
+        secondClient.close();
+        setTimeout(() => {
+          server.close();
+          t.ok('sockets closed');
+          t.end();
+        }, 100);
+      });
+    });
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by @gjvis

#### What does this PR do?
Fixes an issue when 2 clients using same `BROKER_TOKEN` can unintentionally disconnect each other. 

#### How should this be manually tested?
Run a server, connect 2 clients and then disconnect the one that connected first.

#### Any background context you want to provide?
Happened when Heroku was rotating the dyno:

- 1st client was connected and running
- Heroku started 2nd Client dyno, it connected to the broker server and correctly became the primary client for specified token
- 1st dyno was shut down, but it sent a `close` event, removing 2nd dyno as well

The result was that both Server and Client was running and Client had no idea it was disconnected.

It also opens up a possibility to run a fleet of clients as failovers