### PR TITLE
fix: remove snyk-protect target as no patching is required

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,7 @@
     "lint": "eslint cli/*.js lib/**/*.js",
     "check-tests": "! grep 'test.only' test/**/*.test.js -n",
     "cover": "tap test/**/*.test.js --timeout 60 --cov --coverage-report=lcov",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
-    "snyk-protect": "snyk protect",
-    "prepublish": "npm run snyk-protect"
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "keywords": [],
   "author": "Remy Sharp",
@@ -66,8 +64,7 @@
     "snyk-config": "^1.0.1",
     "then-fs": "^2.0.0",
     "tunnel": "0.0.4",
-    "undefsafe": "^1.2.0",
-    "snyk": "^1.41.1"
+    "undefsafe": "^1.2.0"
   },
   "repository": {
     "type": "git",
@@ -76,6 +73,5 @@
   "bugs": {
     "url": "https://github.com/snyk/broker/issues"
   },
-  "homepage": "https://github.com/snyk/broker#readme",
-  "snyk": true
+  "homepage": "https://github.com/snyk/broker#readme"
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by @ … (Snyk internal team)

#### What does this PR do?

Removes `snyk` dependency and the `snyk-protect` npm target.
These were introduced by a fix PR that ignored an issue, and are meant to facilitate patching. No patching is required right now, removing this until required by a patched vuln.