### PR TITLE
fix: remove references to JIRA_BASE_URL 

### DIFF
--- a/client-templates/jira/.env.sample
+++ b/client-templates/jira/.env.sample
@@ -10,9 +10,6 @@ JIRA_PASSWORD=
 # your Jira Server hostname, i.e. jira.yourdomain.com
 JIRA_HOSTNAME=
 
-# Your Jira Server URL, including scheme and hostname
-JIRA_BASE_URL=https://$JIRA_HOSTNAME
-
 # the url of your broker client (including scheme and port)
 # BROKER_CLIENT_URL=
 

--- a/client-templates/jira/accept.json.sample
+++ b/client-templates/jira/accept.json.sample
@@ -7,7 +7,7 @@
       "//": "get jira server info",
       "method": "GET",
       "path": "/rest/api/2/serverInfo",
-      "origin": "${JIRA_BASE_URL}",
+      "origin": "https://${JIRA_HOSTNAME}",
       "auth": {
         "scheme": "basic",
         "username": "${JIRA_USERNAME}",
@@ -18,7 +18,7 @@
       "//": "identify user",
       "method": "GET",
       "path": "/rest/api/2/myself",
-      "origin": "${JIRA_BASE_URL}",
+      "origin": "https://${JIRA_HOSTNAME}",
       "auth": {
         "scheme": "basic",
         "username": "${JIRA_USERNAME}",
@@ -29,7 +29,7 @@
       "//": "used to get a list of all Jira projects",
       "method": "GET",
       "path": "/rest/api/2/project",
-      "origin": "${JIRA_BASE_URL}",
+      "origin": "https://${JIRA_HOSTNAME}",
       "auth": {
         "scheme": "basic",
         "username": "${JIRA_USERNAME}",
@@ -48,7 +48,7 @@
       "//": "used to get a Jira project",
       "method": "GET",
       "path": "/rest/api/2/project/:project",
-      "origin": "${JIRA_BASE_URL}",
+      "origin": "https://${JIRA_HOSTNAME}",
       "auth": {
         "scheme": "basic",
         "username": "${JIRA_USERNAME}",
@@ -59,7 +59,7 @@
       "//": "used to get createmeta for a jira project & issueType",
       "method": "GET",
       "path": "/rest/api/2/issue/createmeta",
-      "origin": "${JIRA_BASE_URL}",
+      "origin": "https://${JIRA_HOSTNAME}",
       "auth": {
         "scheme": "basic",
         "username": "${JIRA_USERNAME}",
@@ -70,7 +70,7 @@
       "//": "used to get jira issue",
       "method": "GET",
       "path": "/rest/api/2/issue/:issue",
-      "origin": "${JIRA_BASE_URL}",
+      "origin": "https://${JIRA_HOSTNAME}",
       "auth": {
         "scheme": "basic",
         "username": "${JIRA_USERNAME}",
@@ -81,7 +81,7 @@
       "//": "used to create jira issue",
       "method": "POST",
       "path": "/rest/api/2/issue",
-      "origin": "${JIRA_BASE_URL}",
+      "origin": "https://${JIRA_HOSTNAME}",
       "auth": {
         "scheme": "basic",
         "username": "${JIRA_USERNAME}",
@@ -92,7 +92,7 @@
       "//": "used to create jira issue link",
       "method": "POST",
       "path": "/rest/api/2/issue/:issue/remotelink",
-      "origin": "${JIRA_BASE_URL}",
+      "origin": "https://${JIRA_HOSTNAME}",
       "auth": {
         "scheme": "basic",
         "username": "${JIRA_USERNAME}",
@@ -103,7 +103,7 @@
       "//": "used to get assignable users",
       "method": "GET",
       "path": "/rest/api/2/user/assignable/search",
-      "origin": "${JIRA_BASE_URL}",
+      "origin": "https://${JIRA_HOSTNAME}",
       "auth": {
         "scheme": "basic",
         "username": "${JIRA_USERNAME}",
@@ -114,7 +114,7 @@
       "//": "used to get available components",
       "method": "GET",
       "path": "/rest/api/2/project/:project/components",
-      "origin": "${JIRA_BASE_URL}",
+      "origin": "https://${JIRA_HOSTNAME}",
       "auth": {
         "scheme": "basic",
         "username": "${JIRA_USERNAME}",

--- a/dockerfiles/jira/Dockerfile
+++ b/dockerfiles/jira/Dockerfile
@@ -30,9 +30,6 @@ ENV JIRA_PASSWORD <password>
 # Your Jira Server host
 ENV JIRA_HOSTNAME your.jira.server.hostname
 
-# Your Jira Server URL, including scheme and hostname
-ENV JIRA_BASE_URL https://$JIRA_HOSTNAME
-
 # The port used by the broker client to accept internal connections
 # Default value is 7341
 ENV PORT 7341


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This is a breaking change for our jira broker client users, deploy with care.

Introduced `JIRA_HOSTNAME` a while ago to allow more control while forcing default rules to HTTPS. I thought I was making it so that it overrides `JIRA_BASE_URL`, but turns out I simply made both env vars mandatory.

Making the breaking change from `JIRA_BASE_URL` to `JIRA_HOSTNAME` now.