### PR TITLE
feat: lowercase BROKER_TOKEN when identifying with server

### DIFF
--- a/lib/server/socket.js
+++ b/lib/server/socket.js
@@ -35,7 +35,7 @@ module.exports = ({ server, filters, config }) => {
     // TODO decide if the socket doesn't identify itself within X period,
     // should we toss it away?
     socket.on('identify', _ => {
-      token = _;
+      token = _.toLowerCase(); // lowercase to standardise tokens
       logger.info('client identified');
       debug('client identified with %s', token);
       const clientPool = connections.get(token) || [];

--- a/test/functional/client-server.test.js
+++ b/test/functional/client-server.test.js
@@ -28,7 +28,7 @@ test('proxy requests originating from behind the broker client', t => {
 
   process.chdir(path.resolve(root, '../fixtures/client'));
   process.env.BROKER_TYPE = 'client';
-  process.env.BROKER_TOKEN = '12345';
+  process.env.BROKER_TOKEN = 'C481349B-4014-43D9-B59D-BA41E1315001'; // uuid.v4
   process.env.BROKER_SERVER_URL = `http://localhost:${serverPort}`;
   const clientPort = port();
   const client = app.main({ port: clientPort });
@@ -111,7 +111,8 @@ test('proxy requests originating from behind the broker client', t => {
         request({ url, method: 'post' }, (err, res) => {
           const responseBody = JSON.parse(res.body);
           t.equal(res.statusCode, 200, '200 statusCode');
-          t.equal(responseBody['x-broker-token'], token, 'X-Broker-Token header sent');
+          t.equal(responseBody['x-broker-token'], token.toLowerCase(),
+                  'X-Broker-Token header present and lowercased');
           t.end();
         });
       });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by @gjvis

#### What does this PR do?

BREAKING CHANGE: standardising BROKER_TOKEN to lowercase

Without this change, an uppercase token on the client may not work against an expected lowercase token on the server side, creating a mismatch.
