### PR TITLE
fix: switch back to released engine-io.client

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "dotenv": "^2.0.0",
     "ejson": "^2.1.2",
     "engine.io": "^3.1.0",
-    "engine.io-client": "socketio/engine.io-client#753c180fa54d2576ec890fb89caccaeb1a299fc7",
+    "engine.io-client": "^3.1.1",
     "es6-promise": "^4.1.0",
     "express": "^4.14.0",
     "js-yaml": "^3.6.1",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules

#### What does this PR do?

engine.io-client 3.1.1 has been released without the pinned vulnerable dep, switching back.