### PR TITLE
Fix/header substitution

### DIFF
--- a/lib/relay.js
+++ b/lib/relay.js
@@ -114,9 +114,9 @@ function responseHandler(filterRules, config) {
       }
 
       // check whether we want to do variable substitution on the headers
-      if (headers && headers.BROKER_VAR_SUB) {
-        logger.info({ headerVars: headers.BROKER_VAR_SUB }, 'headers variable swap');
-        for (const path of headers.BROKER_VAR_SUB.split(',')) {
+      if (headers && headers['x-broker-var-sub']) {
+        logger.info({ headerVars: headers['x-broker-var-sub'] }, 'headers variable swap');
+        for (const path of headers['x-broker-var-sub'].split(',')) {
           let source = undefsafe(headers, path.trim()); // get the value
           source = replace(source, config); // replace the variables
           undefsafe(headers, path.trim(), source); // put it back in

--- a/test/functional/init.test.js
+++ b/test/functional/init.test.js
@@ -6,7 +6,7 @@ const init = require('../../cli/init');
 
 tmp.setGracefulCleanup(); // always remove temporary directories
 
-test('init creates files from specified client-templates', t => {
+test('init creates files from github template', t => {
   const originalWorkDir = process.cwd();
   t.teardown(() => process.chdir(originalWorkDir));
 
@@ -26,7 +26,7 @@ test('init creates files from specified client-templates', t => {
   });
 });
 
-test('init creates files from specified bitbucket', t => {
+test('init creates files from bitbucket-server template', t => {
   const originalWorkDir = process.cwd();
   t.teardown(() => process.chdir(originalWorkDir));
 
@@ -35,6 +35,26 @@ test('init creates files from specified bitbucket', t => {
     process.chdir(path);
 
     init({_: ['bitbucket-server']})
+      .then(() => Promise.all([
+        fs.stat('.env'),
+        fs.stat('accept.json'),
+      ]))
+      .then(stats => {
+        t.ok(stats.every(Boolean), 'all templated files created');
+        t.end();
+      });
+  });
+});
+
+test('init creates files from gitlab template', t => {
+  const originalWorkDir = process.cwd();
+  t.teardown(() => process.chdir(originalWorkDir));
+
+  tmp.dir({ unsafeCleanup: true }, (err, path) => {
+    if (err) { throw err; }
+    process.chdir(path);
+
+    init({_: ['gitlab']})
       .then(() => Promise.all([
         fs.stat('.env'),
         fs.stat('accept.json'),

--- a/test/unit/relay-response-headers.test.js
+++ b/test/unit/relay-response-headers.test.js
@@ -30,7 +30,7 @@ test('relay swaps header values found in BROKER_VAR_SUB', t => {
   }], config)(brokerToken);
 
   const headers = {
-    BROKER_VAR_SUB: 'private-token,replaceme',
+    'x-broker-var-sub': 'private-token,replaceme',
     donttouch: 'not to be changed ${VALUE}',
     'private-token': 'Bearer ${SECRET_TOKEN}',
     replaceme: 'replace ${VALUE}',


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by @ … (Snyk internal team)

#### What does this PR do?

Fixes HTTP header substitution logic by relying on dashes in HTTP header names. Underscores are frowned upon and silently discarded by default nginx config, so it seems.