### PR TITLE
fix: use env healthcheck path in dockerfiles

### DIFF
--- a/dockerfiles/bitbucket-server/Dockerfile
+++ b/dockerfiles/bitbucket-server/Dockerfile
@@ -52,10 +52,13 @@ ENV BROKER_SERVER_URL https://broker.snyk.io
 # Bitbucket Server instance
 ENV ACCEPT accept.json
 
+# The path for the broker's internal healthcheck URL. Must start with a '/'.
+ENV BROKER_HEALTHCHECK_PATH /healthcheck
 
 
+EXPOSE $PORT
 
 HEALTHCHECK --interval=10s --timeout=1s \
-  CMD wget -q --spider http://localhost:$PORT/healthcheck
+  CMD wget -q --spider http://localhost:${PORT}${BROKER_HEALTHCHECK_PATH}
 
 CMD ["broker", "--verbose"]

--- a/dockerfiles/github-com/Dockerfile
+++ b/dockerfiles/github-com/Dockerfile
@@ -56,12 +56,13 @@ ENV BROKER_SERVER_URL https://broker.snyk.io
 # GitHub account
 ENV ACCEPT accept.json
 
-
+# The path for the broker's internal healthcheck URL. Must start with a '/'.
+ENV BROKER_HEALTHCHECK_PATH /healthcheck
 
 
 EXPOSE $PORT
 
 HEALTHCHECK --interval=10s --timeout=1s \
-  CMD wget -q --spider http://localhost:$PORT/healthcheck
+  CMD wget -q --spider http://localhost:${PORT}${BROKER_HEALTHCHECK_PATH}
 
 CMD ["broker", "--verbose"]

--- a/dockerfiles/github-enterprise/Dockerfile
+++ b/dockerfiles/github-enterprise/Dockerfile
@@ -56,12 +56,13 @@ ENV BROKER_SERVER_URL https://broker.snyk.io
 # github enterprise instance
 ENV ACCEPT accept.json
 
-
+# The path for the broker's internal healthcheck URL. Must start with a '/'.
+ENV BROKER_HEALTHCHECK_PATH /healthcheck
 
 
 EXPOSE $PORT
 
 HEALTHCHECK --interval=10s --timeout=1s \
-  CMD wget -q --spider http://localhost:$PORT/healthcheck
+  CMD wget -q --spider http://localhost:${PORT}${BROKER_HEALTHCHECK_PATH}
 
 CMD ["broker", "--verbose"]


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by @ … (Snyk internal team)

#### What does this PR do?

Now that `/healthcheck` is configurable via an env var, all dockerfiles follow suit and allow customisation of the healthcheck path.