### PR TITLE
fix: allow token validation on gitlab default rules

### DIFF
--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -2,6 +2,12 @@
   "private":
   [
     {
+      "//": "identify user",
+      "method": "GET",
+      "path": "/api/v4/user",
+      "origin": "https://${GITLAB}"
+    },
+    {
       "//": "list the user's projects",
       "method": "GET",
       "path": "/api/v4/projects",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by @ … (Snyk internal team)

#### What does this PR do?

Adds `GET /api/v4/user` to default Gitlab accept filter to support token validation for Snyk access.