### PR TITLE
feat: allow fetching requirements.txt to support Python projects

### DIFF
--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -38,6 +38,12 @@
       "origin": "https://${BITBUCKET_USERNAME}:${BITBUCKET_PASSWORD}@${BITBUCKET_API}"
     },
     {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/requirements.txt",
+      "origin": "https://${BITBUCKET_USERNAME}:${BITBUCKET_PASSWORD}@${BITBUCKET_API}"
+    },
+    {
       "//": "used to check if there's any ignore rules or existing patches",
       "method": "GET",
       "path": "/projects/:project/repos/:repo/browse/.snyk",

--- a/client-templates/github/accept.json.sample
+++ b/client-templates/github/accept.json.sample
@@ -29,6 +29,14 @@
           },
           {
             "path": "commits.*.added.*",
+            "value": "requirements.txt"
+          },
+          {
+            "path": "commits.*.modified.*",
+            "value": "requirements.txt"
+          },
+          {
+            "path": "commits.*.added.*",
             "value": ".snyk"
           },
           {
@@ -112,7 +120,13 @@
       "method": "GET",
       "path": "/:name/:repo/:branch*/pom.xml",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-     },
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:branch*/requirements.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
     {
       "//": "used to check if there's any ignore rules or existing patches",
       "method": "GET",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by @ … (Snyk internal team)

#### What does this PR do?

We want to be able to fetch `requirements.txt` files to detect Python projects. This change adds a default filter to allow fetching these files both from GitHub and Bitbucket.

In order to make use of this change, either generate a new `accept.json` filter by running `broker init [github|bitbucket]`, or apply this patch to your existing `accept.json` file.