### PR TITLE
fix: allow filtering by request headers

### DIFF
--- a/lib/filters/index.js
+++ b/lib/filters/index.js
@@ -89,14 +89,12 @@ module.exports = ruleSource => {
 
       logger.debug({ path, origin, url }, 'match');
 
-      // GITLAB support
+      // GITLAB support hack
       // request comes in with dummy token, replace with config
       if (config.GITLAB_TOKEN && req.headers) {
-        if (req.headers['private-token'] === 'dummy_token') {
-          req.headers['private-token'] = config.GITLAB_TOKEN;
-        }
+        req.headers['private-token'] = config.GITLAB_TOKEN;
       };
-      
+
       querystring = (querystring) ? `?${querystring}` : '';
       return origin + url + querystring;
     };

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -57,8 +57,8 @@ function responseHandler(filterRules, config) {
 
   return (brokerToken) => ({ url, headers, method, body = null } = {}, emit) => {
     // run the request through the filter
-    logger.info({ method, url }, 'request captured');
-    filters({ url, method, body }, (error, result) => {
+    logger.info({ method, url, headers }, 'request captured');
+    filters({ url, method, body, headers }, (error, result) => {
       if (error) {
         logger.info({ method, url }, 'blocked');
         return emit({


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by @ … (Snyk internal team)

#### What does this PR do?

Allows filtering requests by HTTP headers.
Specifically, supports Gitlab `private-token` header replacement.