### PR TITLE
fix: allow requests with over 100kb in body length

### DIFF
--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -28,7 +28,7 @@ function main({ httpsKey = null, httpsCert = null, port = 7341 } = {}, altPort =
 
   app.disable('x-powered-by');
   app.use(markEmptyRequestBody);
-  app.use(bodyParser.raw({ type: '*/*' }));
+  app.use(bodyParser.raw({ type: '*/*', limit: '5mb' }));
   app.use(stripEmptyRequestBody);
 
   if (altPort) {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by @ … (Snyk internal team)

#### What does this PR do?

The default size limit for `body-parser` is 100kb (see https://www.npmjs.com/package/body-parser#limit-1). This causes the broker to reject requests with larger body sizes. 413 is returned on the response by the `body-parser` middleware with direct output to the console in the following form:
```
Error: request entity too large
    at readStream (/usr/local/lib/node_modules/snyk-broker/node_modules/raw-body/index.js:196:17)
    at getRawBody (/usr/local/lib/node_modules/snyk-broker/node_modules/raw-body/index.js:106:12)
    at read (/usr/local/lib/node_modules/snyk-broker/node_modules/body-parser/lib/read.js:76:3)
    at rawParser (/usr/local/lib/node_modules/snyk-broker/node_modules/body-parser/lib/types/raw.js:81:5)
    at Layer.handle [as handle_request] (/usr/local/lib/node_modules/snyk-broker/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/usr/local/lib/node_modules/snyk-broker/node_modules/express/lib/router/index.js:317:13)
    at /usr/local/lib/node_modules/snyk-broker/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/usr/local/lib/node_modules/snyk-broker/node_modules/express/lib/router/index.js:335:12)
    at next (/usr/local/lib/node_modules/snyk-broker/node_modules/express/lib/router/index.js:275:10)
    at markEmptyRequestBody (/usr/local/lib/node_modules/snyk-broker/lib/webserver.js:23:3)
```

Larger body sizes are expected when PR webhooks carry a long list of affected files, etc. Solving this quickly by raising the limit to 5mb. A better solution would be to rely on an env var to set the max size, best considered should 5mb prove to be insufficient.