### PR TITLE
fix: url in query parameter breaks querystring relaying

### DIFF
--- a/lib/filters/index.js
+++ b/lib/filters/index.js
@@ -63,8 +63,9 @@ module.exports = ruleSource => {
       if (req.method.toLowerCase() !== method && method !== 'any') {
         return false;
       }
-
-      let [url, querystring] = req.url.split('?');
+      // query params might contain additional "?"s, only split on the 1st one
+      const parts = req.url.split('?');
+      let [url, querystring] = [parts[0], parts.slice(1).join('?')];
       const res = regexp.exec(url);
       if (!res) {
         // debug('bad regexp match', path, req.url, regexp.source);

--- a/test/functional/server-client.test.js
+++ b/test/functional/server-client.test.js
@@ -171,11 +171,18 @@ test('proxy requests originating from behind the broker server', t => {
       });
 
       t.test('querystring parameters are brokered', t => {
-        const url = `http://localhost:${serverPort}/broker/${token}/echo-query?shape=square&colour=yellow`;
+        const url = `http://localhost:${serverPort}/broker/${token}/` +
+                'echo-query?shape=square&colour=yellow&' +
+                'url_as_param=https%3A%2F%2Fclojars.org%2Fsearch%3Fq%3Dbtc&' +
+                'one_more_top_level_param=true';
         request({ url, method: 'get' }, (err, res) => {
           const responseBody = JSON.parse(res.body);
           t.equal(res.statusCode, 200, '200 statusCode');
-          t.same(responseBody, {shape: 'square', colour: 'yellow'},
+          t.same(responseBody, {
+            shape: 'square', colour: 'yellow',
+            url_as_param: 'https://clojars.org/search?q=btc',
+            one_more_top_level_param: 'true',
+          },
             'querystring brokered');
           t.end();
         });


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by @ … (Snyk internal team)

#### What does this PR do?
fix: when sending a query param that has a "?" inside (i.e. a callbac…d internal query params were broken due to querystring split.

This pr adds a test and fixes the issue.
