### PR TITLE
feat: gitlab adding new endpoints for searching projects

### DIFF
--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -210,6 +210,18 @@
       "method": "GET",
       "path": "/api/v4/groups/:id/projects",
       "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "get current user. so we'll be able to fetch it's projects",
+      "method": "GET",
+      "path": "/api/v4/user",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "get user's projects",
+      "method": "GET",
+      "path": "/api/v4/users/:user/projects",
+      "origin": "https://${GITLAB}"
     }
   ]
 }


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
In order to support search on PAS on Gitlab, new endpoints were added.
