### PR TITLE
feat: allow *.csproj files

### DIFF
--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -142,6 +142,17 @@
       }
     },
     {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/*.csproj",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
       "//": "used to check if there's any ignore rules or existing patches",
       "method": "GET",
       "path": "/projects/:project/repos/:repo/browse*/.snyk",

--- a/client-templates/github-com/accept.json.sample
+++ b/client-templates/github-com/accept.json.sample
@@ -90,6 +90,14 @@
           {
             "path": "commits.*.modified.*",
             "value": "packages.config"
+          },
+          {
+            "path": "commits.*.added.*",
+            "value": "*.csproj"
+          },
+          {
+            "path": "commits.*.modified.*",
+            "value": "*.csproj"
           }
         ]
       },
@@ -317,6 +325,18 @@
       "//": "used to determine the full dependency tree",
       "method": "GET",
       "path": "/:name/:repo/:path*/packages.config",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/*.csproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/*.csproj",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {

--- a/client-templates/github-enterprise/accept.json.sample
+++ b/client-templates/github-enterprise/accept.json.sample
@@ -90,6 +90,14 @@
           {
             "path": "commits.*.modified.*",
             "value": "packages.config"
+          },
+          {
+            "path": "commits.*.added.*",
+            "value": "*.csproj"
+          },
+          {
+            "path": "commits.*.modified.*",
+            "value": "*.csproj"
           }
         ]
       },
@@ -257,6 +265,12 @@
       "//": "used to determine the full dependency tree",
       "method": "GET",
       "path": "/repos/:name/:repo/contents/:path*/packages.config",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/*.csproj",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {

--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -94,6 +94,12 @@
       "origin": "https://${GITLAB}"
     },
     {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/*.csproj",
+      "origin": "https://${GITLAB}"
+    },
+    {
       "//": "used to check if there's any ignore rules or existing patches",
       "method": "GET",
       "path": "/api/v4/projects/:project/repository/files*/.snyk",
@@ -118,7 +124,8 @@
             "**/build.gradle",
             "**/build.sbt",
             "**/.snyk",
-            "**/packages.config"
+            "**/packages.config",
+            "**/*.csproj"
           ]
         }
       ]


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
- Allow a new manifest type `*.csproj` for .NET projects

#### Any background context you want to provide?
This is part of the planned work around .net & .net core SCM support

