### PR TITLE
fix: accept filepath with %2F (encoded '/')

### DIFF
--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -67,7 +67,29 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fpackage.json",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/projects/:project/repos/:repo/browse*/package-lock.json",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fpackage-lock.json",
       "origin": "https://${BITBUCKET_API}",
       "auth": {
         "scheme": "basic",
@@ -89,7 +111,29 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2FGemfile.lock",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/projects/:project/repos/:repo/browse*/Gemfile",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2FGemfile",
       "origin": "https://${BITBUCKET_API}",
       "auth": {
         "scheme": "basic",
@@ -111,7 +155,29 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fpom.xml",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/projects/:project/repos/:repo/browse*/requirements.txt",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Frequirements.txt",
       "origin": "https://${BITBUCKET_API}",
       "auth": {
         "scheme": "basic",
@@ -133,7 +199,29 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fyarn.lock",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/projects/:project/repos/:repo/browse*/build.gradle",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fbuild.gradle",
       "origin": "https://${BITBUCKET_API}",
       "auth": {
         "scheme": "basic",
@@ -155,7 +243,29 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fbuild.sbt",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/projects/:project/repos/:repo/browse*/packages.config",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fpackages.config",
       "origin": "https://${BITBUCKET_API}",
       "auth": {
         "scheme": "basic",
@@ -177,7 +287,29 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2F*.csproj",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/projects/:project/repos/:repo/browse*/*.vbproj",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2F*.vbproj",
       "origin": "https://${BITBUCKET_API}",
       "auth": {
         "scheme": "basic",
@@ -199,7 +331,29 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2F*.fsproj",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/projects/:project/repos/:repo/browse*/project.json",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fproject.json",
       "origin": "https://${BITBUCKET_API}",
       "auth": {
         "scheme": "basic",
@@ -221,7 +375,29 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2FGopkg.toml",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/projects/:project/repos/:repo/browse*/Gopkg.lock",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2FGopkg.lock",
       "origin": "https://${BITBUCKET_API}",
       "auth": {
         "scheme": "basic",
@@ -241,9 +417,31 @@
       }
     },
     {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/vendor%2Fvendor.json",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
       "//": "used to check if there's any ignore rules or existing patches",
       "method": "GET",
       "path": "/projects/:project/repos/:repo/browse*/.snyk",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to check if there's any ignore rules or existing patches",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2F.snyk",
       "origin": "https://${BITBUCKET_API}",
       "auth": {
         "scheme": "basic",

--- a/client-templates/github-com/accept.json.sample
+++ b/client-templates/github-com/accept.json.sample
@@ -292,7 +292,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpackage.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/:name/:repo/:path*/package.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fpackage.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
@@ -304,7 +316,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpackage-lock.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/:name/:repo/:path*/package-lock.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fpackage-lock.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
@@ -316,7 +340,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FGemfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/:name/:repo/:path*/Gemfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2FGemfile.lock",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
@@ -328,7 +364,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FGemfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/:name/:repo/:path*/Gemfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2FGemfile",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
@@ -340,7 +388,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpom.xml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/:name/:repo/:path*/pom.xml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fpom.xml",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
@@ -352,7 +412,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Frequirements.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/:name/:repo/:path*/requirements.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Frequirements.txt",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
@@ -364,7 +436,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fyarn.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/:name/:repo/:path*/yarn.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fyarn.lock",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
@@ -376,7 +460,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fbuild.gradle",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/:name/:repo/:path*/build.gradle",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fbuild.gradle",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
@@ -388,7 +484,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fbuild.sbt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/:name/:repo/:path*/build.sbt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fbuild.sbt",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
@@ -400,7 +508,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpackages.config",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/:name/:repo/:path*/packages.config",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fpackages.config",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
@@ -412,7 +532,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2F*.csproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/:name/:repo/:path*/*.csproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2F*.csproj",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
@@ -424,7 +556,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2F*.fsproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/:name/:repo/:path*/*.fsproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2F*.fsproj",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
@@ -436,7 +580,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2F*.vbproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/:name/:repo/:path*/*.vbproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2F*.vbproj",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
@@ -448,7 +604,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/%2Fproject.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/:name/:repo/:path*/project.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fproject.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
@@ -460,7 +628,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FGopkg.toml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/:name/:repo/:path*/Gopkg.toml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2FGopkg.toml",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
@@ -472,7 +652,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FGopkg.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/:name/:repo/:path*/Gopkg.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2FGopkg.lock",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
@@ -484,7 +676,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fvendor.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/:name/:repo/:path*/vendor.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fvendor.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
@@ -494,12 +698,23 @@
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
+      "//": "used to check if there's any ignore rules or existing patches",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2F.snyk",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
       "//": "used to determine the full dependency tree",
       "method": "GET",
       "path": "/:name/:repo/:path*/.snyk",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
-
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2F.snyk",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
     {
       "//": "get details of the repo",
       "method": "GET",

--- a/client-templates/github-enterprise/accept.json.sample
+++ b/client-templates/github-enterprise/accept.json.sample
@@ -293,7 +293,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpackage.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/repos/:name/:repo/contents/:path*/package-lock.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpackage-lock.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
@@ -305,7 +317,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FGemfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/repos/:name/:repo/contents/:path*/Gemfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FGemfile",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
@@ -317,7 +341,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpom.xml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/repos/:name/:repo/contents/:path*/requirements.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Frequirements.txt",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
@@ -329,13 +365,30 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fyarn.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/repos/:name/:repo/contents/:path*/build.gradle",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fbuild.gradle",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/repos/:name/:repo/contents/:path*/build.sbt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fbuild.sbt",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
@@ -347,7 +400,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpackages.config",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+   },
+   {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/repos/:name/:repo/contents/:path*/*.csproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2F*.csproj",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
@@ -359,7 +424,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2F*.fsproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/repos/:name/:repo/contents/:path*/*.vbproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2F*.vbproj",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
@@ -371,7 +448,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fproject.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/repos/:name/:repo/contents/:path*/Gopkg.toml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FGopkg.toml",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
@@ -383,7 +472,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FGopkg.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/repos/:name/:repo/contents/:path*/vendor/vendor.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/vendor%2Fvendor.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
@@ -392,7 +493,12 @@
       "path": "/repos/:name/:repo/contents/:path*/.snyk",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
-
+    {
+      "//": "used to check if there's any ignore rules or existing patches",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2F.snyk",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
     {
       "//": "get details of the repo",
       "method": "GET",

--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -54,7 +54,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fpackage.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/api/v4/projects/:project/repository/files*/package-lock.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fpackage-lock.json",
       "origin": "https://${GITLAB}"
     },
     {
@@ -66,7 +78,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2FGemfile.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/api/v4/projects/:project/repository/files*/Gemfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2FGemfile",
       "origin": "https://${GITLAB}"
     },
     {
@@ -78,7 +102,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fpom.xml",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/api/v4/projects/:project/repository/files*/requirements.txt",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Frequirements.txt",
       "origin": "https://${GITLAB}"
     },
     {
@@ -90,7 +126,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fyarn.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/api/v4/projects/:project/repository/files*/build.gradle",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fbuild.gradle",
       "origin": "https://${GITLAB}"
     },
     {
@@ -102,7 +150,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fbuild.sbt",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/api/v4/projects/:project/repository/files*/packages.config",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fpackages.config",
       "origin": "https://${GITLAB}"
     },
     {
@@ -114,7 +174,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2F*.csproj",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/api/v4/projects/:project/repository/files*/*.vbproj",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2F*.vbproj",
       "origin": "https://${GITLAB}"
     },
     {
@@ -126,7 +198,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2F*.fsproj",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/api/v4/projects/:project/repository/files*/project.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fproject.json",
       "origin": "https://${GITLAB}"
     },
     {
@@ -138,7 +222,19 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2FGopkg.toml",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/api/v4/projects/:project/repository/files*/Gopkg.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2FGopkg.lock",
       "origin": "https://${GITLAB}"
     },
     {
@@ -148,9 +244,21 @@
       "origin": "https://${GITLAB}"
     },
     {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fvendor.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
       "//": "used to check if there's any ignore rules or existing patches",
       "method": "GET",
       "path": "/api/v4/projects/:project/repository/files*/.snyk",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to check if there's any ignore rules or existing patches",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2F.snyk",
       "origin": "https://${GITLAB}"
     },
     {
@@ -163,23 +271,41 @@
           "queryParam": "file_path",
           "values": [
             "**/package.json",
+            "**%2Fpackage.json",
             "**/yarn.lock",
+            "**%2Fyarn.lock",
             "**/package-lock.json",
+            "**%2Fpackage-lock.json",
             "**/Gemfile",
+            "**%2FGemfile",
             "**/Gemfile.lock",
+            "**%2FGemfile.lock",
             "**/pom.xml",
+            "**%2Fpom.xml",
             "**/requirements.txt",
+            "**%2Frequirements.txt",
             "**/build.gradle",
+            "**%2Fbuild.gradle",
             "**/build.sbt",
+            "**%2Fbuild.sbt",
             "**/.snyk",
+            "**%2F.snyk",
             "**/packages.config",
+            "**%2Fpackages.config",
             "**/*.csproj",
+            "**%2F*.csproj",
             "**/*.vbproj",
+            "**%2F*.vbproj",
             "**/*.fsproj",
+            "**%2F*.fsproj",
             "**/project.json",
+            "**%2Fproject.json"
             "**/Gopkg.toml",
+            "**%2FGopkg.toml",
             "**/Gopkg.lock",
-            "**/vendor.json"
+            "**%2FGopkg.lock",
+            "**/vendor.json",
+            "**%2Fvendor.json"
           ]
         }
       ]


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Second part of https://github.com/snyk/broker/pull/168
Some APIs expect encoded slash (%2F) in the filepath. This commit add explicit accept rules for such case