### PR TITLE
fix: consider the case where body is 'null'

### DIFF
--- a/lib/try-json-parse.js
+++ b/lib/try-json-parse.js
@@ -1,6 +1,6 @@
 module.exports = (data) => {
   try {
-    return JSON.parse(Buffer.from(data));
+    return JSON.parse(Buffer.from(data)) || {};
   } catch (e) {
     return {};
   }

--- a/test/unit/try-json-parse.test.js
+++ b/test/unit/try-json-parse.test.js
@@ -20,6 +20,7 @@ test('tryJSONParse', t => {
   t.same(tryJSONParse(null), {}, 'null parses as empty');
   t.same(tryJSONParse(data), {}, 'objects parse as empty');
   t.same(tryJSONParse("nonsense"), {}, 'malformed strings parse as empty');
+  t.same(tryJSONParse("null"), {}, 'null strings parse as empty');
 
   t.end();
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by @ … (Snyk internal team)

#### What does this PR do?

when getting the body it could be a string representation of null, meaning 'null'...
in this case Buffer.from('null') will return 'null' and JSON.parse will parse it as null.
eventually this chain of event will cause tryJsonParse to return null and relay.js will fail on line 114
because parsedBody will be null.
