### PR TITLE
Feat/configurable client healthcheck

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -16,7 +16,7 @@ module.exports = ({ port = null, config = {}, filters = {} }) => {
   const { app, server } = require('../webserver')(config, port);
 
   // IMPORTANT: defined before relay (`app.all('/*', ...`)
-  app.get('/healthcheck', (req, res, next) => {
+  app.get(config.brokerHealthcheckPath || '/healthcheck', (req, res) => {
     return res.status(200).json({ ok: true });
   });
 

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -30,7 +30,7 @@ module.exports = ({ port = null, config = {}, filters = {} }) => {
     close: done => {
       logger.info('closing');
       server.close();
-      io.destroy(done || (() => debug('closed')));
+      io.destroy(done || (() => logger.info('closed')));
     },
   };
 };


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules

#### What does this PR do?

feat: allow custom broker client healthcheck path

The broker client healthcheck path can be customised by setting the BROKER_HEALTHCHECK_PATH environment variable (or providing it in the `.env` file), to be more accommodating of existing load balancers.