### PR TITLE
feat: support full depth manifest discovery for Gitlab

### DIFF
--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -46,6 +46,12 @@
       "origin": "https://${GITLAB}"
     },
     {
+      "//": "used to search all manifest files",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/tree",
+      "origin": "https://${GITLAB}"
+    },
+    {
       "//": "used to determine the full dependency tree",
       "method": "GET",
       "path": "/api/v4/projects/:project/repository/files*/package.json",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adds allow rule for full depth manifest discovery  API for Gitlab