### PR TITLE
feat: allow APIs used for creating fix pull request on bitbucket-server

### DIFF
--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -98,6 +98,24 @@
       "method": "POST",
       "path": "/rest/build-status/1.0/commits/:sha",
       "origin": "https://${BITBUCKET_USERNAME}:${BITBUCKET_PASSWORD}@${BITBUCKET}"
+    },
+    {
+      "//": "used to create a new branch for fix PRs",
+      "method": "POST",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/branches",
+      "origin": "https://${BITBUCKET_USERNAME}:${BITBUCKET_PASSWORD}@${BITBUCKET}"
+    },
+    {
+      "//": "used to create or update a file for fix PRs",
+      "method": "PUT",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/browse/:path",
+      "origin": "https://${BITBUCKET_USERNAME}:${BITBUCKET_PASSWORD}@${BITBUCKET}"
+    },
+    {
+      "//": "used to create a pull request for fix PRs",
+      "method": "POST",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests",
+      "origin": "https://${BITBUCKET_USERNAME}:${BITBUCKET_PASSWORD}@${BITBUCKET}"
     }
   ]
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by @ … (Snyk internal team)

#### What does this PR do?
Adds APIs used for creating fix pull request on bitbucket-server in the template `accept.json`

#### Where should the reviewer start?
`client-templates/bitbucket-server/accept.json.sample`

