### PR TITLE
fix: updating usage with init and logging changes

### DIFF
--- a/usage.txt
+++ b/usage.txt
@@ -5,19 +5,24 @@
 
   This will run the Snyk broker that allows requests to be proxied to your
   internal environment, using controls to configure what types of
-  requests are allowed and to what end point. By default, the broker runs
-  in a silent mode.
+  requests are allowed and to what end point.
+
+  The broker outputs logs in single-line JSON form to `stdout`. By default,
+  the broker runs with `info` level logging. Set the desired logging verbosity
+  by setting the `LOG_LEVEL` environment variable to one of the following:
+  `debug`, `info`, `warn`, `error`, `fatal`. Only the selected log level and UP
+  will be logged.
 
   Commands:
     client .............. run the broker in client mode
     server .............. run the broker in server mode
     init <template> ..... generate the client broker files required
                           for a given template. Supported templates:
-                          github, bitbucket-server, gitlab
+                          github-com, github-enterprise, bitbucket-server,
+                          gitlab
 
   Flags:
 
-    -V, --verbose......... verbose logging
     -h, --help ........... this help
     -v, --version ........ current version
 


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Update usage text with recent changes:
* `init` template types now split between `github-com` and `github-enterprise`.
* logging verbosity is no longer affected by `--verbose`, but by the `LOG_LEVEL` env var instead.