### PR TITLE
feat: Adds support for project.json dependency files.

### DIFF
--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -197,6 +197,17 @@
       }
     },
     {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/project.json",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
       "//": "used to check if there's any ignore rules or existing patches",
       "method": "GET",
       "path": "/projects/:project/repos/:repo/browse*/.snyk",

--- a/client-templates/github-com/accept.json.sample
+++ b/client-templates/github-com/accept.json.sample
@@ -114,6 +114,14 @@
           {
             "path": "commits.*.modified.*",
             "value": "*.fsproj"
+          },
+          {
+            "path": "commits.*.added.*",
+            "value": "project.json"
+          },
+          {
+            "path": "commits.*.modified.*",
+            "value": "project.json"
           }
         ]
       },
@@ -405,6 +413,18 @@
       "//": "used to determine the full dependency tree",
       "method": "GET",
       "path": "/:name/:repo/:path*/*.vbproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/project.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/project.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {

--- a/client-templates/github-enterprise/accept.json.sample
+++ b/client-templates/github-enterprise/accept.json.sample
@@ -114,6 +114,14 @@
           {
             "path": "commits.*.modified.*",
             "value": "*.fsproj"
+          },
+          {
+            "path": "commits.*.added.*",
+            "value": "project.json"
+          },
+          {
+            "path": "commits.*.modified.*",
+            "value": "project.json"
           }
         ]
       },
@@ -327,6 +335,12 @@
       "//": "used to determine the full dependency tree",
       "method": "GET",
       "path": "/repos/:name/:repo/contents/:path*/*.vbproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/project.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {

--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -124,6 +124,12 @@
       "origin": "https://${GITLAB}"
     },
     {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/project.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
       "//": "used to check if there's any ignore rules or existing patches",
       "method": "GET",
       "path": "/api/v4/projects/:project/repository/files*/.snyk",
@@ -151,7 +157,8 @@
             "**/packages.config",
             "**/*.csproj",
             "**/*.vbproj",
-            "**/*.fsproj"
+            "**/*.fsproj",
+            "**/project.json"
           ]
         }
       ]


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR adds support for project.json dotnet dependencies.

#### Where should the reviewer start?

Fire up a local Broker for any of the SCMs and add a repo containing a project.json file. Do a search for snyk-fixtures/dotnet-project-json, there is a repo for GitHub, GitHub Enterprise, Bitbucket Server and GitLab for testing.

#### How should this be manually tested?

I've tested this for each SCM but to test manually yourself try adding a repo containing a project.json using a Broker for each SCM.

#### Screenshots

![](https://media.giphy.com/media/ErdfMetILIMko/giphy.gif)