### PR TITLE
feat: Support for binary data streaming

### DIFF
--- a/README.npm.md
+++ b/README.npm.md
@@ -117,6 +117,22 @@ The `private` rules should be determined by what you want to allow through the s
 
 This `public` rule will ensure everything is forwarded to your clients, and will allow your client to handle blocking out messages.
 
+Sometimes large amounts of data need to be transferred in a response to a request. In these instances it might makes sense to stream
+the data for these requests:
+
+```json
+  "public": [{
+    "//": "accept any requests to our connected clients",
+    "method": "any",
+    "path": "/blobs/*",
+    "stream": true
+  }, {
+    "//": "accept any requests to our connected clients",
+    "method": "any",
+    "path": "/*"
+  }],
+```
+
 ## Development & how to test
 
 The project's source code is written in full ES6 (with commonjs modules). This requires the source to be developed with node@6. However, during the release process, the code is transpiled to ES5 via babel and is released with node LTS in mind, node@4 and upwards.
@@ -284,4 +300,3 @@ Public filters are for requests that a recieved on your broker client and are in
 * [License: Apache License, Version 2.0](LICENSE)
 * [Contributing](.github/CONTRIBUTING.md)
 * [Security](SECURITY.md)
-

--- a/lib/client/socket.js
+++ b/lib/client/socket.js
@@ -30,10 +30,12 @@ module.exports = ({ url, token, filters, config, identifyingMetadata }) => {
 
   logger.info({ url }, 'broker client is connecting to broker server');
 
-  const response = relay.response(filters, config);
+  const response = relay.response(filters, config, io);
+  const streamingResponse = relay.streamingResponse;
 
   // RS note: this bind doesn't feel right, it feels like a sloppy way of
   // getting the filters into the request function.
+  io.on('chunk', streamingResponse(token));
   io.on('request', response());
   io.on('error', ({ type, description }) => {
     if (type === 'TransportError') {
@@ -53,7 +55,7 @@ module.exports = ({ url, token, filters, config, identifyingMetadata }) => {
   io.on('close', () => {
     logger.warn({ url, token }, 'websocket connection to the broker server was closed');
   });
-  
+
   // only required if we're manually opening the connection
   // io.open();
 

--- a/lib/filters/index.js
+++ b/lib/filters/index.js
@@ -32,7 +32,7 @@ module.exports = ruleSource => {
   // array of entries with
   const tests = rules.map(entry => {
     const keys = [];
-    let { method, origin, path, valid } = entry;
+    let { method, origin, path, valid, stream } = entry;
     method = (method || 'get').toLowerCase();
     valid = valid || [];
 
@@ -135,6 +135,7 @@ module.exports = ruleSource => {
       return {
         url: origin + url + querystring,
         auth: entry.auth && authHeader(entry.auth),
+        stream
       };
     };
   });

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -9,6 +9,7 @@ const tryJSONParse = require('./try-json-parse');
 const logger = require('./log');
 const version = require('./version');
 const stream = require('stream');
+const NodeCache = require('node-cache');
 
 module.exports = {
   request: requestHandler,
@@ -16,29 +17,36 @@ module.exports = {
   streamingResponse: streamResponseHandler,
 };
 
-const binaryRequest = [
-  'application/vnd.docker.image.rootfs.diff.tar.gzip',
-];
+const streams = new NodeCache({
+  stdTTL: 18000,  // 5 hours
+  checkperiod: 3600, // 1 hour
+  useClones: false
+});
 
-const streams = new Map();
-
-// Stream processing is only available on
-// the server side i.e. the client sends
-// binary chunks to the server.
 function streamResponseHandler(token) {
-  return (streamingID, chunk, finished) => {
-    var streamBuffer = streams.get(streamingID);
+  return (streamingID, chunk, finished, ioResponse) => {
+    const stream = streams.get(streamingID);
 
-    if (streamBuffer) {
-      if (chunk) {
-        streamBuffer.write(chunk);
-      }
-      if (finished) {
-        streamBuffer.end();
-        streams.delete(streamingID);
+    if (stream) {
+      const { streamBuffer, response } = stream;
+
+      if (streamBuffer) {
+        if (ioResponse) {
+          response.status(ioResponse.status)
+            .set(ioResponse.headers);
+        }
+        if (chunk) {
+          streamBuffer.write(chunk);
+        }
+        if (finished) {
+          streamBuffer.end();
+          streams.del(streamingID);
+        }
+      } else {
+        logger.warn({ streamingID, token }, 'discarding binary chunk');
       }
     } else {
-      logger.warn({ streamingID, token }, 'discarding binary chunk');
+      logger.warn({ streamingID, token }, 'trying to write into a closed stream');
     }
   };
 }
@@ -74,14 +82,16 @@ function requestHandler(filterRules) {
       logContext.ioUrl = result.url;
 
       // check if this is a streaming request for binary data
-      if (req.headers && binaryRequest.indexOf(req.headers['accept']) !== -1) {
+      if (result.stream) {
         const streamingID = uuid();
         const streamBuffer = new stream.PassThrough();
-
         logContext.streamingID = streamingID;
-        logger.debug(logContext, 'sending binary request over websocket connection');
+        logger.debug(logContext, 'sending stream request over websocket connection');
 
-        streams.set(streamingID, streamBuffer);
+        streams.set(streamingID, {
+          response : res,
+          streamBuffer
+        });
         streamBuffer.pipe(res);
 
         res.locals.io.send('request', {
@@ -90,6 +100,12 @@ function requestHandler(filterRules) {
           body: req.body,
           headers: req.headers,
           streamingID,
+        }, () => {
+          // Streaming requests should not be handled using the emit function
+          // but rather by sending 'chunk' messages
+          const msg = 'Broker client does not support streaming requests';
+          logger.error(logContext, msg);
+          return res.status(501).send({message: msg});
         });
 
         return;
@@ -263,22 +279,33 @@ function responseHandler(filterRules, config, io) {
 
       // check if this is a streaming request for binary data
       if (streamingID) {
-        logger.debug(logContext, 'serving binary stream request');
+        logger.debug(logContext, 'serving stream request');
 
         req.encoding = null; // no encoding for binary data
 
-        request(req).on('data', chunk => {
+        request(req).on('response', response => {
+          const status = (response && response.statusCode) || 500;
+          logResponse(logContext, status, response.headers);
+          io.send('chunk', streamingID, '', false, {
+            status,
+            headers : response.headers
+          });
+        }).on('data', chunk => {
           io.send('chunk', streamingID, chunk, false);
         }).on('end', () => {
           io.send('chunk', streamingID, '', true);
+        }).on('error', error => {
+          logError(logContext, error);
+          io.send('chunk', streamingID, error.message, true, {
+            status : 500
+          });
         });
         return;
       }
 
       request(req, (error, response, body) => {
         if (error) {
-          logContext.error = error;
-          logger.error(logContext, 'error while sending websocket request over HTTP connection');
+          logError(logContext, error);
           return emit({
             status: 500,
             body: error.message
@@ -286,18 +313,26 @@ function responseHandler(filterRules, config, io) {
         }
 
         const status = (response && response.statusCode) || 500;
-        logContext.httpStatus = status;
-        logContext.httpHeaders = response.headers;
-
-        const logMsg = 'sending response back to websocket connection';
-        if (status <= 200) {
-          logger.debug(logContext, logMsg);
-        } else {
-          logger.info(logContext, logMsg);
-        }
-
+        logResponse(logContext, status, response.headers);
         emit({ status, body, headers: response.headers });
       });
     });
   };
+}
+
+function logResponse(logContext, status, headers) {
+  logContext.httpStatus = status;
+  logContext.httpHeaders = headers;
+
+  const logMsg = 'sending response back to websocket connection';
+  if (status <= 200) {
+    logger.debug(logContext, logMsg);
+  } else {
+    logger.info(logContext, logMsg);
+  }
+}
+
+function logError(logContext, error) {
+  logContext.error = error;
+  logger.error(logContext, 'error while sending websocket request over HTTP connection');
 }

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -8,11 +8,40 @@ const replace = require('./replace-vars');
 const tryJSONParse = require('./try-json-parse');
 const logger = require('./log');
 const version = require('./version');
+const stream = require('stream');
 
 module.exports = {
   request: requestHandler,
   response: responseHandler,
+  streamingResponse: streamResponseHandler,
 };
+
+const binaryRequest = [
+  'application/vnd.docker.image.rootfs.diff.tar.gzip',
+];
+
+const streams = new Map();
+
+// Stream processing is only available on
+// the server side i.e. the client sends
+// binary chunks to the server.
+function streamResponseHandler(token) {
+  return (streamingID, chunk, finished) => {
+    var streamBuffer = streams.get(streamingID);
+
+    if (streamBuffer) {
+      if (chunk) {
+        streamBuffer.write(chunk);
+      }
+      if (finished) {
+        streamBuffer.end();
+        streams.delete(streamingID);
+      }
+    } else {
+      logger.warn({ streamingID, token }, 'discarding binary chunk');
+    }
+  };
+}
 
 // 1. Request coming in over HTTP conn (logged)
 // 2. Filter for rule match (log and block if no match)
@@ -43,6 +72,29 @@ function requestHandler(filterRules) {
 
       req.url = result.url;
       logContext.ioUrl = result.url;
+
+      // check if this is a streaming request for binary data
+      if (req.headers && binaryRequest.indexOf(req.headers['accept']) !== -1) {
+        const streamingID = uuid();
+        const streamBuffer = new stream.PassThrough();
+
+        logContext.streamingID = streamingID;
+        logger.debug(logContext, 'sending binary request over websocket connection');
+
+        streams.set(streamingID, streamBuffer);
+        streamBuffer.pipe(res);
+
+        res.locals.io.send('request', {
+          url: req.url,
+          method: req.method,
+          body: req.body,
+          headers: req.headers,
+          streamingID,
+        });
+
+        return;
+      }
+
       logger.debug(logContext, 'sending request over websocket connection');
 
       // relay the http request over the websocket, handle websocket response
@@ -51,6 +103,7 @@ function requestHandler(filterRules) {
         method: req.method,
         body: req.body,
         headers: req.headers,
+        streamingID : '',
       }, ioResponse => {
         logContext.ioStatus = ioResponse.status;
         logContext.ioHeaders = ioResponse.headers;
@@ -84,15 +137,16 @@ function requestHandler(filterRules) {
 // 3. Relay over HTTP conn (logged)
 // 4. Get response over HTTP conn (logged)
 // 5. Send response over websocket conn
-function responseHandler(filterRules, config) {
+function responseHandler(filterRules, config, io) {
   const filters = Filters(filterRules);
 
-  return (brokerToken) => ({ url, headers = {}, method, body = null } = {}, emit) => {
+  return (brokerToken) => ({ url, headers = {}, method, body = null, streamingID = '' } = {}, emit) => {
     const logContext = {
       url,
       method,
       headers,
       requestId: headers['snyk-request-id'] || uuid(),
+      streamingID,
     };
 
     logger.debug(logContext, 'received request over webscoket connection');
@@ -197,7 +251,7 @@ function responseHandler(filterRules, config) {
 
       logger.debug(logContext, 'sending websocket request over HTTP connection');
 
-      request({
+      var req = {
         url: result.url,
         headers: headers,
         method,
@@ -205,7 +259,23 @@ function responseHandler(filterRules, config) {
         agentOptions: {
           ca: config.caCert, // Optional CA cert
         },
-      }, (error, response, body) => {
+      };
+
+      // check if this is a streaming request for binary data
+      if (streamingID) {
+        logger.debug(logContext, 'serving binary stream request');
+
+        req.encoding = null; // no encoding for binary data
+
+        request(req).on('data', chunk => {
+          io.send('chunk', streamingID, chunk, false);
+        }).on('end', () => {
+          io.send('chunk', streamingID, '', true);
+        });
+        return;
+      }
+
+      request(req, (error, response, body) => {
         if (error) {
           logContext.error = error;
           logger.error(logContext, 'error while sending websocket request over HTTP connection');

--- a/lib/server/socket.js
+++ b/lib/server/socket.js
@@ -8,7 +8,8 @@ module.exports = ({ server, filters, config }) => {
   io.plugin('emitter', Emitter);
 
   const connections = new Map();
-  const response = relay.response(filters, config);
+  const response = relay.response(filters, config, io);
+  const streamingResponse = relay.streamingResponse;
 
   io.on('error', error => logger.error({ error }, 'Primus/engine.io server error'));
 
@@ -57,9 +58,10 @@ module.exports = ({ server, filters, config }) => {
       clientPool.unshift({ socket, metadata: clientData.metadata });
       connections.set(token, clientPool);
 
+      socket.on('chunk', streamingResponse(token));
       socket.on('request', response(token));
     });
-    
+
     ['close', 'end', 'disconnect'].forEach(e => socket.on(e, () => close(e)));
     socket.on('error', (error) => {
       logger.warn({ error }, 'error on websocket connection');

--- a/package-lock.json
+++ b/package-lock.json
@@ -463,6 +463,11 @@
         "wrap-ansi": "^2.0.0"
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2246,6 +2251,22 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-cache": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.1.tgz",
+      "integrity": "sha512-BOb67bWg2dTyax5kdef5WfU3X8xu4wPg+zHzkvls0Q/QpYycIFRLEEIdAx9Wma43DxG6Qzn4illdZoYseKWa4A==",
+      "requires": {
+        "clone": "2.x",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
+      }
     },
     "node-status-codes": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "lodash.escaperegexp": "^4.1.2",
     "lodash.mapvalues": "^4.6.0",
     "minimatch": "^3.0.4",
+    "node-cache": "^4.2.1",
     "path-to-regexp": "^1.5.3",
     "primus": "^6.0.1",
     "primus-emitter": "^3.1.1",

--- a/test/fixtures/client/filters.json
+++ b/test/fixtures/client/filters.json
@@ -72,6 +72,11 @@
       ]
     },
 
+    {
+      "path": "/test-blob/*",
+      "method": "GET",
+      "origin": "http://localhost:${originPort}"
+    },
 
     {
       "path": "/repos/:repo/:owner/contents/folder*/package.json",

--- a/test/fixtures/server/filters.json
+++ b/test/fixtures/server/filters.json
@@ -28,10 +28,21 @@
       "path": "/echo-query/:param?",
       "method": "GET",
       "origin": "http://localhost:${originPort}"
+    },
+
+    {
+      "path": "/test-blob/*",
+      "method": "GET",
+      "origin": "http://localhost:${originPort}",
     }
 
   ],
   "public": [
+    {
+      "path": "/test-blob/*",
+      "method": "GET",
+      "stream": true
+    },
     {
       "path": "/*",
       "method": "GET"

--- a/test/utils.js
+++ b/test/utils.js
@@ -15,6 +15,27 @@ const { app: echoServer, server } = webserver({
   httpsCert: process.env.TEST_CERT, // Optional
 });
 
+echoServer.get(
+  '/test-blob/1',
+  (req, res) => {
+    res.setHeader('test-orig-url', req.originalUrl);
+    res.status(299);
+
+    const buf = new Buffer(500);
+    for (var i=0; i<500; i++) {
+      buf.writeUInt8(i & 0xFF, i);
+    }
+    res.send(buf);
+  });
+
+echoServer.get(
+  '/test-blob/2',
+  (req, res) => {
+    res.setHeader('test-orig-url', req.originalUrl);
+    res.status(500);
+    res.send('Test Error');
+  });
+
 echoServer.get('/basic-auth', (req, res) => {
   res.send(req.headers.authorization);
 });
@@ -44,7 +65,7 @@ echoServer.get(
   (req, res) => {
     res.send(req.originalUrl);
   });
-  
+
 echoServer.get('/repos/owner/repo/contents/folder/package.json',
   (req, res) => {
     res.json({headers: req.headers, query: req.query, url: req.url});


### PR DESCRIPTION
Adds support for streaming of binary data. Using the `data` and `end` events the request response on the client side is switched to streaming and each received `chunk` is send over the websocket. The server forwards each received `chunk` directly to the consuming service.