### PR TITLE
Fix/gitlab proper header subs

### DIFF
--- a/lib/filters/index.js
+++ b/lib/filters/index.js
@@ -89,12 +89,6 @@ module.exports = ruleSource => {
 
       logger.debug({ path, origin, url }, 'match');
 
-      // GITLAB support hack
-      // request comes in with dummy token, replace with config
-      if (config.GITLAB_TOKEN && req.headers) {
-        req.headers['private-token'] = config.GITLAB_TOKEN;
-      };
-
       querystring = (querystring) ? `?${querystring}` : '';
       return origin + url + querystring;
     };


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by @ … (Snyk internal team)

#### What does this PR do?

Removes Gitlab related hack, expecting Gitlab `private-token` header substitution to happen based on the headers substitution logic in #70 

Can only be merged and deployed after both #70 and https://github.com/snyk/gitlab-agent/pull/21 are deployed