### PR TITLE
fix: improve broker error messages

### DIFF
--- a/lib/relay.js
+++ b/lib/relay.js
@@ -33,10 +33,12 @@ function requestHandler(filterRules) {
     logger.debug(logContext, 'received request over HTTP connection');
     filters(req, (error, result) => {
       if (error) {
+        const reason = 'Request does not match any accept rule, blocking HTTP request';
+        error.reason = reason;
         logContext.error = error;
-        logger.info(logContext, 'no rule match, blocking HTTP request');
+        logger.warn(logContext, reason);
         // TODO: respect request headers, block according to content-type
-        return res.status(401).send(error.message);
+        return res.status(401).send({message: error.message, reason});
       }
 
       req.url = result.url;
@@ -97,11 +99,16 @@ function responseHandler(filterRules, config) {
 
     filters({ url, method, body, headers }, (error, result) => {
       if (error) {
+        const reason = 'Response does not match any accept rule, blocking websocket request';
         logContext.error = error;
-        logger.info(logContext, 'no rule match, blocking websocket request');
+        error.reason = reason;
+        logger.warn(logContext, reason);
         return emit({
           status: 401,
-          body: error.message,
+          body: {
+            message: error.message,
+            reason,
+          },
         });
       }
 

--- a/test/functional/client-server.test.js
+++ b/test/functional/client-server.test.js
@@ -78,7 +78,8 @@ test('proxy requests originating from behind the broker client', t => {
         const url = `http://localhost:${clientPort}/not-allowed`;
         request({ url, 'method': 'post', json: true }, (err, res, body) => {
           t.equal(res.statusCode, 401, '401 statusCode');
-          t.equal(body, 'blocked', '"blocked" body: ' + body);
+          t.equal(body.message, 'blocked', '"blocked" body: ' + body);
+          t.equal(body.reason, 'Request does not match any accept rule, blocking HTTP request', 'Block message');
           t.end();
         });
       });
@@ -100,7 +101,7 @@ test('proxy requests originating from behind the broker client', t => {
         const body = { proxy: { me: 'now!' }};
         request({ url, 'method': 'post', json: true, body }, (err, res, body) => {
           t.equal(res.statusCode, 401, '401 statusCode');
-          t.equal(body, 'blocked', '"blocked" body: ' + body);
+          t.equal(body.message, 'blocked', '"blocked" body: ' + body);
           t.end();
         });
       });

--- a/test/functional/server-client.test.js
+++ b/test/functional/server-client.test.js
@@ -113,7 +113,8 @@ test('proxy requests originating from behind the broker server', t => {
         const url = `http://localhost:${serverPort}/broker/${token}/not-allowed`;
         request({ url, 'method': 'post', json: true }, (err, res, body) => {
           t.equal(res.statusCode, 401, '401 statusCode');
-          t.equal(body, 'blocked', '"blocked" body: ' + body);
+          t.equal(body.message, 'blocked', '"blocked" body: ' + body);
+          t.equal(body.reason, 'Response does not match any accept rule, blocking websocket request', 'Block message');
           t.end();
         });
       });
@@ -135,7 +136,8 @@ test('proxy requests originating from behind the broker server', t => {
         const body = { proxy: { me: 'now!' }};
         request({ url, 'method': 'post', json: true, body }, (err, res, body) => {
           t.equal(res.statusCode, 401, '401 statusCode');
-          t.equal(body, 'blocked', '"blocked" body: ' + body);
+          t.equal(body.message, 'blocked', '"blocked" body: ' + body);
+          t.equal(body.reason, 'Response does not match any accept rule, blocking websocket request', 'Block message');
           t.end();
         });
       });
@@ -211,9 +213,10 @@ test('proxy requests originating from behind the broker server', t => {
         t => {
           const url = `http://localhost:${serverPort}/broker/${token}/` +
                        'long/nested%2Fpath%2Fto%2Ffile.ext';
-          request({ url, method: 'get' }, (err, res) => {
+          request({ url, method: 'get', json: true }, (err, res) => {
             t.equal(res.statusCode, 401, '401 statusCode');
-            t.equal(res.body, 'blocked', 'request is blocked');
+            t.equal(res.body.message, 'blocked', 'Block message');
+            t.equal(res.body.reason, 'Response does not match any accept rule, blocking websocket request', 'Block message');
             t.end();
           });
         });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
1. Improves an error message when request is blocked because of the policy
2. Changes the body of the error message from plain text to json format of {message, reason}, where `message` will be the error message sent before and `reason` will be a block reason (when there's no a matching accept rule in accept.json file)