### PR TITLE
feat: allow a GET to api/v3/projects/visible on GitLab

### DIFF
--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -28,6 +28,12 @@
       "origin": "https://${GITLAB}"
     },
     {
+      "//": "list the user's visible projects",
+      "method": "GET",
+      "path": "/api/v3/projects/visible",
+      "origin": "https://${GITLAB}"
+    },
+    {
       "//": "used to determine the full dependency tree",
       "method": "GET",
       "path": "/api/v4/projects/:project/repository/files*/package.json",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by @ … (Snyk internal team)

#### What does this PR do?
adds the path `/api/v3/projects/visible` to the GitLab client template.
