### PR TITLE
fix: env vars that depend on custom ones are also custom

### DIFF
--- a/dockerfiles/bitbucket-server/Dockerfile
+++ b/dockerfiles/bitbucket-server/Dockerfile
@@ -32,6 +32,9 @@ ENV BITBUCKET_PASSWORD <password>
 # Your Bitbucket Server host, excluding scheme
 ENV BITBUCKET your.bitbucket.server.hostname
 
+# The Bitbucket server API URL
+ENV BITBUCKET_API $BITBUCKET/rest/api/1.0
+
 # The port used by the broker client to accept internal connections
 # Default value is 7341
 ENV PORT 7341
@@ -41,8 +44,6 @@ ENV PORT 7341
 # Generic Broker Client configuration #
 #######################################
 
-# The Bitbucket server API URL
-ENV BITBUCKET_API $BITBUCKET/rest/api/1.0
 
 # The URL of the Snyk broker server
 ENV BROKER_SERVER_URL https://broker.snyk.io

--- a/dockerfiles/github-enterprise/Dockerfile
+++ b/dockerfiles/github-enterprise/Dockerfile
@@ -20,14 +20,20 @@ RUN broker init github
 # or provide as runtime args `-e`    #
 ######################################
 
-# The host where your GitHub Enterprise is running, excluding scheme.
-ENV GITHUB=your.ghe.domain.com
-
 # Your unique broker identifier, copied from snyk.io org settings page
 # ENV BROKER_TOKEN <broker-token>
 
 # Your personal access token to your github.com / GHE account
 # ENV GITHUB_TOKEN <github-token>
+
+# The host where your GitHub Enterprise is running, excluding scheme.
+ENV GITHUB=your.ghe.domain.com
+
+# The URL that the github API should be accessed at.
+ENV GITHUB_API $GITHUB/api/v3
+
+# The URL where raw file content is accessed, excluding scheme.
+ENV GITHUB_RAW $GITHUB/raw
 
 # The port used by the broker client to accept webhooks
 # Default value is 7341
@@ -42,12 +48,6 @@ ENV PORT 7341
 #######################################
 # Generic Broker Client configuration #
 #######################################
-
-# The URL that the github API should be accessed at.
-ENV GITHUB_API $GITHUB/api/v3
-
-# The URL where raw file content is accessed, excluding scheme.
-ENV GITHUB_RAW $GITHUB/raw
 
 # The URL of the Snyk broker server
 ENV BROKER_SERVER_URL https://broker.snyk.io


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by @ … (Snyk internal team)

#### What does this PR do?

Rearranges grouping of env vars in Dockerfiles so that all custom vars and their derivatives are in the custom vars group.