### PR TITLE
fix: prefer supplied url creds over auth header

### DIFF
--- a/cli/init.js
+++ b/cli/init.js
@@ -13,7 +13,7 @@ module.exports = (args) => {
   const dir = path.resolve(root, project);
 
   return fs.readdir(root).then(files => {
-    if (!files.includes(project)) {
+    if (files.indexOf(project) === -1) {
       throw new Error(`${project} is an invalid template name`);
     }
 

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -79,13 +79,22 @@ function responseHandler(filterRules, config) {
       const parsed = parse(result);
       const auth = parsed.auth;
 
-      // put the token in the authorization header instead of on the URL
-      // if it's there.
-      if (auth && !auth.includes(':')) {
-        headers.authorization = `token ${auth}`;
-        // then strip from the url
-        delete parsed.auth;
-        result = format(parsed);
+      if (auth) {
+        // if URL contains basic auth,
+        // remove authorization header to prefer auth on the URL.
+        if (auth.includes(':')) {
+          delete headers.authorization;
+        }
+
+        // if URL contains token auth,
+        // put the token in the authorization header
+        // instead of on the URL.
+        else {
+          headers.authorization = `token ${auth}`;
+          // then strip from the url
+          delete parsed.auth;
+          result = format(parsed);
+        }
       }
 
       // if the request is all good - and at this point it is, we'll check

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "node lib",
     "dev": "node lib | ./node_modules/.bin/bunyan",
     "es5ify": "babel --ignore=node_modules . -d .",
-    "test": "CI=1 tap -R spec test/**/*.test.js --timeout 60 2>&1",
+    "test": "CI=1 tap -R spec test/**/*.test.js --timeout 60",
     "lint": "eslint cli/*.js lib/**/*.js",
     "check-tests": "! grep 'test.only' test/**/*.test.js -n",
     "cover": "tap test/**/*.test.js --timeout 60 --cov --coverage-report=lcov",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "node lib",
     "dev": "node lib | ./node_modules/.bin/bunyan",
     "es5ify": "babel --ignore=node_modules . -d .",
-    "test": "CI=1 tap -R spec test/**/*.test.js --timeout 60 2>&1 | ./node_modules/.bin/bunyan",
+    "test": "CI=1 tap -R spec test/**/*.test.js --timeout 60 2>&1",
     "lint": "eslint cli/*.js lib/**/*.js",
     "check-tests": "! grep 'test.only' test/**/*.test.js -n",
     "cover": "tap test/**/*.test.js --timeout 60 --cov --coverage-report=lcov",

--- a/test/fixtures/client/filters-https.json
+++ b/test/fixtures/client/filters-https.json
@@ -26,6 +26,18 @@
     },
 
     {
+      "path": "/echo-headers/github",
+      "method": "POST",
+      "origin": "http://githubToken@localhost:${originPort}"
+    },
+
+    {
+      "path": "/echo-headers/bitbucket",
+      "method": "POST",
+      "origin": "http://bitbucketUser:bitbucketPassword@localhost:${originPort}"
+    },
+
+    {
       "path": "/echo-headers",
       "method": "POST",
       "origin": "https://localhost:${originPort}"

--- a/test/fixtures/client/filters.json
+++ b/test/fixtures/client/filters.json
@@ -26,6 +26,18 @@
     },
 
     {
+      "path": "/echo-headers/github",
+      "method": "POST",
+      "origin": "http://githubToken@localhost:${originPort}"
+    },
+
+    {
+      "path": "/echo-headers/bitbucket",
+      "method": "POST",
+      "origin": "http://bitbucketUser:bitbucketPassword@localhost:${originPort}"
+    },
+
+    {
       "path": "/echo-headers",
       "method": "POST",
       "origin": "http://localhost:${originPort}"

--- a/test/fixtures/server/filters.json
+++ b/test/fixtures/server/filters.json
@@ -13,7 +13,7 @@
     },
 
     {
-      "path": "/echo-headers",
+      "path": "/echo-headers/:param?",
       "method": "POST",
       "origin": "http://localhost:${originPort}"
     },

--- a/test/functional/client-server.test.js
+++ b/test/functional/client-server.test.js
@@ -128,30 +128,6 @@ test('proxy requests originating from behind the broker client', t => {
         });
       });
 
-      t.test('auth header is replaced when url contains token', t => {
-        const url = `http://githubToken@localhost:${clientPort}/echo-headers`;
-        const headers = [{authorization: 'broker auth'}];
-        request({ url, method: 'post', headers }, (err, res) => {
-          const responseBody = JSON.parse(res.body);
-          t.equal(res.statusCode, 200, '200 statusCode');
-          t.equal(responseBody['authorization'], 'token githubToken',
-            'auth header was replaced by github token');
-          t.end();
-        });
-      });
-
-      t.test('auth header is is deleted when url contains basic auth', t => {
-        const url = `http://username@pass@localhost:${clientPort}/echo-headers`;
-        const headers = [{authorization: 'broker auth'}];
-        request({ url, method: 'post', headers }, (err, res) => {
-          const responseBody = JSON.parse(res.body);
-          t.equal(res.statusCode, 200, '200 statusCode');
-          t.notOk(responseBody['authorization'], 'token githubToken',
-            'auth header was deleted, to prefer creds on the url');
-          t.end();
-        });
-      });
-
       t.test('clean up', t => {
         client.close();
         setTimeout(() => {

--- a/test/functional/client-server.test.js
+++ b/test/functional/client-server.test.js
@@ -128,6 +128,30 @@ test('proxy requests originating from behind the broker client', t => {
         });
       });
 
+      t.test('auth header is replaced when url contains token', t => {
+        const url = `http://githubToken@localhost:${clientPort}/echo-headers`;
+        const headers = [{authorization: 'broker auth'}];
+        request({ url, method: 'post', headers }, (err, res) => {
+          const responseBody = JSON.parse(res.body);
+          t.equal(res.statusCode, 200, '200 statusCode');
+          t.equal(responseBody['authorization'], 'token githubToken',
+            'auth header was replaced by github token');
+          t.end();
+        });
+      });
+
+      t.test('auth header is is deleted when url contains basic auth', t => {
+        const url = `http://username@pass@localhost:${clientPort}/echo-headers`;
+        const headers = [{authorization: 'broker auth'}];
+        request({ url, method: 'post', headers }, (err, res) => {
+          const responseBody = JSON.parse(res.body);
+          t.equal(res.statusCode, 200, '200 statusCode');
+          t.notOk(responseBody['authorization'], 'token githubToken',
+            'auth header was deleted, to prefer creds on the url');
+          t.end();
+        });
+      });
+
       t.test('clean up', t => {
         client.close();
         setTimeout(() => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -26,7 +26,7 @@ echoServer.post('/echo-body/:param?', (req, res) => {
   res.send(req.body);
 });
 
-echoServer.post('/echo-headers', (req, res) => {
+echoServer.post('/echo-headers/:param?', (req, res) => {
   res.json(req.headers);
 });
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by @ … (Snyk internal team)

#### What does this PR do?
In a case when a request url contains HTTP credentials
on the url, we want to prefer them over the auth header.
The resolution is to strip the Authorization header.

 From:
 `Authorization: auth https://user:name@someapi.com/v1/repos`
 To:
 `https://user:name@someapi.com/v1/repos`
