### PR TITLE
feat: allow graphql queries to pass through the broker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .nyc_output
 coverage
 /test/fixtures/certs/tmp
+accept.json

--- a/client-templates/github/.env.sample
+++ b/client-templates/github/.env.sample
@@ -12,6 +12,10 @@ GITHUB=
 # changed to "api.github.com"
 GITHUB_API=$GITHUB/api/v3
 
+# the url that the github graphql API should be accessed at.
+# For github.com this should be changed to "api.github.com/graphql"
+GITHUB_GRAPHQL=$GITHUB/api/graphql
+
 # the url of your broker client (including scheme and port)
 # BROKER_CLIENT_URL=
 

--- a/client-templates/github/accept.json.sample
+++ b/client-templates/github/accept.json.sample
@@ -253,6 +253,19 @@
       "method": "PATCH",
       "path": "/repos/:name/:repo/git/refs/heads/:ref",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "query graphql",
+      "method": "POST",
+      "path": "/graphql",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_GRAPHQL}",
+      "valid": [
+        {
+          "//": "query for all the file names 2 levels deep in the repo. used for auto project detection",
+          "path": "query",
+          "regex": "{\\s*repositoryOwner\\(login:\\s*\"([a-zA-Z0-9-_.]+)\"\\)\\s*{\\s*repository\\(name:\\s*\"([a-zA-Z0-9-_.]+)\"\\)\\s*{\\s*object\\(expression:\\s*\"([^\"{}]+)\"\\)\\s*{\\s*\\.\\.\\.\\s*on\\s+Tree\\s+{\\s*entries\\s*{\\s*name\\s+type\\s+object\\s*{\\s*\\.\\.\\.\\s*on\\s+Tree\\s+{\\s*entries\\s*{\\s*name\\s+type\\s+object\\s*{\\s*\\.\\.\\.on\\s+Tree\\s*{\\s*entries\\s*{\\s*name\\s+type\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}"
+        }
+      ]
     }
   ]
 }

--- a/lib/filters/index.js
+++ b/lib/filters/index.js
@@ -36,7 +36,8 @@ module.exports = ruleSource => {
     method = (method || 'get').toLowerCase();
     valid = valid || [];
 
-    const bodyFilters = valid.filter(v => !!v.path);
+    const bodyFilters = valid.filter(v => !!v.path && !v.regex);
+    const bodyRegexFilters = valid.filter(v => !!v.path && !!v.regex);
     const queryFilters = valid.filter(v => !!v.queryParam);
 
     // now track if there's any values that we need to interpolate later
@@ -82,15 +83,33 @@ module.exports = ruleSource => {
       }
 
       // if validity filters are present, at least one must be satisfied
-      if (bodyFilters.length || queryFilters.length) {
+      if (bodyFilters.length || bodyRegexFilters.length ||
+          queryFilters.length) {
         let isValid;
 
+        let parsedBody;
         if (bodyFilters.length) {
-          const parsedBody = tryJSONParse(req.body);
+          parsedBody = tryJSONParse(req.body);
 
           // validate against the body
           isValid = bodyFilters.some(({ path, value }) => {
             return undefsafe(parsedBody, path, value);
+          });
+        }
+
+        if (!isValid && bodyRegexFilters.length) {
+          parsedBody = parsedBody || tryJSONParse(req.body);
+
+          // validate against the body by regex
+          isValid = bodyRegexFilters.some(({ path, regex }) => {
+            try {
+              const re = new RegExp(regex);
+              return re.test(undefsafe(parsedBody, path));
+            } catch (err) {
+              logger.error({err, path, regex},
+                           'failed to test regex rule');
+              return false;
+            }
           });
         }
 

--- a/test/fixtures/relay.json
+++ b/test/fixtures/relay.json
@@ -63,5 +63,22 @@
         "value": ".snyk"
       }
     ]
+  },
+  {
+    "//": "used to filter only the wanted graphql query",
+    "method": "POST",
+    "path": "/graphql",
+    "valid": [
+      {
+        "//": "malformed regex does not break other filters",
+        "path": "query",
+        "regex": "INVALID regex ("
+      },
+      {
+        "//": "query for all the file names 2 levels deep in the repo. used for auto project detection",
+        "path": "query",
+        "regex": "{\\s*repositoryOwner\\(login:\\s*\"([a-zA-Z0-9-_.]+)\"\\)\\s*{\\s*repository\\(name:\\s*\"([a-zA-Z0-9-_.]+)\"\\)\\s*{\\s*object\\(expression:\\s*\"([^\"{}]+)\"\\)\\s*{\\s*\\.\\.\\.\\s*on\\s+Tree\\s+{\\s*entries\\s*{\\s*name\\s+type\\s+object\\s*{\\s*\\.\\.\\.\\s*on\\s+Tree\\s+{\\s*entries\\s*{\\s*name\\s+type\\s+object\\s*{\\s*\\.\\.\\.on\\s+Tree\\s*{\\s*entries\\s*{\\s*name\\s+type\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by @darscan 

#### What does this PR do?
adds the ability to query github's graphql through the broker, by adding a new set of filters/rules: body regex.

One new such regex is added to the github broker sample to allow this specific graphql query, but no others.