### PR TITLE
fix: unescapre urls when testing filters, to support custom file locations

### DIFF
--- a/client-templates/snyk/accept.json.sample
+++ b/client-templates/snyk/accept.json.sample
@@ -92,19 +92,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
-      "path": "/:name/:repo/:branch/package.json",
+      "path": "/:name/:repo/:branch*/package.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
-      "path": "/:name/:repo/:branch/Gemfile.lock",
+      "path": "/:name/:repo/:branch*/Gemfile.lock",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
-      "path": "/:name/:repo/:branch/Gemfile",
+      "path": "/:name/:repo/:branch*/Gemfile",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {

--- a/lib/filters/index.js
+++ b/lib/filters/index.js
@@ -98,6 +98,8 @@ module.exports = ruleSource => {
 
   return (url, callback) => {
     let res = false;
+    // unescape url
+    url.url = decodeURIComponent(url.url);
     logger.debug(`testing ${tests.length} rules`);
     for (const test of tests) {
       res = test(url);

--- a/test/fixtures/client/filters.json
+++ b/test/fixtures/client/filters.json
@@ -35,6 +35,12 @@
       "path": "/echo-query",
       "method": "GET",
       "origin": "http://localhost:${originPort}"
+    },
+
+    {
+      "path": "/nested/path-with/wild*/to/file.ext",
+      "method": "GET",
+      "origin": "http://localhost:${originPort}"
     }
 
   ],

--- a/test/functional/server-client.test.js
+++ b/test/functional/server-client.test.js
@@ -35,7 +35,7 @@ test('proxy requests originating from behind the broker server', t => {
   // wait for the client to successfully connect to the server and identify itself
   server.io.on('connection', socket => {
     socket.on('identify', token => {
-      t.plan(11);
+      t.plan(12);
 
       t.test('successfully broker POST', t => {
         const url = `http://localhost:${serverPort}/broker/${token}/echo-body`;
@@ -150,6 +150,20 @@ test('proxy requests originating from behind the broker server', t => {
           t.end();
         });
       });
+
+      t.test('sucessfully broker GET to an escaped url with a wildcard filter',
+             t => {
+               // url is escaped: %2F <=> `/`,
+               // filter path is "/nested/path-with/wild*/to/file.ext"
+               const url = `http://localhost:${serverPort}/broker/${token}/` +
+                       'nested/path-with/wildcard/and-an-escaped-slash/to%2F' +
+                       'file.ext';
+               request({ url, method: 'get' }, (err, res) => {
+                 t.equal(res.statusCode, 200, '200 statusCode');
+                 t.equal(res.body, 'file.ext', 'filename brokered');
+                 t.end();
+               });
+             });
 
       t.test('clean up', t => {
         client.close();

--- a/test/utils.js
+++ b/test/utils.js
@@ -34,6 +34,12 @@ echoServer.get('/echo-query', (req, res) => {
   res.json(req.query);
 });
 
+echoServer.get(
+  '/nested/path-with/wildcard/and-an-escaped-slash/to/:filename',
+  (req, res) => {
+    res.send(req.params.filename);
+  });
+
 echoServer.all('*', (req, res) => {
   res.send(false);
 });


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by @ … (Snyk internal team)

#### What does this PR do?
Escapes urls before they are tested against filters.
For example, a request might be something like
`GET https://raw.githubusercontent.com/USER/REPO/COMMIT-ISH/path%2Fto%2Fpackage.json`, but should be unescaped before tested against a rule like
```
{
      "//": "used to determine the full dependency tree",
      "method": "GET",
      "path": "/:name/:repo/:branch*/package.json",
      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
    }
```
(the `%2F`s are replaced by a `/`s to create `https://raw.githubusercontent.com/USER/REPO/COMMIT-ISH/path/to/package.json`)
