### PR TITLE
feat: broker client systemcheck endpoint

### DIFF
--- a/client-templates/bitbucket-server/.env.sample
+++ b/client-templates/bitbucket-server/.env.sample
@@ -20,6 +20,12 @@ BITBUCKET_API=$BITBUCKET/rest/api/1.0
 # the url of your broker client (including scheme and port)
 # BROKER_CLIENT_URL=
 
+# Bitbucket server validation url, checked by broker client systemcheck endpoint
+BROKER_CLIENT_VALIDATION_URL=https://$BITBUCKET/rest/api/1.0/projects
+
+# Bitbucket server basic auth creds
+BROKER_CLIENT_VALIDATION_BASIC_AUTH="$BITBUCKET_USERNAME:$BITBUCKET_PASSWORD"
+
 # The URL of the Snyk broker server
 BROKER_SERVER_URL=https://broker.snyk.io
 

--- a/client-templates/github-com/.env.sample
+++ b/client-templates/github-com/.env.sample
@@ -4,24 +4,26 @@ BROKER_TOKEN=
 # your personal access token to your github.com account
 GITHUB_TOKEN=
 
-# the host GitHub, excluding scheme. For github.com
-# this should be "github.com"
-GITHUB=
+# the host for GitHub, excluding scheme
+GITHUB=github.com
 
-# the host for GitHub's raw content, excluding scheme. For github.com
-# this should be "raw.githubusercontent.com"
-GITHUB_RAW=
+# the host for GitHub's raw content, excluding scheme
+GITHUB_RAW=raw.githubusercontent.com
 
-# the url that the github API should be accessed at. For github.com this should be
-# changed to "api.github.com"
-GITHUB_API=$GITHUB/api/v3
+# the GitHub REST API url, excluding scheme
+GITHUB_API=api.github.com
 
-# the url that the github graphql API should be accessed at.
-# For github.com this should be changed to "api.github.com"
-GITHUB_GRAPHQL=$GITHUB/api
+# the GitHub GraphQL API url, excluding scheme
+GITHUB_GRAPHQL=api.github.com
 
 # the url of your broker client (including scheme and port)
 # BROKER_CLIENT_URL=
+
+# GitHub validation url, checked by broker client systemcheck endpoint
+BROKER_CLIENT_VALIDATION_URL=https://$GITHUB_API/user
+
+# GitHub validation request Authorization header
+BROKER_CLIENT_VALIDATION_AUTHORIZATION_HEADER="token $GITHUB_TOKEN"
 
 # The URL of the Snyk broker server
 BROKER_SERVER_URL=https://broker.snyk.io

--- a/client-templates/github-enterprise/.env.sample
+++ b/client-templates/github-enterprise/.env.sample
@@ -4,20 +4,23 @@ BROKER_TOKEN=
 # your personal access token to your github enterprise account
 GITHUB_TOKEN=
 
-# the host where your GitHub Enterprise is running, excluding scheme. For github.com
-# this should be "github.com"
+# the host for your GitHub Enterprise deployment, excluding scheme
 GITHUB=
 
-# the url that the github API should be accessed at. For github.com this should be
-# changed to "api.github.com"
+# the GitHub Enterprise REST API url, excluding scheme
 GITHUB_API=$GITHUB/api/v3
 
-# the url that the github graphql API should be accessed at.
-# For github.com this should be changed to "api.github.com"
+# the GitHub Enterprise GraphQL API url, excluding scheme
 GITHUB_GRAPHQL=$GITHUB/api
 
 # the url of your broker client (including scheme and port)
 # BROKER_CLIENT_URL=
+
+# GitHub Enterprise validation url, checked by broker client systemcheck endpoint
+BROKER_CLIENT_VALIDATION_URL=https://$GITHUB_API/user
+
+# GitHub Enterprise validation request Authorization header
+BROKER_CLIENT_VALIDATION_AUTHORIZATION_HEADER="token $GITHUB_TOKEN"
 
 # The URL of the Snyk broker server
 BROKER_SERVER_URL=https://broker.snyk.io

