### PR TITLE
Feat/docker node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ cache:
 notifications:
   email: false
 node_js:
-  - 4
-  - 6
   - 8
 before_script:
   - npm run es5ify
@@ -19,5 +17,5 @@ after_success:
   # manually detect master branch push, and post a dockerhub trigger to build the docker images
   - 'if [ "$TRAVIS_BRANCH" = "master" ]; then curl -s -H "Content-Type: application/json" --data "{\"build\": true}" -X POST https://registry.hub.docker.com/u/snyk/broker/trigger/${DOCKER_TOKEN}/; fi'
 branches:
-  except:
-    - /^v\d+\.\d+\.\d+$/
+  only:
+    - master

--- a/dockerfiles/bitbucket-server/Dockerfile
+++ b/dockerfiles/bitbucket-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6-slim
+FROM node:8-slim
 
 MAINTAINER Snyk Ltd
 

--- a/dockerfiles/github-com/Dockerfile
+++ b/dockerfiles/github-com/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6-slim
+FROM node:8-slim
 
 MAINTAINER Snyk Ltd
 

--- a/dockerfiles/github-enterprise/Dockerfile
+++ b/dockerfiles/github-enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6-slim
+FROM node:8-slim
 
 MAINTAINER Snyk Ltd
 

--- a/dockerfiles/gitlab/Dockerfile
+++ b/dockerfiles/gitlab/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6-slim
+FROM node:8-slim
 
 MAINTAINER Snyk Ltd
 


### PR DESCRIPTION
* Test on nodejs 8 only
* Base docker images on `node:8-slim`

The purpose is to advance to newer node versions (node 6 will move to maintenance on May 2018), and have faster test & release cycles for the broker at the expense of a narrower runtime support.