### PR TITLE
fix: make response log less noisy

### DIFF
--- a/lib/relay.js
+++ b/lib/relay.js
@@ -52,7 +52,14 @@ function requestHandler(filterRules) {
       }, ioResponse => {
         logContext.ioStatus = ioResponse.status;
         logContext.ioHeaders = ioResponse.headers;
-        logger.info(logContext, 'sending response back to HTTP connection');
+
+        const logMsg = 'sending response back to HTTP connection';
+        if (ioResponse.status <= 200) {
+          logger.debug(logContext, logMsg);
+        } else {
+          logger.info(logContext, logMsg);
+        }
+
         const httpResponse = res
           .status(ioResponse.status)
           .set(ioResponse.headers);
@@ -204,7 +211,14 @@ function responseHandler(filterRules, config) {
         const status = (response && response.statusCode) || 500;
         logContext.httpStatus = status;
         logContext.httpHeaders = response.headers;
-        logger.info(logContext, 'sending response back to websocket connection');
+
+        const logMsg = 'sending response back to websocket connection';
+        if (status <= 200) {
+          logger.debug(logContext, logMsg);
+        } else {
+          logger.info(logContext, logMsg);
+        }
+
         emit({ status, body, headers: response.headers });
       });
     });


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Reduce the log level of the `sending response back to websocket connection` message to debug in case the response is 2XX