### PR TITLE
fix: allow fetching package-lock.json to support npm5 repos

### DIFF
--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -22,6 +22,12 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/package-lock.json",
+      "origin": "https://${BITBUCKET_USERNAME}:${BITBUCKET_PASSWORD}@${BITBUCKET_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/projects/:project/repos/:repo/browse*/Gemfile.lock",
       "origin": "https://${BITBUCKET_USERNAME}:${BITBUCKET_PASSWORD}@${BITBUCKET_API}"
     },

--- a/client-templates/github/accept.json.sample
+++ b/client-templates/github/accept.json.sample
@@ -21,6 +21,14 @@
           },
           {
             "path": "commits.*.added.*",
+            "value": "package-lock.json"
+          },
+          {
+            "path": "commits.*.modified.*",
+            "value": "package-lock.json"
+          },
+          {
+            "path": "commits.*.added.*",
             "value": "Gemfile.lock"
           },
           {
@@ -93,6 +101,12 @@
       "//": "used to determine the full dependency tree",
       "method": "GET",
       "path": "/:name/:repo/:branch*/package.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:branch*/package-lock.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {


### PR DESCRIPTION
We want to be able to fetch `package-lock.json` to detect an npm5 project. This change adds a default filter to allow fetching these files both from GitHub and Bitbucket.

In order to make use of this change, either generate a new `accept.json` filter by running `broker init [github|bitbucket]`, or apply this patch to your existing `accept.json` file.