### PR TITLE
feat: rules for bitbucket-server webhooks (ingress and egress)

### DIFF
--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -1,4 +1,12 @@
 {
+  "public":
+  [
+      {
+        "//": "used for pushing up webhooks from bitbucket-server",
+        "method": "POST",
+        "path": "/webhook/bitbucket-server/:webhookId"
+      }
+  ],
   "private":
   [
     {
@@ -72,6 +80,24 @@
       "method": "GET",
       "path": "/projects/:project/repos/:repo/browse/.snyk",
       "origin": "https://${BITBUCKET_USERNAME}:${BITBUCKET_PASSWORD}@${BITBUCKET_API}"
+    },
+    {
+      "//": "allow webhooks to be added, to allow commits to be checked by Snyk. Rules for what is sent to Snyk are controlled in the `public` accept filters",
+      "method": "POST",
+      "path": "/projects/:projectKey/repos/:repoSlug/webhooks",
+      "origin": "https://${BITBUCKET_USERNAME}:${BITBUCKET_PASSWORD}@${BITBUCKET_API}"
+    },
+    {
+      "//": "allow webhooks to be deleted, used to cleanup when a user deactivates or deletes a project",
+      "method": "DELETE",
+      "path": "/projects/:projectKey/repos/:repoSlug/webhooks/:webhookId",
+      "origin": "https://${BITBUCKET_USERNAME}:${BITBUCKET_PASSWORD}@${BITBUCKET_API}"
+    },
+    {
+      "//": "used to create commit status messages",
+      "method": "POST",
+      "path": "/rest/build-status/1.0/commits/:sha",
+      "origin": "https://${BITBUCKET_USERNAME}:${BITBUCKET_PASSWORD}@${BITBUCKET}"
     }
   ]
 }

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -99,6 +99,12 @@ function responseHandler(filterRules, config) {
 
       // if the request is all good - and at this point it is, we'll check
       // whether we want to do variable substitution on the body
+      //
+      // Variable substitution - for those who forgot - is substituting a part
+      // of a given string (e.g. "${SOME_ENV_VAR}/rest/of/string")
+      // with an env var of the same name (SOME_ENV_VAR).
+      // This is used (for example) to substitute the snyk url
+      // with the broker's url when defining the target for an incoming webhook.
       if (body) {
         const parsedBody = tryJSONParse(body);
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by @adrukh and @aviadatsnyk 

#### What does this PR do?

Rules for supporting bitbucket-server webhooks through the broker. The intended behavior will be to create and delete webhooks, and to send commit messages (from Snyk to Bitbucket-Server); and to receive webhook events (from Bitbucket-Server, and into Snyk).