### PR TITLE
feat: add clients' health endpoint

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -15,6 +15,11 @@ module.exports = ({ port = null, config = {}, filters = {} }) => {
   // start the local webserver to listen for relay requests
   const { app, server } = require('../webserver')(config, port);
 
+  // IMPORTANT: defined before relay (`app.all('/*', ...`)
+  app.get('/healthcheck', (req, res, next) => {
+    return res.status(200).json({ ok: true });
+  });
+
   app.all('/*', (req, res, next) => {
     res.locals.io = io;
     next();

--- a/lib/healthcheck.js
+++ b/lib/healthcheck.js
@@ -1,9 +1,0 @@
-const express = require('express');
-const router = express.Router();
-
-module.exports = router;
-
-router.route('/').get(function (req, res, next) {
-  // Only check currently is that the webserver is up
-  res.status(200).json({ ok: true });
-});

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,6 @@ function main({ port, client } = {}) {
     filters = yaml.safeLoad(fs.readFileSync(acceptLocation, 'utf8'));
   }
 
-
   // if the config has the broker server, then we must assume it's a client
   return app[method]({ config, port, filters });
 }
@@ -47,4 +46,3 @@ function main({ port, client } = {}) {
 if (!module.parent) {
   main();
 }
-

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -15,8 +15,19 @@ module.exports = ({ config = {}, port = null, filters = {} }) => {
     config,
   });
 
-  app.all('/broker/:id/*', (req, res, next) => {
+  // before the `app.all('/broker/:id/*'` route
+  app.get('/broker/:id', (req, res) => {
+    const id = req.params.id;
 
+    if (connections.has(id)) {
+      return res.status(200).json({ ok: true });
+    }
+
+    debug('no broker found matching "%s"', id);
+    return res.status(404).json({ ok: false });
+  });
+
+  app.all('/broker/:id/*', (req, res, next) => {
     const id = req.params.id;
 
     // check if we have this broker in the connections
@@ -34,6 +45,9 @@ module.exports = ({ config = {}, port = null, filters = {} }) => {
 
     next();
   }, relay.request(filters.public));
+
+  app.get('/healthcheck', (req, res) =>
+          res.status(200).json({ ok: true }));
 
   return {
     io,

--- a/lib/server/socket.js
+++ b/lib/server/socket.js
@@ -25,6 +25,7 @@ module.exports = ({ server, filters, config }) => {
           return connections.set(token, clientPool);
         }
         debug('removing client %s', token);
+        // TODO: log/emit warning
         return connections.delete(token);
       }
     };

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -30,7 +30,6 @@ function main({ key = null, cert = null, port = 7341 } = {}, altPort = null) {
   app.use(markEmptyRequestBody);
   app.use(bodyParser.raw({ type: '*/*' }));
   app.use(stripEmptyRequestBody);
-  app.use('/healthcheck', require('./healthcheck'));
 
   if (altPort) {
     port = altPort;

--- a/test/functional/healthcheck.test.js
+++ b/test/functional/healthcheck.test.js
@@ -12,6 +12,8 @@ test('proxy requests originating from behind the broker client', t => {
    * 1. start broker in server mode
    * 2. start broker in client mode and join (1)
    * 3. check /healthcheck on client and server
+   * 4. stop client and check it's on "disconnected" in the server
+   * 5. restart client with same token, make sure it's not in "disconnected"
    */
 
   process.env.ACCEPT = 'filters.json';
@@ -20,19 +22,23 @@ test('proxy requests originating from behind the broker client', t => {
   process.env.BROKER_TYPE = 'server';
   const serverPort = port();
   const server = app.main({ port: serverPort });
+  const BROKER_TOKEN = '12345';
 
   process.chdir(path.resolve(root, '../fixtures/client'));
   process.env.BROKER_TYPE = 'client';
-  process.env.BROKER_TOKEN = '12345';
+  process.env.BROKER_TOKEN = BROKER_TOKEN;
   process.env.BROKER_SERVER_URL = `http://localhost:${serverPort}`;
   const clientPort = port();
-  const client = app.main({ port: clientPort });
+  let client = app.main({ port: clientPort });
 
-  t.plan(3);
+  t.plan(6);
 
+  const serverHealth = `http://localhost:${serverPort}/healthcheck`;
+  const serverClientHealth = `http://localhost:${serverPort}/` +
+          `broker/${BROKER_TOKEN}`;
+  const clientHealth = `http://localhost:${clientPort}/healthcheck`;
   t.test('server healthcheck', t => {
-    const url = `http://localhost:${serverPort}/healthcheck`;
-    request({url, json: true }, (err, res) => {
+    request({url: serverHealth, json: true }, (err, res) => {
       if (err) { return t.threw(err); }
 
       t.equal(res.statusCode, 200, '200 statusCode');
@@ -45,14 +51,48 @@ test('proxy requests originating from behind the broker client', t => {
   server.io.once('connection', socket => {
     socket.once('identify', () => {
       t.test('client healthcheck', t => {
-        const url = `http://localhost:${clientPort}/healthcheck`;
-        request({url, json: true }, (err, res) => {
+        request({url: clientHealth, json: true }, (err, res) => {
           if (err) { return t.threw(err); }
 
           t.equal(res.statusCode, 200, '200 statusCode');
           t.equal(res.body['ok'], true, '{ ok: true } in body');
           t.end();
         });
+      });
+
+      t.test('serve client-health with connected client', t => {
+        request({url: serverClientHealth, json: true }, (err, res) => {
+          if (err) { return t.threw(err); }
+
+          t.equal(res.statusCode, 200, '200 statusCode');
+          t.equal(res.body['ok'], true, '{ ok: true } in body');
+          t.end();
+        });
+      });
+
+      t.test('server client-health after client disconnected', t => {
+        client.close();
+        setTimeout(() => {
+          request({url: serverClientHealth, json: true }, (err, res) => {
+            if (err) { return t.threw(err); }
+
+            t.equal(res.statusCode, 404, '404 statusCode');
+            t.end();
+          });
+        }, 100);
+      });
+
+      t.test('server client-health after client re-connected', t => {
+        client = app.main({ port: clientPort });
+        setTimeout(() => {
+          request({url: serverClientHealth, json: true }, (err, res) => {
+            if (err) { return t.threw(err); }
+
+            t.equal(res.statusCode, 200, '200 statusCode');
+            t.equal(res.body['ok'], true, '{ ok: true } in body');
+            t.end();
+          });
+        }, 20);
       });
 
       t.test('clean up', t => {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by @ … (Snyk internal team)

#### What does this PR do?
adds the client's connection status to the server healthcheck.

#### How should this be manually tested?
run both a server and a client locally. call `/healthcheck` before and after stopping the client, and then restart the client again and call `/healthcheck` again.

