### PR TITLE
Add /files endpoint to BBS accept.json sample

### DIFF
--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -54,6 +54,17 @@
       }
     },
     {
+      "//": "read all file names to find manifests",
+      "method": "GET",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/files/:searchPath?",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
       "//": "used to determine the full dependency tree",
       "method": "GET",
       "path": "/projects/:project/repos/:repo/browse*/package.json",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adds a `/files` endpoint, used by recursive manifest search, to the sample Bitbucket Server accept.json
https://snyksec.atlassian.net/browse/COMET-241