### PR TITLE
fix: allow default branch checking on bitbucket server template rules

### DIFF
--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -122,6 +122,12 @@
       "method": "GET",
       "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests",
       "origin": "https://${BITBUCKET_USERNAME}:${BITBUCKET_PASSWORD}@${BITBUCKET}"
+    },
+    {
+      "//": "used to check for a repo's default branch",
+      "method": "GET",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/branches/default",
+      "origin": "https://${BITBUCKET_USERNAME}:${BITBUCKET_PASSWORD}@${BITBUCKET}"
     }
   ]
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by @ … (Snyk internal team)

#### What does this PR do?

Adds a rule in the bitbucket server template to allow checking for a repo's default branch.