### PR TITLE
Feat/client metadata

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -1,15 +1,22 @@
 const socket = require('./socket');
 const relay = require('../relay');
 const logger = require('../log');
+const version = require('../version');
 
 module.exports = ({ port = null, config = {}, filters = {} }) => {
-  logger.info('running');
+  logger.info({ version }, 'running in client mode');
+
+  const identifyingMetadata = {
+    version,
+    filters,
+  };
 
   const io = socket({
     token: config.brokerToken,
     url: config.brokerServerUrl,
     filters: filters.private,
     config,
+    identifyingMetadata,
   });
 
   // start the local webserver to listen for relay requests
@@ -17,7 +24,7 @@ module.exports = ({ port = null, config = {}, filters = {} }) => {
 
   // IMPORTANT: defined before relay (`app.all('/*', ...`)
   app.get(config.brokerHealthcheckPath || '/healthcheck', (req, res) => {
-    return res.status(200).json({ ok: true });
+    return res.status(200).json({ ok: true, version });
   });
 
   app.all('/*', (req, res, next) => {

--- a/lib/client/socket.js
+++ b/lib/client/socket.js
@@ -2,7 +2,6 @@ require('../patch-https-request-for-proxying');
 
 const Primus = require('primus');
 const relay = require('../relay');
-const httpErrors = require('../http-errors');
 const Socket = Primus.createSocket({
   transformer: 'engine.io',
   parser: 'EJSON',
@@ -12,7 +11,7 @@ const Socket = Primus.createSocket({
 });
 const logger = require('../log');
 
-module.exports = ({ url, token, filters, config }) => {
+module.exports = ({ url, token, filters, config, identifyingMetadata }) => {
   if (!token) { // null, undefined, empty, etc.
     logger.error('missing client token');
     const error = new ReferenceError('BROKER_TOKEN is required to successfully identify itself to the server');
@@ -38,12 +37,14 @@ module.exports = ({ url, token, filters, config }) => {
   io.on('request', response());
   io.on('error', ({ type, description }) => {
     if (type === 'TransportError') {
-      console.error(`Failed to connect to broker server: ${httpErrors[description]}`);
+      logger.error({ type, description }, 'Failed to connect to broker server');
     }
   });
   io.on('open', () => {
-    logger.info({ token, url }, 'identifying');
-    io.send('identify', token);
+    logger.info({ token, identifyingMetadata },
+      'identifying with broker server');
+    const clientData = { token, metadata: identifyingMetadata };
+    io.send('identify', clientData);
   });
 
   // only required if we're manually opening the connection

--- a/lib/filters/index.js
+++ b/lib/filters/index.js
@@ -18,7 +18,7 @@ module.exports = ruleSource => {
     try {
       rules = require(ruleSource);
     } catch (e) {
-      console.warn(`Unable to parse ${ruleSource}, ignoring for now: ${e.message}`);
+      logger.warn({ ruleSource, error: e }, 'Unable to parse rule source, ignoring');
     }
   }
 

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -2,9 +2,10 @@ const logger = require('../log');
 const debug = require('debug')('broker:server:index');
 const socket = require('./socket');
 const relay = require('../relay');
+const version = require('../version');
 
 module.exports = ({ config = {}, port = null, filters = {} }) => {
-  logger.info('running');
+  logger.info({ version }, 'running in server mode');
 
   // start the local webserver to listen for relay requests
   const { app, server } = require('../webserver')(config, port);
@@ -20,7 +21,8 @@ module.exports = ({ config = {}, port = null, filters = {} }) => {
     const id = req.params.id;
 
     if (connections.has(id)) {
-      return res.status(200).json({ ok: true });
+      const metadata = connections.get(id)[0].metadata;
+      return res.status(200).json({ ok: true, version: metadata.version });
     }
     debug('no broker found matching "%s"', id);
     return res.status(404).json({ ok: false });
@@ -36,7 +38,7 @@ module.exports = ({ config = {}, port = null, filters = {} }) => {
     }
 
     // Grab a first (newest) client from the pool
-    res.locals.io = connections.get(id)[0];
+    res.locals.io = connections.get(id)[0].socket;
 
      // strip the leading url
     req.url = req.url.slice(`/broker/${id}`.length);
@@ -46,7 +48,7 @@ module.exports = ({ config = {}, port = null, filters = {} }) => {
   }, relay.request(filters.public));
 
   app.get('/healthcheck', (req, res) =>
-          res.status(200).json({ ok: true }));
+          res.status(200).json({ ok: true, version }));
 
   return {
     io,

--- a/lib/server/socket.js
+++ b/lib/server/socket.js
@@ -11,7 +11,7 @@ module.exports = ({ server, filters, config }) => {
   const connections = new Map();
   const response = relay.response(filters, config);
 
-  io.on('error', error => console.error(error.stack));
+  io.on('error', error => logger.error({ error }, 'Primus/engine.io server error'));
 
   io.on('connection', function (socket) {
     logger.info('new client connection');
@@ -21,7 +21,7 @@ module.exports = ({ server, filters, config }) => {
       if (token) {
         logger.info('client closed');
         debug('connection to %s closed', token);
-        const clientPool = connections.get(token).filter(_ => _ !== socket);
+        const clientPool = connections.get(token).filter(_ => _.socket !== socket);
         if (clientPool.length) {
           logger.info('client still has %s connection/s', clientPool.length);
           return connections.set(token, clientPool);
@@ -34,13 +34,28 @@ module.exports = ({ server, filters, config }) => {
 
     // TODO decide if the socket doesn't identify itself within X period,
     // should we toss it away?
-    socket.on('identify', _ => {
-      token = _.toLowerCase(); // lowercase to standardise tokens
-      logger.info('client identified');
-      debug('client identified with %s', token);
+    socket.on('identify', clientData => {
+      // clientData can be a string token coming from older broker clients,
+      // OR an object coming from newer clients in the form of { token, metadata }
+      if (typeof clientData === 'object') {
+        token = clientData.token && clientData.token.toLowerCase();
+      } else {
+        token = clientData.toLowerCase(); // lowercase to standardise tokens
+        // stub a proper clientData, signal client is too old
+        clientData = { token, metadata: { version: 'pre-4.27' } };
+      }
+
+      if (!token) {
+        logger.warn({ clientData }, 'client identified without a token');
+        return;
+      }
+
+      logger.info({ clientData }, 'client identified');
+
       const clientPool = connections.get(token) || [];
-      clientPool.unshift(socket);
+      clientPool.unshift({ socket, metadata: clientData.metadata });
       connections.set(token, clientPool);
+
       socket.on('request', response(token));
     });
     socket.on('close', close);

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,0 +1,1 @@
+module.exports = require('../package.json').version || 'local';

--- a/test/functional/client-ca.test.js
+++ b/test/functional/client-ca.test.js
@@ -39,7 +39,8 @@ test('correctly use supplied CA cert on client for connections', t => {
 
   // wait for the client to successfully connect to the server and identify itself
   server.io.once('connection', socket => {
-    socket.on('identify', token => {
+    socket.on('identify', clientData => {
+      const token = clientData.token;
       t.test('get an error trying to connect to a server with unknown CA', t => {
         const url = `http://localhost:${serverPort}/broker/${token}/echo-body`;
         request({ url, method: 'post', json: true }, (err, res) => {

--- a/test/functional/client-pool.test.js
+++ b/test/functional/client-pool.test.js
@@ -40,7 +40,8 @@ test('correctly handle pool of multiple clients with same BROKER_TOKEN', t => {
 
   // wait for the client to successfully connect to the server and identify itself
   server.io.once('connection', socket => {
-    socket.on('identify', token => {
+    socket.on('identify', clientData => {
+      const token = clientData.token;
       t.test('successfully broker POST with 1st connected client', t => {
         const url = `http://localhost:${serverPort}/broker/${token}/echo-body`;
         request({ url, method: 'post', json: true }, (err, res) => {

--- a/test/functional/client-server.test.js
+++ b/test/functional/client-server.test.js
@@ -36,7 +36,7 @@ test('proxy requests originating from behind the broker client', t => {
 
   // wait for the client to successfully connect to the server and identify itself
   server.io.once('connection', socket => {
-    socket.once('identify', token => {
+    socket.once('identify', clientData => {
       t.plan(12);
 
       t.test('successfully broker POST', t => {
@@ -142,7 +142,7 @@ test('proxy requests originating from behind the broker client', t => {
         request({ url, method: 'post' }, (err, res) => {
           const responseBody = JSON.parse(res.body);
           t.equal(res.statusCode, 200, '200 statusCode');
-          t.equal(responseBody['x-broker-token'], token.toLowerCase(),
+          t.equal(responseBody['x-broker-token'], clientData.token.toLowerCase(),
                   'X-Broker-Token header present and lowercased');
           t.end();
         });

--- a/test/functional/healthcheck.test.js
+++ b/test/functional/healthcheck.test.js
@@ -46,7 +46,8 @@ test('proxy requests originating from behind the broker client', t => {
       if (err) { return t.threw(err); }
 
       t.equal(res.statusCode, 200, '200 statusCode');
-      t.equal(res.body['ok'], true, '{ ok: true } in body');
+      t.equal(res.body.ok, true, '{ ok: true } in body');
+      t.ok(res.body.version, 'version in body');
       t.end();
     });
   });
@@ -59,7 +60,8 @@ test('proxy requests originating from behind the broker client', t => {
           if (err) { return t.threw(err); }
 
           t.equal(res.statusCode, 200, '200 statusCode');
-          t.equal(res.body['ok'], true, '{ ok: true } in body');
+          t.equal(res.body.ok, true, '{ ok: true } in body');
+          t.ok(res.body.version, 'version in body');
           t.end();
         });
       });
@@ -69,7 +71,8 @@ test('proxy requests originating from behind the broker client', t => {
           if (err) { return t.threw(err); }
 
           t.equal(res.statusCode, 200, '200 statusCode');
-          t.equal(res.body['ok'], true, '{ ok: true } in body');
+          t.equal(res.body.ok, true, '{ ok: true } in body');
+          t.ok(res.body.version, 'version in body');
           t.end();
         });
       });
@@ -93,7 +96,8 @@ test('proxy requests originating from behind the broker client', t => {
             if (err) { return t.threw(err); }
 
             t.equal(res.statusCode, 200, '200 statusCode');
-            t.equal(res.body['ok'], true, '{ ok: true } in body');
+            t.equal(res.body.ok, true, '{ ok: true } in body');
+            t.ok(res.body.version, 'version in body');
             t.end();
           });
         }, 20);
@@ -115,7 +119,8 @@ test('proxy requests originating from behind the broker client', t => {
                 if (err) { return t.threw(err); }
 
                 t.equal(res.statusCode, 200, '200 statusCode');
-                t.equal(res.body['ok'], true, '{ ok: true } in body');
+                t.equal(res.body.ok, true, '{ ok: true } in body');
+                t.ok(res.body.version, 'version in body');
                 t.end();
               });
             });

--- a/test/functional/no-filter.test.js
+++ b/test/functional/no-filter.test.js
@@ -31,7 +31,8 @@ test('no filters broker', t => {
 
   // wait for the client to successfully connect to the server and identify itself
   server.io.on('connection', socket => {
-    socket.on('identify', token => {
+    socket.on('identify', clientData => {
+      const token = clientData.token;
       t.plan(2);
 
       t.test('successfully broker with no filter should reject', t => {


### PR DESCRIPTION
Broker clients will now identify themselves with the broker client by passing their metadata in addition to their token.

The purpose of this change is to improve visibility into live broker clients for better troubleshooting etc.