### PR TITLE
feat: allow .fsproj files through the broker

### DIFF
--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -186,6 +186,17 @@
       }
     },
     {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/*.fsproj",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
       "//": "used to check if there's any ignore rules or existing patches",
       "method": "GET",
       "path": "/projects/:project/repos/:repo/browse*/.snyk",

--- a/client-templates/github-com/accept.json.sample
+++ b/client-templates/github-com/accept.json.sample
@@ -106,6 +106,14 @@
           {
             "path": "commits.*.modified.*",
             "value": "*.vbproj"
+          },
+          {
+            "path": "commits.*.added.*",
+            "value": "*.fsproj"
+          },
+          {
+            "path": "commits.*.modified.*",
+            "value": "*.fsproj"
           }
         ]
       },
@@ -373,6 +381,18 @@
       "//": "used to determine the full dependency tree",
       "method": "GET",
       "path": "/:name/:repo/:path*/*.csproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/*.fsproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/*.fsproj",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {

--- a/client-templates/github-enterprise/accept.json.sample
+++ b/client-templates/github-enterprise/accept.json.sample
@@ -106,6 +106,14 @@
           {
             "path": "commits.*.modified.*",
             "value": "*.vbproj"
+          },
+          {
+            "path": "commits.*.added.*",
+            "value": "*.fsproj"
+          },
+          {
+            "path": "commits.*.modified.*",
+            "value": "*.fsproj"
           }
         ]
       },
@@ -307,6 +315,12 @@
       "//": "used to determine the full dependency tree",
       "method": "GET",
       "path": "/repos/:name/:repo/contents/:path*/*.csproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/*.fsproj",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {

--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -118,6 +118,12 @@
       "origin": "https://${GITLAB}"
     },
     {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/*.fsproj",
+      "origin": "https://${GITLAB}"
+    },
+    {
       "//": "used to check if there's any ignore rules or existing patches",
       "method": "GET",
       "path": "/api/v4/projects/:project/repository/files*/.snyk",
@@ -144,7 +150,8 @@
             "**/.snyk",
             "**/packages.config",
             "**/*.csproj",
-            "**/*.vbproj"
+            "**/*.vbproj",
+            "**/*.fsproj"
           ]
         }
       ]


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adds support for .fsproj files through the broker

#### How should this be manually tested?
1. Create a local broker client
2. Import repo containing .fsproj file from different SCs

#### Screenshots
![image](https://user-images.githubusercontent.com/39525942/48775929-20f74580-ecd7-11e8-890f-5aa8ae5bc5c9.png)
