### PR TITLE
feat: add support for getting a single repo

### DIFF
--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -31,6 +31,17 @@
         "password": "${BITBUCKET_PASSWORD}"
       }
      },
+     {
+      "//": "fetch a given repo",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",

--- a/client-templates/github-com/accept.json.sample
+++ b/client-templates/github-com/accept.json.sample
@@ -131,6 +131,13 @@
     },
 
     {
+      "//": "get a user's repo",
+      "method": "GET",
+      "path": "/repos/:user/:repo",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+
+    {
       "//": "rate limit check",
       "method": "GET",
       "path": "/rate_limit",

--- a/client-templates/github-enterprise/accept.json.sample
+++ b/client-templates/github-enterprise/accept.json.sample
@@ -131,6 +131,13 @@
     },
 
     {
+      "//": "get a user's repo",
+      "method": "GET",
+      "path": "/repos/:user/:repo",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+
+    {
       "//": "rate limit check",
       "method": "GET",
       "path": "/rate_limit",

--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -34,6 +34,18 @@
       "origin": "https://${GITLAB}"
     },
     {
+      "//": "get a user's project",
+      "method": "GET",
+      "path": "/api/v3/projects/:project",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "get a user's project",
+      "method": "GET",
+      "path": "/api/v4/projects/:project",
+      "origin": "https://${GITLAB}"
+    },
+    {
       "//": "used to determine the full dependency tree",
       "method": "GET",
       "path": "/api/v4/projects/:project/repository/files*/package.json",


### PR DESCRIPTION
- [X] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Update the relevant client templates to support fetching a single repo

### Links

https://snyksec.atlassian.net/browse/SC-6291

#### Any background context you want to provide?

Needed to support the import API. Some useful links I used to determine the endpoints needed:
https://github.com/snyk/bitbucket-server-agent/commit/de6f8410ed7e0c7b55d97e599fa147960858b2bb
https://github.com/snyk/gitlab-agent/blob/develop/lib/gitlab/client.js
https://github.com/snyk/github-agent/commit/a9c5f63e37a2b6d2af3c73718f8aac179cfbb6af
https://developer.github.com/v3/repos/#get
