### PR TITLE
fix: gl missing projects when using admin user

### DIFF
--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -222,6 +222,12 @@
       "method": "GET",
       "path": "/api/v4/users/:user/projects",
       "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "get all users. so we'll be able to fetch projects that admin can access",
+      "method": "GET",
+      "path": "/api/v4/users",
+      "origin": "https://${GITLAB}"
     }
   ]
 }


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING]
#### What does this PR do?
admin user couldn't see other user's project. that resulted on us showing only partial data on PAS page. and crashed whenever searching something that is owned by other user.

adding users endpoint.