### PR TITLE
fix: make sure that env vars always exist

### DIFF
--- a/client-templates/bitbucket-server/.env.sample
+++ b/client-templates/bitbucket-server/.env.sample
@@ -1,16 +1,16 @@
 # your unique broker identifier
-BROKER_TOKEN=
+BROKER_TOKEN=<broker-token>
 
 # your personal username to your bitbucket server account
-BITBUCKET_USERNAME=
+BITBUCKET_USERNAME=<username>
 
 # your personal password to your bitbucket server account
-BITBUCKET_PASSWORD=
+BITBUCKET_PASSWORD=<password>
 
 # the host where your Bitbucket Server is running, excluding scheme.
 # for bitbucket.yourdomain.com
 # this should be "bitbucket.yourdomain.com"
-BITBUCKET=
+BITBUCKET=bitbucket.yourdomain.com
 
 # the url that the Bitbucket server API should be accessed at.
 # for bitbucket.yourdomain.com this should be
@@ -32,3 +32,6 @@ BROKER_SERVER_URL=https://broker.snyk.io
 # the fine detail accept rules that allow Snyk to make API requests to your
 # bitbucket server instance
 ACCEPT=accept.json
+
+# The path for the broker's internal healthcheck URL. Must start with a '/'.
+BROKER_HEALTHCHECK_PATH=/healthcheck

--- a/client-templates/github-com/.env.sample
+++ b/client-templates/github-com/.env.sample
@@ -1,8 +1,8 @@
 # your unique broker identifier
-BROKER_TOKEN=
+BROKER_TOKEN=<broker-token>
 
 # your personal access token to your github.com account
-GITHUB_TOKEN=
+GITHUB_TOKEN=<github-token>
 
 # the host for GitHub, excluding scheme
 GITHUB=github.com
@@ -31,3 +31,6 @@ BROKER_SERVER_URL=https://broker.snyk.io
 # the fine detail accept rules that allow Snyk to make API requests to your
 # github.com
 ACCEPT=accept.json
+
+# The path for the broker's internal healthcheck URL. Must start with a '/'.
+BROKER_HEALTHCHECK_PATH=/healthcheck

--- a/client-templates/github-enterprise/.env.sample
+++ b/client-templates/github-enterprise/.env.sample
@@ -1,11 +1,11 @@
 # your unique broker identifier
-BROKER_TOKEN=
+BROKER_TOKEN=<broker-token>
 
 # your personal access token to your github enterprise account
-GITHUB_TOKEN=
+GITHUB_TOKEN=<github-token>
 
 # the host for your GitHub Enterprise deployment, excluding scheme
-GITHUB=
+GITHUB=ghe.yourdomain.com
 
 # the GitHub Enterprise REST API url, excluding scheme
 GITHUB_API=$GITHUB/api/v3
@@ -28,3 +28,6 @@ BROKER_SERVER_URL=https://broker.snyk.io
 # the fine detail accept rules that allow Snyk to make API requests to your
 # github enterprise instance
 ACCEPT=accept.json
+
+# The path for the broker's internal healthcheck URL. Must start with a '/'.
+BROKER_HEALTHCHECK_PATH=/healthcheck

--- a/client-templates/gitlab/.env.sample
+++ b/client-templates/gitlab/.env.sample
@@ -1,12 +1,12 @@
 # your unique broker identifier
-BROKER_TOKEN=
+BROKER_TOKEN=<broker-token>
 
 # your personal token to your Gitlab server account
-GITLAB_TOKEN=
+GITLAB_TOKEN=<gitlab-token>
 
 # the host where your Gitlab Server is running, excluding scheme.
 # i.e. gitlab.yourdomain.com
-GITLAB=
+GITLAB=gitlab.yourdomain.com
 
 # the url of your broker client (including scheme and port)
 # BROKER_CLIENT_URL=
@@ -20,3 +20,6 @@ BROKER_SERVER_URL=https://broker.snyk.io
 # the fine detail accept rules that allow Snyk to make API requests to your
 # gitlab instance
 ACCEPT=accept.json
+
+# The path for the broker's internal healthcheck URL. Must start with a '/'.
+BROKER_HEALTHCHECK_PATH=/healthcheck

--- a/client-templates/jira/.env.sample
+++ b/client-templates/jira/.env.sample
@@ -1,14 +1,14 @@
 # your unique broker identifier
-BROKER_TOKEN=
+BROKER_TOKEN=<broker-token>
 
 # your personal username to your Jira Server account
-JIRA_USERNAME=
+JIRA_USERNAME=<jira-username>
 
 # your personal password or API token to your Jira Server account
