### PR TITLE
fix: https support relies on proper env vars

### DIFF
--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -21,8 +21,8 @@ const stripEmptyRequestBody = (req, res, next) => {
   next();
 };
 
-function main({ key = null, cert = null, port = 7341 } = {}, altPort = null) {
-  const http = (!key && !cert); // no https if there's no certs
+function main({ httpsKey = null, httpsCert = null, port = 7341 } = {}, altPort = null) {
+  const http = (!httpsKey && !httpsCert); // no https if there's no certs
   const https = http ? require('http') : require('https');
   const app = express();
 
@@ -37,8 +37,8 @@ function main({ key = null, cert = null, port = 7341 } = {}, altPort = null) {
 
   logger.info('local server listening @ %s', port);
   const serverArgs = http ? [app] : [{
-    key: fs.readFileSync(key),
-    cert: fs.readFileSync(cert),
+    key: fs.readFileSync(httpsKey),
+    cert: fs.readFileSync(httpsCert),
   }, app];
 
   const server = https.createServer.apply(https, serverArgs).listen(port);

--- a/test/utils.js
+++ b/test/utils.js
@@ -10,8 +10,8 @@ function port() {
 const echoServerPort = port();
 const { app: echoServer, server } = webserver({
   port: echoServerPort,
-  key: process.env.TEST_KEY, // Optional
-  cert: process.env.TEST_CERT, // Optional
+  httpsKey: process.env.TEST_KEY, // Optional
+  httpsCert: process.env.TEST_CERT, // Optional
 });
 
 echoServer.get('/echo-param/:param', (req, res) => {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by @gjvis 

#### What does this PR do?

Env vars are expanded and camelified for the broker, so `process.env.HTTPS_KEY` becomes `httpsKey`. Renamed server options to match this convention, as documented in README.md

Based on a patch provided by @radekk
