### PR TITLE
fix: update Snyk template to support Snyk Fix PRs on GitHub Enterprise

### DIFF
--- a/client-templates/github/accept.json.sample
+++ b/client-templates/github/accept.json.sample
@@ -139,6 +139,12 @@
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
+      "//": "get the head commit of an individual ref",
+      "method": "GET",
+      "path": "/repos/:name/:repo/git/refs/heads/:ref",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
       "//": "get the details of an individual ref",
       "method": "GET",
       "path": "/repos/:name/:repo/git/refs/:ref",
@@ -178,6 +184,12 @@
       "//": "update ref",
       "method": "PATCH",
       "path": "/repos/:name/:repo/git/refs/:sha",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "update ref head",
+      "method": "PATCH",
+      "path": "/repos/:name/:repo/git/refs/heads/:ref",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     }
   ]


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules

#### What does this PR do?

Updates the Snyk client template to add two new whitelist rules needed for opening Snyk Fix Pull-Requests against GitHub Enterprise instances.
