### PR TITLE
feat: add GitLab commit endpoint to whitelist

### DIFF
--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -429,6 +429,12 @@
       "method": "GET",
       "path": "/api/v4/projects/:project/repository/commits",
       "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "get a specific commit identified by the commit hash or name of a branch or tag.",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/commits/:sha",
+      "origin": "https://${GITLAB}"
     }
   ]
 }


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Add commit [endpoint](https://docs.gitlab.com/ee/api/commits.html#get-a-single-commit) to GitLab's whitelist. 
This needs for caching functionality, to avoid unnecessary requests to SCM and increasing dependencies test speed.