--- a/client-templates/gitlab/.env.sample
+++ b/client-templates/gitlab/.env.sample
@@ -11,6 +11,9 @@ GITLAB=
 # the url of your broker client (including scheme and port)
 # BROKER_CLIENT_URL=
 
+# GitLab validation url, checked by broker client systemcheck endpoint
+BROKER_CLIENT_VALIDATION_URL=https://$GITLAB/api/v3/user?private_token=$GITLAB_TOKEN
+
 # The URL of the Snyk broker server
 BROKER_SERVER_URL=https://broker.snyk.io
 

--- a/client-templates/jira/.env.sample
+++ b/client-templates/jira/.env.sample
@@ -4,15 +4,23 @@ BROKER_TOKEN=
 # your personal username to your Jira Server account
 JIRA_USERNAME=
 
-# your personal password to your Jira Server account
+# your personal password or API token to your Jira Server account
 JIRA_PASSWORD=
 
+# your Jira Server hostname, i.e. jira.yourdomain.com
+JIRA_HOSTNAME=
+
 # Your Jira Server URL, including scheme and hostname
-# i.e. https://jira.yourdomain.com
-JIRA_BASE_URL=
+JIRA_BASE_URL=https://$JIRA_HOSTNAME
 
 # the url of your broker client (including scheme and port)
 # BROKER_CLIENT_URL=
+
+# Jira validation url, checked by broker client systemcheck endpoint
+BROKER_CLIENT_VALIDATION_URL=https://$JIRA_HOSTNAME/rest/api/2/myself
+
+# Jira basic auth creds
+BROKER_CLIENT_VALIDATION_BASIC_AUTH="$JIRA_USERNAME:$JIRA_PASSWORD"
 
 # The URL of the Snyk broker server
 BROKER_SERVER_URL=https://broker.snyk.io

--- a/dockerfiles/bitbucket-server/Dockerfile
+++ b/dockerfiles/bitbucket-server/Dockerfile
@@ -59,10 +59,16 @@ ENV ACCEPT accept.json
 # The path for the broker's internal healthcheck URL. Must start with a '/'.
 ENV BROKER_HEALTHCHECK_PATH /healthcheck
 
+# Bitbucket server validation url, checked by broker client healthcheck endpoint
+ENV BROKER_CLIENT_VALIDATION_URL https://$BITBUCKET/rest/api/1.0/projects
+
+# Bitbucket server basic auth creds
+ENV BROKER_CLIENT_VALIDATION_BASIC_AUTH "$BITBUCKET_USERNAME:$BITBUCKET_PASSWORD"
+
 
 EXPOSE $PORT
 
-HEALTHCHECK --interval=10s --timeout=1s \
+HEALTHCHECK --interval=60s --timeout=10s \
   CMD wget -q --spider http://localhost:${PORT}${BROKER_HEALTHCHECK_PATH}
 
 CMD ["broker", "--verbose"]

--- a/dockerfiles/bitbucket-server/Dockerfile
+++ b/dockerfiles/bitbucket-server/Dockerfile
@@ -68,7 +68,4 @@ ENV BROKER_CLIENT_VALIDATION_BASIC_AUTH "$BITBUCKET_USERNAME:$BITBUCKET_PASSWORD
 
 EXPOSE $PORT
 
-HEALTHCHECK --interval=60s --timeout=10s \
-  CMD wget -q --spider http://localhost:${PORT}${BROKER_HEALTHCHECK_PATH}
-
 CMD ["broker", "--verbose"]

--- a/dockerfiles/github-com/Dockerfile
+++ b/dockerfiles/github-com/Dockerfile
@@ -62,10 +62,16 @@ ENV ACCEPT accept.json
 # The path for the broker's internal healthcheck URL. Must start with a '/'.
 ENV BROKER_HEALTHCHECK_PATH /healthcheck
 
+# GitHub validation url, checked by broker client healthcheck endpoint
+ENV BROKER_CLIENT_VALIDATION_URL https://$GITHUB_API/user
+
+# GitHub validation request Authorization header
+ENV BROKER_CLIENT_VALIDATION_AUTHORIZATION_HEADER "token $GITHUB_TOKEN"
+
 
 EXPOSE $PORT
 
