### PR TITLE
fix: ignore case of client broker id

### DIFF
--- a/lib/server/socket.js
+++ b/lib/server/socket.js
@@ -35,7 +35,7 @@ module.exports = ({ server, filters, config }) => {
     // TODO decide if the socket doesn't identify itself within X period,
     // should we toss it away?
     socket.on('identify', _ => {
-      token = _;
+      token = _.toLowerCase();
       logger.info('client identified');
       debug('client identified with %s', token);
       const clientPool = connections.get(token) || [];


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by @

#### What does this PR do?

Server is now lower-casing the client identifying token.

Snyk requests made to the broker server always carry a lower-case uuid token, and using an upper-case token on the client config will create a mismatch on the server.