### PR TITLE
fix: expose metadata of all clients on connection-status

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -21,8 +21,10 @@ module.exports = ({ config = {}, port = null, filters = {} }) => {
     const id = req.params.id;
 
     if (connections.has(id)) {
-      const metadata = connections.get(id)[0].metadata;
-      return res.status(200).json({ ok: true, version: metadata.version });
+      const clientsMetadata = connections.get(id).map(conn => ({
+        version: conn.metadata && conn.metadata.version,
+      }));
+      return res.status(200).json({ ok: true, clients: clientsMetadata });
     }
     debug('no broker found matching "%s"', id);
     return res.status(404).json({ ok: false });

--- a/test/functional/healthcheck.test.js
+++ b/test/functional/healthcheck.test.js
@@ -72,7 +72,7 @@ test('proxy requests originating from behind the broker client', t => {
 
           t.equal(res.statusCode, 200, '200 statusCode');
           t.equal(res.body.ok, true, '{ ok: true } in body');
-          t.ok(res.body.version, 'version in body');
+          t.ok(res.body.clients[0].version, 'client version in body');
           t.end();
         });
       });
@@ -97,7 +97,7 @@ test('proxy requests originating from behind the broker client', t => {
 
             t.equal(res.statusCode, 200, '200 statusCode');
             t.equal(res.body.ok, true, '{ ok: true } in body');
-            t.ok(res.body.version, 'version in body');
+            t.ok(res.body.clients[0].version, 'client version in body');
             t.end();
           });
         }, 20);


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by @ … (Snyk internal team)

#### What does this PR do?

When checking for the status of a specific connection, expose the versions of all clients and not just the first one. This is done to improve visibility into number of client connections for the same token, and their versions.