### PR TITLE
feat: Use Broker ID during initial client registration

### DIFF
--- a/lib/client/socket.js
+++ b/lib/client/socket.js
@@ -2,13 +2,6 @@ require('../patch-https-request-for-proxying');
 
 const Primus = require('primus');
 const relay = require('../relay');
-const Socket = Primus.createSocket({
-  transformer: 'engine.io',
-  parser: 'EJSON',
-  plugin: {
-    'emitter': require('primus-emitter'),
-  }
-});
 const logger = require('../log');
 
 module.exports = ({ url, token, filters, config, identifyingMetadata }) => {
@@ -26,6 +19,14 @@ module.exports = ({ url, token, filters, config, identifyingMetadata }) => {
     throw error;
   }
 
+  const Socket = Primus.createSocket({
+    transformer: 'engine.io',
+    parser: 'EJSON',
+    plugin: {
+      'emitter': require('primus-emitter'),
+    },
+    pathname : `/primus/${token}`,
+  });
   const io = new Socket(url);
 
   logger.info({ url }, 'broker client is connecting to broker server');


### PR DESCRIPTION
This PR adds the Broker ID to the initial connection URL when a client connects to the server. This change is required for load-balancing requests to the server.