### PR TITLE
feat: update GH and GHE contributors API

### DIFF
--- a/client-templates/github-com/accept.json.sample
+++ b/client-templates/github-com/accept.json.sample
@@ -892,7 +892,7 @@
     {
       "//": "used to get repo's contributors list",
       "method": "GET",
-      "path": "/repos/:owner/:repo/contributors",
+      "path": "/repos/:owner/:repo/commits",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {

--- a/client-templates/github-enterprise/accept.json.sample
+++ b/client-templates/github-enterprise/accept.json.sample
@@ -641,7 +641,7 @@
     {
       "//": "used to get repo's contributors list",
       "method": "GET",
-      "path": "/repos/:owner/:repo/contributors",
+      "path": "/repos/:owner/:repo/commits",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Updates the contributors API for GH and GHE to use /commits instead of /contributors endpoint. This allows counting devs in a specific time range.
