### PR TITLE
feat: allow filtering for yarn.lock files to support Yarn projects

### DIFF
--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -50,6 +50,12 @@
       "origin": "https://${BITBUCKET_USERNAME}:${BITBUCKET_PASSWORD}@${BITBUCKET_API}"
     },
     {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/yarn.lock",
+      "origin": "https://${BITBUCKET_USERNAME}:${BITBUCKET_PASSWORD}@${BITBUCKET_API}"
+    },
+    {
       "//": "used to check if there's any ignore rules or existing patches",
       "method": "GET",
       "path": "/projects/:project/repos/:repo/browse/.snyk",

--- a/client-templates/github/accept.json.sample
+++ b/client-templates/github/accept.json.sample
@@ -53,6 +53,14 @@
           },
           {
             "path": "commits.*.added.*",
+            "value": "yarn.lock"
+          },
+          {
+            "path": "commits.*.modified.*",
+            "value": "yarn.lock"
+          },
+          {
+            "path": "commits.*.added.*",
             "value": ".snyk"
           },
           {
@@ -147,6 +155,12 @@
       "//": "used to determine the full dependency tree",
       "method": "GET",
       "path": "/:name/:repo/:branch*/requirements.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:branch*/yarn.lock",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by @ … (Snyk internal team)

#### What does this PR do?

Adds `yarn.lock` as an allowed file for filtering in GitHub commit webhooks and GET requests from repos.