-HEALTHCHECK --interval=10s --timeout=1s \
+HEALTHCHECK --interval=60s --timeout=10s \
   CMD wget -q --spider http://localhost:${PORT}${BROKER_HEALTHCHECK_PATH}
 
 CMD ["broker", "--verbose"]

--- a/dockerfiles/github-com/Dockerfile
+++ b/dockerfiles/github-com/Dockerfile
@@ -71,7 +71,4 @@ ENV BROKER_CLIENT_VALIDATION_AUTHORIZATION_HEADER "token $GITHUB_TOKEN"
 
 EXPOSE $PORT
 
-HEALTHCHECK --interval=60s --timeout=10s \
-  CMD wget -q --spider http://localhost:${PORT}${BROKER_HEALTHCHECK_PATH}
-
 CMD ["broker", "--verbose"]

--- a/dockerfiles/github-enterprise/Dockerfile
+++ b/dockerfiles/github-enterprise/Dockerfile
@@ -68,7 +68,4 @@ ENV BROKER_CLIENT_VALIDATION_AUTHORIZATION_HEADER "token $GITHUB_TOKEN"
 
 EXPOSE $PORT
 
-HEALTHCHECK --interval=60s --timeout=10s \
-  CMD wget -q --spider http://localhost:${PORT}${BROKER_HEALTHCHECK_PATH}
-
 CMD ["broker", "--verbose"]

--- a/dockerfiles/github-enterprise/Dockerfile
+++ b/dockerfiles/github-enterprise/Dockerfile
@@ -59,10 +59,16 @@ ENV ACCEPT accept.json
 # The path for the broker's internal healthcheck URL. Must start with a '/'.
 ENV BROKER_HEALTHCHECK_PATH /healthcheck
 
+# GitHub Enterprise validation url, checked by broker client healthcheck endpoint
+ENV BROKER_CLIENT_VALIDATION_URL https://$GITHUB_API/user
+
+# GitHub Enterprise validation request Authorization header
+ENV BROKER_CLIENT_VALIDATION_AUTHORIZATION_HEADER "token $GITHUB_TOKEN"
+
 
 EXPOSE $PORT
 
-HEALTHCHECK --interval=10s --timeout=1s \
+HEALTHCHECK --interval=60s --timeout=10s \
   CMD wget -q --spider http://localhost:${PORT}${BROKER_HEALTHCHECK_PATH}
 
 CMD ["broker", "--verbose"]

--- a/dockerfiles/gitlab/Dockerfile
+++ b/dockerfiles/gitlab/Dockerfile
@@ -60,7 +60,4 @@ ENV BROKER_CLIENT_VALIDATION_URL https://$GITLAB/api/v3/user?private_token=$GITL
 
 EXPOSE $PORT
 
-HEALTHCHECK --interval=60s --timeout=10s \
-  CMD wget -q --spider http://localhost:${PORT}${BROKER_HEALTHCHECK_PATH}
-
 CMD ["broker", "--verbose"]

--- a/dockerfiles/gitlab/Dockerfile
+++ b/dockerfiles/gitlab/Dockerfile
@@ -53,10 +53,14 @@ ENV ACCEPT accept.json
 # The path for the broker's internal healthcheck URL. Must start with a '/'.
 ENV BROKER_HEALTHCHECK_PATH /healthcheck
 
+# GitLab validation url, checked by broker client healthcheck endpoint
+ENV BROKER_CLIENT_VALIDATION_URL https://$GITLAB/api/v3/user?private_token=$GITLAB_TOKEN
+
+
 
 EXPOSE $PORT
 
-HEALTHCHECK --interval=10s --timeout=1s \
+HEALTHCHECK --interval=60s --timeout=10s \
   CMD wget -q --spider http://localhost:${PORT}${BROKER_HEALTHCHECK_PATH}
 
 CMD ["broker", "--verbose"]

--- a/dockerfiles/jira/Dockerfile
+++ b/dockerfiles/jira/Dockerfile
@@ -27,8 +27,11 @@ ENV BROKER_TOKEN <broker-token>
 ENV JIRA_USERNAME <username>
 ENV JIRA_PASSWORD <password>
 
