### PR TITLE
feat: added mapping for getting single commit endpoint

### DIFF
--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -615,6 +615,17 @@
       }
     },
     {
+      "//": "get a specific commit identified by the commit hash or name of a branch",
+      "method": "GET",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/commits/:sha",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
       "//": "used to create a Code Insights report",
       "method": "PUT",
       "path": "/rest/insights/1.0/projects/:project/repos/:repo/commits/:sha/reports/:report",


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adding new proxy for fetching single commit via [Bitbucket Server API](https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html#idm8283038112). The purpose is faster dependency discover process and caching in broker usage cases.
