### PR TITLE
fix: align vendor.json for bitbucket as well

### DIFF
--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -408,7 +408,7 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
-      "path": "/projects/:project/repos/:repo/browse*/vendor/vendor.json",
+      "path": "/projects/:project/repos/:repo/browse*/vendor.json",
       "origin": "https://${BITBUCKET_API}",
       "auth": {
         "scheme": "basic",
@@ -419,7 +419,7 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
-      "path": "/projects/:project/repos/:repo/browse*%2Fvendor%2Fvendor.json",
+      "path": "/projects/:project/repos/:repo/browse*%2Fvendor.json",
       "origin": "https://${BITBUCKET_API}",
       "auth": {
         "scheme": "basic",


### PR DESCRIPTION

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Continuing work begun in https://github.com/snyk/broker/pull/171, this PR allows `vendor.json` to be anywhere in the repo, not specifically in `vendor` folder.