+# Your Jira Server host
+ENV JIRA_HOSTNAME your.jira.server.hostname
+
 # Your Jira Server URL, including scheme and hostname
-ENV JIRA_BASE_URL https://your.jira.server.hostname
+ENV JIRA_BASE_URL https://$JIRA_HOSTNAME
 
 # The port used by the broker client to accept internal connections
 # Default value is 7341
@@ -54,10 +57,16 @@ ENV ACCEPT accept.json
 # The path for the broker's internal healthcheck URL. Must start with a '/'.
 ENV BROKER_HEALTHCHECK_PATH /healthcheck
 
+# Jira validation url, checked by broker client healthcheck endpoint
+ENV BROKER_CLIENT_VALIDATION_URL https://$JIRA_HOSTNAME/rest/api/2/myself
+
+# Jira basic auth creds
+ENV BROKER_CLIENT_VALIDATION_BASIC_AUTH "$JIRA_USERNAME:$JIRA_PASSWORD"
+
 
 EXPOSE $PORT
 
-HEALTHCHECK --interval=10s --timeout=1s \
+HEALTHCHECK --interval=60s --timeout=10s \
   CMD wget -q --spider http://localhost:${PORT}${BROKER_HEALTHCHECK_PATH}
 
 CMD ["broker", "--verbose"]

--- a/dockerfiles/jira/Dockerfile
+++ b/dockerfiles/jira/Dockerfile
@@ -66,7 +66,4 @@ ENV BROKER_CLIENT_VALIDATION_BASIC_AUTH "$JIRA_USERNAME:$JIRA_PASSWORD"
 
 EXPOSE $PORT
 
-HEALTHCHECK --interval=60s --timeout=10s \
-  CMD wget -q --spider http://localhost:${PORT}${BROKER_HEALTHCHECK_PATH}
-
 CMD ["broker", "--verbose"]

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -1,4 +1,5 @@
 const primus = require('primus');
+const request = require('request');
 const socket = require('./socket');
 const relay = require('../relay');
 const logger = require('../log');