-JIRA_PASSWORD=
+JIRA_PASSWORD=<jira-password>
 
 # your Jira Server hostname, i.e. jira.yourdomain.com
-JIRA_HOSTNAME=
+JIRA_HOSTNAME=jira.yourdomain.com
 
 # the url of your broker client (including scheme and port)
 # BROKER_CLIENT_URL=
@@ -25,3 +25,6 @@ BROKER_SERVER_URL=https://broker.snyk.io
 # the fine detail accept rules that allow Snyk to make API requests to your
 # Jira instance
 ACCEPT=accept.json
+
+# The path for the broker's internal healthcheck URL. Must start with a '/'.
+BROKER_HEALTHCHECK_PATH=/healthcheck

--- a/dockerfiles/bitbucket-server/Dockerfile
+++ b/dockerfiles/bitbucket-server/Dockerfile
@@ -37,34 +37,12 @@ ENV BITBUCKET_API $BITBUCKET/rest/api/1.0
 
 # The port used by the broker client to accept internal connections
 # Default value is 7341
-ENV PORT 7341
+# ENV PORT 7341
 
 # The URL of your broker client (including scheme and port)
 # This will be used as the webhook payload URL coming in from
 # your Bitbucket Server.
 # ENV BROKER_CLIENT_URL http://<broker.client.hostname>:$PORT
-
-#######################################
-# Generic Broker Client configuration #
-#######################################
-
-
-# The URL of the Snyk broker server
-ENV BROKER_SERVER_URL https://broker.snyk.io
-
-# The fine detail accept rules that allow Snyk to make API requests to your
-# Bitbucket Server instance
-ENV ACCEPT accept.json
-
-# The path for the broker's internal healthcheck URL. Must start with a '/'.
-ENV BROKER_HEALTHCHECK_PATH /healthcheck
-
-# Bitbucket server validation url, checked by broker client healthcheck endpoint
-ENV BROKER_CLIENT_VALIDATION_URL https://$BITBUCKET/rest/api/1.0/projects
-
-# Bitbucket server basic auth creds
-ENV BROKER_CLIENT_VALIDATION_BASIC_AUTH "$BITBUCKET_USERNAME:$BITBUCKET_PASSWORD"
-
 
 EXPOSE $PORT
 

--- a/dockerfiles/github-com/Dockerfile
+++ b/dockerfiles/github-com/Dockerfile
@@ -21,52 +21,18 @@ RUN broker init github-com
 ######################################
 
 # Your unique broker identifier, copied from snyk.io org settings page
-# ENV BROKER_TOKEN <broker-token>
+ENV BROKER_TOKEN <broker-token>
 
 # Your personal access token to your github.com / GHE account
-# ENV GITHUB_TOKEN <github-token>
+ENV GITHUB_TOKEN <github-token>
 
 # The port used by the broker client to accept webhooks
 # Default value is 7341
-ENV PORT 7341
+# ENV PORT 7341
 
 # The URL of your broker client (including scheme and port)
 # This will be used as the webhook payload URL coming in from GitHub
 # ENV BROKER_CLIENT_URL http://<broker.client.hostname>:$PORT
-
-
-
-#######################################
-# Generic Broker Client configuration #
-#######################################
-
-# GitHub host is github.com
-ENV GITHUB github.com
-
-# GitHub host for serving raw files
-ENV GITHUB_RAW raw.githubusercontent.com
-
-# Github API endpoint, excluding scheme.
-ENV GITHUB_API api.github.com
-
-# Github GraphQL API endpoint, excluding scheme.
-ENV GITHUB_GRAPHQL api.github.com
-
-# The URL of the Snyk broker server
-ENV BROKER_SERVER_URL https://broker.snyk.io
-
-# The fine detail accept rules that allow Snyk to make API requests to your
-# GitHub account
-ENV ACCEPT accept.json
-
-# The path for the broker's internal healthcheck URL. Must start with a '/'.
-ENV BROKER_HEALTHCHECK_PATH /healthcheck
-
-# GitHub validation url, checked by broker client healthcheck endpoint
-ENV BROKER_CLIENT_VALIDATION_URL https://$GITHUB_API/user
-
-# GitHub validation request Authorization header
-ENV BROKER_CLIENT_VALIDATION_AUTHORIZATION_HEADER "token $GITHUB_TOKEN"
 
 
 EXPOSE $PORT

--- a/dockerfiles/github-enterprise/Dockerfile
+++ b/dockerfiles/github-enterprise/Dockerfile
@@ -21,10 +21,10 @@ RUN broker init github-enterprise
 ######################################
 
 # Your unique broker identifier, copied from snyk.io org settings page
