### PR TITLE
fix: ensure tokens are sanitised from logs

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -1,5 +1,9 @@
 const bunyan = require('bunyan');
+const escapeRegExp = require('lodash.escaperegexp');
 const config = require('./config');
+
+const sanitiseConfigVariable = (raw, variable) =>
+  raw.replace(new RegExp(escapeRegExp(config[variable]), 'igm'), variable);
 
 // sanitises sensitive values, replacing all occurences with label
 function sanitise(raw) {
@@ -11,23 +15,23 @@ function sanitise(raw) {
   // Regexp is case-insensitive, global and multiline matching,
   // this way all occurences are replaced.
   if (config.BROKER_TOKEN) {
-    raw = raw.replace(new RegExp(config.BROKER_TOKEN, 'igm'), 'BROKER_TOKEN');
+    raw = sanitiseConfigVariable(raw, 'BROKER_TOKEN');
   }
 
   if (config.GITHUB_TOKEN) {
-    raw = raw.replace(new RegExp(config.GITHUB_TOKEN, 'igm'), 'GITHUB_TOKEN');
+    raw = sanitiseConfigVariable(raw, 'GITHUB_TOKEN');
   }
 
   if (config.BITBUCKET_USERNAME) {
-    raw = raw.replace(new RegExp(config.BITBUCKET_USERNAME, 'igm'), 'BITBUCKET_USERNAME');
+    raw = sanitiseConfigVariable(raw, 'BITBUCKET_USERNAME');
   }
 
   if (config.BITBUCKET_PASSWORD) {
-    raw = raw.replace(new RegExp(config.BITBUCKET_PASSWORD, 'igm'), 'BITBUCKET_PASSWORD');
+    raw = sanitiseConfigVariable(raw, 'BITBUCKET_PASSWORD');
   }
 
   if (config.GITLAB_TOKEN) {
-    raw = raw.replace(new RegExp(config.GITLAB_TOKEN, 'igm'), 'GITLAB_TOKEN');
+    raw = sanitiseConfigVariable(raw, 'GITLAB_TOKEN');
   }
 
   return raw;

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "es6-promise": "^4.1.0",
     "express": "^4.14.0",
     "js-yaml": "^3.6.1",
+    "lodash.escaperegexp": "^4.1.2",
     "minimatch": "^3.0.4",
     "path-to-regexp": "^1.5.3",
     "primus": "^6.0.1",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules

#### What does this PR do?

This change makes sure that tokens which have special meaning in regular expressions don't break the log sanitisation.
