### PR TITLE
fix: github graphql endpoint for github-com docker image

### DIFF
--- a/dockerfiles/github-com/Dockerfile
+++ b/dockerfiles/github-com/Dockerfile
@@ -43,8 +43,11 @@ ENV PORT 7341
 # GitHub host is github.com
 ENV GITHUB github.com
 
-# The URL that the github API should be accessed, excluding scheme.
+# Github API endpoint, excluding scheme.
 ENV GITHUB_API api.github.com
+
+# Github GraphQL API endpoint, excluding scheme.
+ENV GITHUB_GRAPHQL api.github.com
 
 # The URL of the Snyk broker server
 ENV BROKER_SERVER_URL https://broker.snyk.io

--- a/dockerfiles/github-enterprise/Dockerfile
+++ b/dockerfiles/github-enterprise/Dockerfile
@@ -29,8 +29,11 @@ RUN broker init github
 # The host where your GitHub Enterprise is running, excluding scheme.
 ENV GITHUB=your.ghe.domain.com
 
-# The URL that the github API should be accessed at.
+# Github API endpoint, excluding scheme.
 ENV GITHUB_API $GITHUB/api/v3
+
+# Github GraphQL API endpoint, excluding scheme.
+ENV GITHUB_GRAPHQL $GITHUB/api
 
 # The port used by the broker client to accept webhooks
 # Default value is 7341


### PR DESCRIPTION
The default .env template for github set the GraphQL endpoint to $GTIHUB/api, which is correct for GHE, but incorrect for github.com.

Overriding the default .env template values in the Dockerfile for both github.com and GHE to fix github.com endpoint, and be explicit about this setting
