### PR TITLE
fix: fix PRs for nested files in bitbucket-server

### DIFF
--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -78,7 +78,7 @@
     {
       "//": "used to check if there's any ignore rules or existing patches",
       "method": "GET",
-      "path": "/projects/:project/repos/:repo/browse/.snyk",
+      "path": "/projects/:project/repos/:repo/browse*/.snyk",
       "origin": "https://${BITBUCKET_USERNAME}:${BITBUCKET_PASSWORD}@${BITBUCKET_API}"
     },
     {
@@ -108,7 +108,7 @@
     {
       "//": "used to create or update a file for fix PRs",
       "method": "PUT",
-      "path": "/rest/api/1.0/projects/:project/repos/:repo/browse/:path",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/browse/*",
       "origin": "https://${BITBUCKET_USERNAME}:${BITBUCKET_PASSWORD}@${BITBUCKET}"
     },
     {


### PR DESCRIPTION
#### What does this PR do?

Modifies `accept.json` template for bitbucket-server broker clients to allow fix PRs for nested manifest files.
