### PR TITLE
feat: allow access to branch status checks on github

### DIFF
--- a/client-templates/github/accept.json.sample
+++ b/client-templates/github/accept.json.sample
@@ -134,6 +134,27 @@
     },
 
     {
+      "//": "used to get status checks on a branch",
+      "method": "GET",
+      "path": "/repos/:user/:repo/branches/:branch/protection/required_status_checks/contexts",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+
+    {
+      "//": "used to create status checks on a branch",
+      "method": "POST",
+      "path": "/repos/:user/:repo/branches/:branch/protection/required_status_checks/contexts",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+
+    {
+      "//": "used to delete status checks on a branch",
+      "method": "DELETE",
+      "path": "/repos/:user/:repo/branches/:branch/protection/required_status_checks/contexts",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+
+    {
       "//": "check if repo is public",
       "method": "GET",
       "path": "/:user/:repo",


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by @ … (Snyk internal team)

#### What does this PR do?

Adds access to branch status checks on GitHub. This will allow Snyk to convert from one version of Snyk status checks to another, needed for smooth migration purposes only.