### PR TITLE
feat: allow APIs used for creating fix merge request

### DIFF
--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -127,6 +127,24 @@
       "method": "POST",
       "path": "/api/v4/projects/:project/statuses/:sha",
       "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create branch for fix merge request",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/branches",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create commits for fix merge request",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/commits",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create merge request for fix merge request",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/merge_requests",
+      "origin": "https://${GITLAB}"
     }
   ]
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by @ … (Snyk internal team)

#### What does this PR do?

Supports the APIs needed for opening fix merge request on gitlab.


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
