### PR TITLE
chore: remove listeners for online/offline events on primus server

### DIFF
--- a/lib/server/socket.js
+++ b/lib/server/socket.js
@@ -11,8 +11,6 @@ module.exports = ({ server, filters, config }) => {
   const response = relay.response(filters, config);
 
   io.on('error', error => console.error(error.stack));
-  io.on('offline', () => console.error('Internet access has gone offline'));
-  io.on('online', () => console.error('Access online'));
 
   io.on('connection', function (socket) {
     debug('new client connection');


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by @ … (Snyk internal team)

#### What does this PR do?

The online/offline events only work on the Primus client so this patch removes the listeners for these events from the server.

#### Where should the reviewer start?


#### How should this be manually tested?

#### Any background context you want to provide?
See https://github.com/primus/primus/blob/b1c33dfc1439ad6df8add9435246bcf1130532d2/primus.js#L248-L260 and https://github.com/primus/primus/blob/b1c33dfc1439ad6df8add9435246bcf1130532d2/primus.js#L555-L603.

#### What are the relevant tickets?


#### Screenshots


#### Additional questions

