### PR TITLE
chore: docker build trigger is within dockerhub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ before_script:
 after_success:
   # publish to npmjs and create a GH release; auto-detects master branch pushes and acts on them only
   - npm run semantic-release
-  # manually detect master branch push, and post a dockerhub trigger to build the docker images
-  - 'if [ "$TRAVIS_BRANCH" = "master" ]; then curl -s -H "Content-Type: application/json" --data "{\"build\": true}" -X POST https://registry.hub.docker.com/u/snyk/broker/trigger/${DOCKER_TOKEN}/; fi'
 branches:
   only:
     - master


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by @ … (Snyk internal team)

#### What does this PR do?

Remove dockerhub build trigger from travis settings, as dockerhub is monitoring the repo directly and builds on new tags.