### PR TITLE
feat: gitlab new contributors API

### DIFF
--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -427,7 +427,7 @@
     {
       "//": "used to get repo's contributors list",
       "method": "GET",
-      "path": "/api/v4/projects/:project/repository/contributors",
+      "path": "/api/v4/projects/:project/repository/commits",
       "origin": "https://${GITLAB}"
     }
   ]


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Updates Gitlab's contributors endpoint to /commits (instead of /contributors). This aligns Gitlab with the other SCMs and allows counting the last 90 days contributors.