-# ENV BROKER_TOKEN <broker-token>
+ENV BROKER_TOKEN <broker-token>
 
 # Your personal access token to your github.com / GHE account
-# ENV GITHUB_TOKEN <github-token>
+ENV GITHUB_TOKEN <github-token>
 
 # The host where your GitHub Enterprise is running, excluding scheme.
 ENV GITHUB=your.ghe.domain.com
@@ -37,34 +37,11 @@ ENV GITHUB_GRAPHQL your.ghe.domain.com/api
 
 # The port used by the broker client to accept webhooks
 # Default value is 7341
-ENV PORT 7341
+# ENV PORT 7341
 
 # The URL of your broker client (including scheme and port)
 # This will be used as the webhook payload URL coming in from GitHub
 # ENV BROKER_CLIENT_URL http://<broker.client.hostname>:$PORT
-
-
-
-#######################################
-# Generic Broker Client configuration #
-#######################################
-
-# The URL of the Snyk broker server
-ENV BROKER_SERVER_URL https://broker.snyk.io
-
-# The fine detail accept rules that allow Snyk to make API requests to your
-# github enterprise instance
-ENV ACCEPT accept.json
-
-# The path for the broker's internal healthcheck URL. Must start with a '/'.
-ENV BROKER_HEALTHCHECK_PATH /healthcheck
-
-# GitHub Enterprise validation url, checked by broker client healthcheck endpoint
-ENV BROKER_CLIENT_VALIDATION_URL https://$GITHUB_API/user
-
-# GitHub Enterprise validation request Authorization header
-ENV BROKER_CLIENT_VALIDATION_AUTHORIZATION_HEADER "token $GITHUB_TOKEN"
-
 
 EXPOSE $PORT
 

--- a/dockerfiles/gitlab/Dockerfile
+++ b/dockerfiles/gitlab/Dockerfile
@@ -31,31 +31,11 @@ ENV GITLAB your.gitlab.server.hostname
 
 # The port used by the broker client to accept internal connections
 # Default value is 7341
-ENV PORT 7341
+# ENV PORT 7341
 
 # The URL of your broker client (including scheme and port)
 # This will be used as the webhook payload URL coming in from Gitlab
 # ENV BROKER_CLIENT_URL http://<broker.client.hostname>:$PORT
-
-
-#######################################
-# Generic Broker Client configuration #
-#######################################
-
-
-# The URL of the Snyk broker server
-ENV BROKER_SERVER_URL https://broker.snyk.io
-
-# The fine detail accept rules that allow Snyk to make API requests to your
-# Bitbucket Server instance
-ENV ACCEPT accept.json
-
-# The path for the broker's internal healthcheck URL. Must start with a '/'.
-ENV BROKER_HEALTHCHECK_PATH /healthcheck
-
-# GitLab validation url, checked by broker client healthcheck endpoint
-ENV BROKER_CLIENT_VALIDATION_URL https://$GITLAB/api/v3/user?private_token=$GITLAB_TOKEN
-
 
 
 EXPOSE $PORT

--- a/dockerfiles/jira/Dockerfile
+++ b/dockerfiles/jira/Dockerfile
@@ -32,34 +32,11 @@ ENV JIRA_HOSTNAME your.jira.server.hostname
 
 # The port used by the broker client to accept internal connections
 # Default value is 7341
-ENV PORT 7341
+# ENV PORT 7341
 
 # The URL of your broker client (including scheme and port)
 # This will be used as the webhook payload URL coming in from Jira
 # ENV BROKER_CLIENT_URL http://<broker.client.hostname>:$PORT
-
-
-#######################################
-# Generic Broker Client configuration #
-#######################################
-
-
-# The URL of the Snyk broker server
-ENV BROKER_SERVER_URL https://broker.snyk.io
-
-# The fine detail accept rules that allow Snyk to make API requests to your
-# Jira instance
-ENV ACCEPT accept.json
-
-# The path for the broker's internal healthcheck URL. Must start with a '/'.
-ENV BROKER_HEALTHCHECK_PATH /healthcheck
-
-# Jira validation url, checked by broker client healthcheck endpoint
-ENV BROKER_CLIENT_VALIDATION_URL https://$JIRA_HOSTNAME/rest/api/2/myself
-
-# Jira basic auth creds
-ENV BROKER_CLIENT_VALIDATION_BASIC_AUTH "$JIRA_USERNAME:$JIRA_PASSWORD"
-
 
 EXPOSE $PORT
 


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This fixes a problem where the broker is working correctly but system check does not work because the url in the env vars isn't defined.