### PR TITLE
fix: include pom.xml in allowed webhook data

### DIFF
--- a/client-templates/github/accept.json.sample
+++ b/client-templates/github/accept.json.sample
@@ -29,6 +29,14 @@
           },
           {
             "path": "commits.*.added.*",
+            "value": "pom.xml"
+          },
+          {
+            "path": "commits.*.modified.*",
+            "value": "pom.xml"
+          },
+          {
+            "path": "commits.*.added.*",
             "value": ".snyk"
           },
           {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by @ … (Snyk internal team)

#### What does this PR do?

Adds `pom.xml` to the list of allowed files on commit webhooks. This will allow Snyk to update project state when the relevant `pom.xml` file changes in the repo.