### PR TITLE
fix: sanitise sensitive tokens from logs

### DIFF
--- a/lib/client/socket.js
+++ b/lib/client/socket.js
@@ -29,7 +29,7 @@ module.exports = ({ url, token, filters, config }) => {
 
   const io = new Socket(url);
 
-  logger.info('connecting to %s', url);
+  logger.info({ url }, 'connecting');
 
   const response = relay.response(filters, config);
 
@@ -42,7 +42,7 @@ module.exports = ({ url, token, filters, config }) => {
     }
   });
   io.on('open', () => {
-    logger.info({token, url}, 'identifying');
+    logger.info({ token, url }, 'identifying');
     io.send('identify', token);
   });
 

--- a/lib/filters/index.js
+++ b/lib/filters/index.js
@@ -50,7 +50,7 @@ module.exports = ruleSource => {
       path = '/' + path;
     }
 
-    logger.info('new filter: %s %s', method, path);
+    logger.info({ method, path }, 'new filter');
     const regexp = pathRegexp(path, keys);
 
     return (req) => {
@@ -88,7 +88,7 @@ module.exports = ruleSource => {
         }
       }
 
-      logger.debug('match %s -> %s', path, origin + url);
+      logger.debug({ path, origin, url }, 'match');
 
       querystring = (querystring) ? `?${querystring}` : '';
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,11 +28,10 @@ function main({ port, client } = {}) {
   const method = client ? 'client' : 'server';
   process.env.BROKER_TYPE = method;
 
-  logger.debug('config.accept:', config.accept);
+  logger.debug({ accept: config.accept }, 'loading rules');
 
   let filters = {};
   if (config.accept) {
-    logger.debug('loading rules from %s', config.accept);
     const acceptLocation = path.resolve(process.cwd(), config.accept);
 
     filters = yaml.safeLoad(fs.readFileSync(acceptLocation, 'utf8'));

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,8 +1,35 @@
 const bunyan = require('bunyan');
-const log = bunyan.createLogger({name: 'snyk-broker', src: true});
+const config = require('./config');
 
-if (process.env.CI == 1) {
-  log.level('warn');
+// sanitises sensitive values, replacing all occurences with label
+function sanitise(raw) {
+  if (!raw || typeof raw !== 'string') {
+    return raw;
+  }
+
+  // Copies original `raw`, doesn't mutate it.
+  // Regexp is case-insensitive, global and multiline matching,
+  // this way all occurences are replaced.
+  if (config.BROKER_TOKEN) {
+    raw = raw.replace(new RegExp(config.BROKER_TOKEN, 'igm'), 'BROKER_TOKEN');
+  }
+
+  if (config.GITHUB_TOKEN) {
+    raw = raw.replace(new RegExp(config.GITHUB_TOKEN, 'igm'), 'GITHUB_TOKEN');
+  }
+
+  return raw;
 }
+
+const log = bunyan.createLogger({
+  name: 'snyk-broker',
+  serializers: {
+    token: sanitise,
+    result: sanitise,
+    url: sanitise,
+  },
+});
+
+log.level(process.env.LOG_LEVEL || 'info');
 
 module.exports = log;

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -18,12 +18,12 @@ function requestHandler(filterRules) {
   return (req, res) => {
     filters(req, (error, result) => {
       if (error) {
-        logger.info('blocked %s %s', req.method, req.url);
+        logger.info({ method: req.method, url: req.url }, 'blocked');
         return res.status(401).send(error.message);
       }
 
       req.url = result;
-      logger.info('send socket request for', req.url);
+      logger.info({ url: req.url }, 'send socket request');
 
       // send the socket request containing the http request we're after
       res.locals.io.send('request', {
@@ -32,7 +32,11 @@ function requestHandler(filterRules) {
         body: req.body,
         headers: req.headers,
       }, response => {
-        logger.info('%s %s (%s)', req.method, req.url, response.status);
+        logger.info({
+          method: req.method,
+          url: req.url,
+          status: response.status,
+        }, 'response');
         res.status(response.status)
           .set(response.headers)
           .send(response.body);
@@ -46,17 +50,17 @@ function responseHandler(filterRules, config) {
 
   return (brokerToken) => ({ url, headers, method, body = null } = {}, emit) => {
     // run the request through the filter
-    logger.info('request captured', url, method);
+    logger.info({ method, url }, 'request captured');
     filters({ url, method, body }, (error, result) => {
       if (error) {
-        logger.info('blocked %s %s', method, url);
+        logger.info({ method, url }, 'blocked');
         return emit({
           status: 401,
           body: error.message,
         });
       }
 
-      logger.info('requesting %s', result);
+      logger.info({ result }, 'requesting');
       if (result.startsWith('http') === false) {
         result = 'https://' + result;
       }
@@ -83,7 +87,7 @@ function responseHandler(filterRules, config) {
         const parsedBody = tryJSONParse(body);
 
         if (parsedBody.BROKER_VAR_SUB) {
-          logger.debug('variable swap on ', parsedBody.BROKER_VAR_SUB);
+          logger.debug(parsedBody.BROKER_VAR_SUB, 'variable swap');
           for (const path of parsedBody.BROKER_VAR_SUB) {
             let source = undefsafe(parsedBody, path); // get the value
             source = replace(source, config); // replace the variables
@@ -115,11 +119,14 @@ function responseHandler(filterRules, config) {
           ca: config.caCert, // Optional CA cert
         },
       }, (error, response, body) => {
-        logger.info('%s %s (%s)', method, result,
-                    (response || { statusCode: 500 }).statusCode);
+        logger.info({
+          method,
+          result,
+          status: (response || { statusCode: 500 }).statusCode,
+        }, 'handling request');
 
         if (error) {
-          logger.error('error: %s', error.message);
+          logger.error(error, 'error while handling request');
           return emit({
             status: 500,
             body: error.message

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -41,7 +41,7 @@ module.exports = ({ config = {}, port = null, filters = {} }) => {
 
      // strip the leading url
     req.url = req.url.slice(`/broker/${id}`.length);
-    logger.debug('request for %s', req.url);
+    logger.debug({ url: req.url }, 'request');
 
     next();
   }, relay.request(filters.public));


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by @

#### What does this PR do?

Sanitises broker and github tokens from logs.

Uses [bunyan serializers](https://github.com/trentm/node-bunyan#serializers) to do the trick. Requires sensitive tokens to appear in properly named keys of logged objects.