### PR TITLE
feat: include pom.xml in allowed webhook data to monitor changes in Maven projects

### DIFF
--- a/client-templates/github/accept.json.sample
+++ b/client-templates/github/accept.json.sample
@@ -45,6 +45,14 @@
           },
           {
             "path": "commits.*.added.*",
+            "value": "pom.xml"
+          },
+          {
+            "path": "commits.*.modified.*",
+            "value": "pom.xml"
+          },
+          {
+            "path": "commits.*.added.*",
             "value": ".snyk"
           },
           {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by @ … (Snyk internal team)

#### What does this PR do?

Adds `pom.xml` to the list of allowed files on commit webhooks. This will allow Snyk to update project state when the relevant `pom.xml` file changes in the repo.