@@ -25,7 +26,7 @@ module.exports = ({ port = null, config = {}, filters = {} }) => {
 
   // IMPORTANT: defined before relay (`app.all('/*', ...`)
   app.get(config.brokerHealthcheckPath || '/healthcheck', (req, res) => {
-    // io.readyState sets the success of the healthcheck
+    // healthcheck state depends on websocket connection status
     // value of primus.Spark.OPEN means the websocket connection is open
     const isConnOpen = (io.readyState === primus.Spark.OPEN);
     const status = isConnOpen ? 200 : 500;
@@ -39,6 +40,70 @@ module.exports = ({ port = null, config = {}, filters = {} }) => {
     return res.status(status).json(data);
   });
 
+  app.get(config.brokerSystemcheckPath || '/systemcheck', (req, res) => {
+    // Systemcheck is the broker client's ability to assert the network 
+    // reachability and some correctness of credentials for the service
+    // being proxied by the broker client.
+
+    const brokerClientValidationMethod =
+      config.brokerClientValidationMethod || 'GET';
+    const brokerClientValidationTimeoutMs =
+      config.brokerClientValidationTimeoutMs || 5000;
+
+    const data = {
+      brokerClientValidationUrl: logger.sanitise(config.brokerClientValidationUrl),
+      brokerClientValidationMethod,
+      brokerClientValidationTimeoutMs,
+    };
+
+    const validationRequestHeaders = {
+      'user-agent': 'Snyk Broker client ' + version,
+    };
+
+    // set auth header according to config
+    if (config.brokerClientValidationAuthorizationHeader) {
+      validationRequestHeaders.authorization = config.brokerClientValidationAuthorizationHeader;
+    } else if (config.brokerClientValidationBasicAuth) {
+      validationRequestHeaders.authorization =
+        `Basic ${new Buffer(config.brokerClientValidationBasicAuth).toString('base64')}`;
+    }
+
+    // make the internal validation request
+    request({
+      url: config.brokerClientValidationUrl,
+      headers: validationRequestHeaders,
+      method: brokerClientValidationMethod,
+      timeout: brokerClientValidationTimeoutMs,
+      json: true,
+    }, (error, response) => {
+      // test logic requires to surface internal data
+      // which is best not exposed in production
+      if (process.env.TAP) {
+        data.testError = error;
+        data.testResponse = response;
+      }
+
+      if (error) {
+        data.ok = false;
+        data.error = error.message;
+        return res.status(500).json(data);
+      }
+
+      data.brokerClientValidationUrlStatusCode = response && response.statusCode;
+      // check for 2xx status code
+      const goodStatusCode = /^2/.test(response && response.statusCode);
+      if (!goodStatusCode) {
+        data.ok = false;
+        data.error = 'Status code is not 2xx';
+        return res.status(500).json(data);
+      }
+
+      data.ok = true;
+      return res.status(200).json(data);
+    });
+  });
+  
+  // relay all other URL paths
   app.all('/*', (req, res, next) => {
     res.locals.io = io;
     next();

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,35 +10,38 @@ const app = module.exports = {
   main: main,
 };
 
-function main({ port, client } = {}) {
+function main({ port, client, config = {} } = {}) {
   // note: the config is loaded in the main function to allow us to mock in tests
   if (process.env.TAP) {
     delete require.cache[require.resolve('./config')];
   }
-  const config = require('./config');
+
+  // merge provided config with env
+  const localConfig = Object.assign({}, require('./config'), config);
+
   if (client === undefined) {
-    client = !!config.brokerServerUrl;
+    client = !!localConfig.brokerServerUrl;
   }
 
-  if (!config.BROKER_CLIENT_URL) {
-    const proto = !config.key && !config.cert ? 'http' : 'https';
-    config.BROKER_CLIENT_URL = `${proto}://localhost:${port || config.port}`;
+  if (!localConfig.BROKER_CLIENT_URL) {
+    const proto = !localConfig.key && !localConfig.cert ? 'http' : 'https';
+    localConfig.BROKER_CLIENT_URL = `${proto}://localhost:${port || localConfig.port}`;
   }
 
   const method = client ? 'client' : 'server';
   process.env.BROKER_TYPE = method;
 
-  logger.debug({ accept: config.accept }, 'loading rules');
+  logger.debug({ accept: localConfig.accept }, 'loading rules');
 
   let filters = {};
-  if (config.accept) {
-    const acceptLocation = path.resolve(process.cwd(), config.accept);
+  if (localConfig.accept) {
+    const acceptLocation = path.resolve(process.cwd(), localConfig.accept);
 
     filters = yaml.safeLoad(fs.readFileSync(acceptLocation, 'utf8'));
   }
 
-  // if the config has the broker server, then we must assume it's a client
-  return app[method]({ config, port, filters });
+  // if the localConfig has the broker server, then we must assume it's a client
+  return app[method]({ config: localConfig, port, filters });
 }
 
 if (!module.parent) {

--- a/lib/log.js
+++ b/lib/log.js
@@ -4,7 +4,7 @@ const mapValues = require('lodash.mapvalues');
 const config = require('./config');
 
 const sanitiseConfigVariable = (raw, variable) =>
-  raw.replace(new RegExp(escapeRegExp(config[variable]), 'igm'), variable);
+  raw.replace(new RegExp(escapeRegExp(config[variable]), 'igm'), '${' + variable + '}');
 
 // sanitises sensitive values, replacing all occurences with label
 function sanitise(raw) {
@@ -35,6 +35,14 @@ function sanitise(raw) {
     raw = sanitiseConfigVariable(raw, 'GITLAB_TOKEN');
   }
 
+  if (config.JIRA_USERNAME) {
+    raw = sanitiseConfigVariable(raw, 'JIRA_USERNAME');
+  }
+
+  if (config.JIRA_USERNAME) {
+    raw = sanitiseConfigVariable(raw, 'JIRA_PASSWORD');
+  }
+
   return raw;
 }
 
@@ -45,7 +53,7 @@ function sanitiseObject(obj) {
 function sanitiseHeaders(headers) {
   const hdrs = JSON.parse(JSON.stringify(headers));
   if (hdrs.authorization) {
-    hdrs.authorization = 'AUTHORIZATION';
+    hdrs.authorization = '${AUTHORIZATION}';
   }
   return sanitiseObject(hdrs);
 }

--- a/lib/log.js
+++ b/lib/log.js
@@ -70,4 +70,7 @@ const log = bunyan.createLogger({
 
 log.level(process.env.LOG_LEVEL || 'info');
 
+// pin sanitation function on the log so it can be used publicly
+log.sanitise = sanitise;
+
 module.exports = log;

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -7,6 +7,7 @@ const Filters = require('./filters');
 const replace = require('./replace-vars');
 const tryJSONParse = require('./try-json-parse');
 const logger = require('./log');
+const version = require('./version');
 
 module.exports = {
   request: requestHandler,
@@ -105,7 +106,7 @@ function responseHandler(filterRules, config) {
       logContext.httpUrl = result.url;
 
       if (!headers['user-agent']) {
-        headers['user-agent'] = 'Snyk Broker';
+        headers['user-agent'] = 'Snyk Broker ' + version;
         logContext.userAgentHeaderSet = true;
       }
 

--- a/test/functional/healthcheck.test.js
+++ b/test/functional/healthcheck.test.js
@@ -17,7 +17,7 @@ test('proxy requests originating from behind the broker client', t => {
    */
 
   process.env.ACCEPT = 'filters.json';
-
+  
   process.chdir(path.resolve(root, '../fixtures/server'));
   process.env.BROKER_TYPE = 'server';
   const serverPort = port();
@@ -92,11 +92,9 @@ test('proxy requests originating from behind the broker client', t => {
       });
 
       t.test('misconfigured client fails healthcheck', t => {
-        // set a bad server url
-        process.env.BROKER_SERVER_URL = 'https://snyk.io';
-        var badClient = app.main({ port: clientPort });
-        // revert to a good server url
-        process.env.BROKER_SERVER_URL = `http://localhost:${serverPort}`;
+        var badClient = app.main({ port: clientPort, config: {
+          brokerServerUrl: 'http://no-such-server',
+        }});
 
         request({url: clientHealth, json: true }, (err, res) => {
           if (err) { return t.threw(err); }

--- a/test/functional/systemcheck.test.js
+++ b/test/functional/systemcheck.test.js
@@ -1,0 +1,123 @@
+const tap = require('tap');
+const test = require('tap-only');
+const path = require('path');
+const request = require('request');
+const app = require('../../lib');
+const root = __dirname;
+
+const { port } = require('../utils')(tap);
+
+test('broker client systemcheck endpoint', t => {
+  /**
+   * 1. start broker in server mode
+   * 2. start broker in client mode and join (1)
+   * 3. check /healthcheck on client and server
+   * 4. stop client and check it's on "disconnected" in the server
+   * 5. restart client with same token, make sure it's not in "disconnected"
+   */
+
+  process.env.ACCEPT = 'filters.json';
+  
+  process.chdir(path.resolve(root, '../fixtures/client'));
+  const clientPort = port();
+  
+  t.plan(4);
+
+  const clientUrl = `http://localhost:${clientPort}`;
+
+  t.test('good validation url, custom endpoint', t => {
+    const client = app.main({ port: clientPort, config: {
+      brokerType: 'client',
+      brokerToken: '1234567890',
+      brokerServerUrl: 'http://localhost:12345',
+      brokerClientValidationUrl: 'https://snyk.io',
+      brokerSystemcheckPath: '/custom-systemcheck',
+    }});
+
+    request({url: `${clientUrl}/custom-systemcheck`, json: true }, (err, res) => {
+      if (err) { return t.threw(err); }
+
+      t.equal(res.statusCode, 200, '200 statusCode');
+      t.equal(res.body.ok, true, '{ ok: true } in body');
+      t.equal(res.body.brokerClientValidationUrl, 'https://snyk.io', 'validation url present');
+
+      client.close();
+      setTimeout(() => {
+        t.end();
+      }, 100);
+    });
+  });
+
+  t.test('good validation url, authorization header', t => {
+    const client = app.main({ port: clientPort, config: {
+      brokerType: 'client',
+      brokerToken: '1234567890',
+      brokerServerUrl: 'http://localhost:12345',
+      brokerClientValidationUrl: 'https://httpbin.org/headers',
+      brokerClientValidationAuthorizationHeader: 'token my-special-access-token',
+    }});
+
+    request({url: `${clientUrl}/systemcheck`, json: true }, (err, res) => {
+      if (err) { return t.threw(err); }
+
+      t.equal(res.statusCode, 200, '200 statusCode');
+      t.equal(res.body.ok, true, '{ ok: true } in body');
+      t.equal(res.body.brokerClientValidationUrl, 'https://httpbin.org/headers', 'validation url present');
+      t.ok(res.body.testResponse.body.headers['User-Agent'], 'user-agent header is present in validation request');
+      t.equal(res.body.testResponse.body.headers.Authorization, 'token my-special-access-token', 'proper authorization header in validation request');
+
+      client.close();
+      setTimeout(() => {
+        t.end();
+      }, 100);
+    });
+  });
+
+  t.test('good validation url, basic auth', t => {
+    const client = app.main({ port: clientPort, config: {
+      brokerType: 'client',
+      brokerToken: '1234567890',
+      brokerServerUrl: 'http://localhost:12345',
+      brokerClientValidationUrl: 'https://httpbin.org/headers',
+      brokerClientValidationBasicAuth: 'username:password',
+    }});
+
+    request({url: `${clientUrl}/systemcheck`, json: true }, (err, res) => {
+      if (err) { return t.threw(err); }
+
+      t.equal(res.statusCode, 200, '200 statusCode');
+      t.equal(res.body.ok, true, '{ ok: true } in body');
+      t.equal(res.body.brokerClientValidationUrl, 'https://httpbin.org/headers', 'validation url present');
+      t.ok(res.body.testResponse.body.headers['User-Agent'], 'user-agent header is present in validation request');
+      const expectedAuthHeader = `Basic ${Buffer('username:password').toString('base64')}`;
+      t.equal(res.body.testResponse.body.headers.Authorization, expectedAuthHeader, 'proper authorization header in request');
+
+      client.close();
+      setTimeout(() => {
+        t.end();
+      }, 100);
+    });
+  });
+
+  t.test('bad validation url', t => {
+    const client = app.main({ port: clientPort, config: {
+      brokerType: 'client',
+      brokerToken: '1234567890',
+      brokerServerUrl: 'http://localhost:12345',
+      brokerClientValidationUrl: 'https://snyk.io/no-such-url-ever',
+    }});
+
+    request({url: `${clientUrl}/systemcheck`, json: true }, (err, res) => {
+      if (err) { return t.threw(err); }
+
+      t.equal(res.statusCode, 500, '500 statusCode');
+      t.equal(res.body.ok, false, '{ ok: false } in body');
+      t.equal(res.body.brokerClientValidationUrl, 'https://snyk.io/no-such-url-ever', 'validation url present');
+
+      client.close();
+      setTimeout(() => {
+        t.end();
+      }, 100);
+    });
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adds a `/systemcheck` endpoint to the broker client, which pokes a configured validation URL, asserting network reachability and some credentials correctness of the broker client configuration. Main purpose is to assist in troubleshooting of connectivity / application issues.

Environment variables configuring the systemcheck:
`BROKER_CLIENT_VALIDATION_URL` - the URL to test
`BROKER_CLIENT_VALIDATION_METHOD` - the HTTP method, default `GET`
`BROKER_CLIENT_VALIDATION_TIMEOUT_MS` - the HTTP request timeout, default 5000ms
`BROKER_CLIENT_VALIDATION_AUTHORIZATION_HEADER` - the `Authorization` header value to be used on the request, default none
`BROKER_CLIENT_VALIDATION_BASIC_AUTH` - the basic auth creds to be base64-encoded and used for the `Authorization` header value, default none