### PR TITLE
feat: rooting out sporadic segfaults in docker images

### DIFF
--- a/dockerfiles/bitbucket-server/Dockerfile
+++ b/dockerfiles/bitbucket-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6-alpine
+FROM node:6-slim
 
 MAINTAINER Snyk Ltd
 

--- a/dockerfiles/github-com/Dockerfile
+++ b/dockerfiles/github-com/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6-alpine
+FROM node:6-slim
 
 MAINTAINER Snyk Ltd
 

--- a/dockerfiles/github-enterprise/Dockerfile
+++ b/dockerfiles/github-enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6-alpine
+FROM node:6-slim
 
 MAINTAINER Snyk Ltd
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by @ … (Snyk internal team)

#### What does this PR do?

Docker images' base changes from `node:6-alpine` to `node:6-slim`. The image will be bigger in size.

I am seeing sporadic segfaults of the broker client image in our env, trying to rule out one potential root cause.