### PR TITLE
fix: expose PORT in bitbucket-server Dockerfile

### DIFF
--- a/dockerfiles/bitbucket-server/Dockerfile
+++ b/dockerfiles/bitbucket-server/Dockerfile
@@ -32,6 +32,11 @@ ENV BITBUCKET_PASSWORD <password>
 # Your Bitbucket Server host, excluding scheme
 ENV BITBUCKET your.bitbucket.server.hostname
 
+# The port used by the broker client to accept internal connections
+# Default value is 7341
+ENV PORT 7341
+
+
 #######################################
 # Generic Broker Client configuration #
 #######################################
@@ -50,6 +55,6 @@ ENV ACCEPT accept.json
 
 
 HEALTHCHECK --interval=10s --timeout=1s \
-  CMD wget -sq http://localhost:7341/healthcheck
+  CMD wget -sq http://localhost:$PORT/healthcheck
 
 CMD ["broker", "--verbose"]


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by @ … (Snyk internal team)

#### What does this PR do?

Exposes `PORT` in the Bitbucket Server Dockerfile. Although webhooks are not yet supported when brokering Bitbucket Server, this change allows customisation of the broker client's port when running the client container.