### PR TITLE
fix: align vendor.json handling

### DIFF
--- a/client-templates/github-enterprise/accept.json.sample
+++ b/client-templates/github-enterprise/accept.json.sample
@@ -479,13 +479,13 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
-      "path": "/repos/:name/:repo/contents/:path*/vendor/vendor.json",
+      "path": "/repos/:name/:repo/contents/:path*/vendor.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
-      "path": "/repos/:name/:repo/contents/:path*%2Fvendor%2Fvendor.json",
+      "path": "/repos/:name/:repo/contents/:path*%2Fvendor.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {


### PR DESCRIPTION
We allow `vendor.json` to be anywhere, not only on `vendor` folder and this behaviour breaks import for GHE brokered customers.

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules