### PR TITLE
feat: Include packages.config in a list of allowed manifest files

### DIFF
--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -131,6 +131,17 @@
       }
     },
     {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/packages.config",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
       "//": "used to check if there's any ignore rules or existing patches",
       "method": "GET",
       "path": "/projects/:project/repos/:repo/browse*/.snyk",

--- a/client-templates/github-com/accept.json.sample
+++ b/client-templates/github-com/accept.json.sample
@@ -82,6 +82,14 @@
           {
             "path": "commits.*.modified.*",
             "value": ".snyk"
+          },
+          {
+            "path": "commits.*.added.*",
+            "value": "packages.config"
+          },
+          {
+            "path": "commits.*.modified.*",
+            "value": "packages.config"
           }
         ]
       },
@@ -297,6 +305,18 @@
       "//": "used to determine the full dependency tree",
       "method": "GET",
       "path": "/:name/:repo/:path*/build.sbt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/packages.config",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/packages.config",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {

--- a/client-templates/github-enterprise/accept.json.sample
+++ b/client-templates/github-enterprise/accept.json.sample
@@ -82,6 +82,14 @@
           {
             "path": "commits.*.modified.*",
             "value": ".snyk"
+          },
+          {
+            "path": "commits.*.added.*",
+            "value": "packages.config"
+          },
+          {
+            "path": "commits.*.modified.*",
+            "value": "packages.config"
           }
         ]
       },
@@ -243,6 +251,12 @@
       "//": "used to determine the full dependency tree",
       "method": "GET",
       "path": "/repos/:name/:repo/contents/:path*/build.sbt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/packages.config",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {

--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -88,6 +88,12 @@
       "origin": "https://${GITLAB}"
     },
     {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/packages.config",
+      "origin": "https://${GITLAB}"
+    },
+    {
       "//": "used to check if there's any ignore rules or existing patches",
       "method": "GET",
       "path": "/api/v4/projects/:project/repository/files*/.snyk",
@@ -111,7 +117,8 @@
             "**/requirements.txt",
             "**/build.gradle",
             "**/build.sbt",
-            "**/.snyk"
+            "**/.snyk",
+            "**/packages.config"
           ]
         }
       ]

--- a/lib/filters/index.js
+++ b/lib/filters/index.js
@@ -23,7 +23,6 @@ module.exports = ruleSource => {
     }
   }
 
-
   if (!Array.isArray(rules)) {
     throw new Error(`unsupported type (${typeof rules}) for filter rules`);
   }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
- Allow a new manifest type `packages.config` for .NET projects


#### Any background context you want to provide?
This is part of the planned work around .net & .net core SCM support

