### PR TITLE
feat: connection status return filters

### DIFF
--- a/lib/relay.js
+++ b/lib/relay.js
@@ -169,7 +169,7 @@ function responseHandler(filterRules, config, io) {
 
     filters({ url, method, body, headers }, (error, result) => {
       if (error) {
-        const reason = 'Response does not match any accept rule, blocking websocket request';
+        const reason = 'Request does not match any accept rule, blocking websocket request';
         logContext.error = error;
         error.reason = reason;
         logger.warn(logContext, reason);

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -23,6 +23,7 @@ module.exports = ({ config = {}, port = null, filters = {} }) => {
     if (connections.has(token)) {
       const clientsMetadata = connections.get(token).map(conn => ({
         version: conn.metadata && conn.metadata.version,
+        filters: conn.metadata && conn.metadata.filters
       }));
       return res.status(200).json({ ok: true, clients: clientsMetadata });
     }

--- a/test/functional/healthcheck.test.js
+++ b/test/functional/healthcheck.test.js
@@ -17,7 +17,7 @@ test('proxy requests originating from behind the broker client', t => {
    */
 
   process.env.ACCEPT = 'filters.json';
-  
+
   process.chdir(path.resolve(root, '../fixtures/server'));
   process.env.BROKER_TYPE = 'server';
   const serverPort = port();
@@ -72,9 +72,13 @@ test('proxy requests originating from behind the broker client', t => {
         request({url: connectionStatus, json: true }, (err, res) => {
           if (err) { return t.threw(err); }
 
+          const expectedFilters = require('../fixtures/client/filters.json');
+
           t.equal(res.statusCode, 200, '200 statusCode');
           t.equal(res.body.ok, true, '{ ok: true } in body');
           t.ok(res.body.clients[0].version, 'client version in body');
+
+          t.deepEqual(res.body.clients[0].filters, expectedFilters, 'correct client filters in body');
           t.end();
         });
       });
@@ -98,7 +102,7 @@ test('proxy requests originating from behind the broker client', t => {
 
         request({url: clientHealth, json: true }, (err, res) => {
           if (err) { return t.threw(err); }
-    
+
           t.equal(res.statusCode, 500, '500 statusCode');
           t.equal(res.body.ok, false, '{ ok: false } in body');
           t.equal(res.body.websocketConnectionOpen, false, '{ websocketConnectionOpen: false } in body');

--- a/test/functional/server-client.test.js
+++ b/test/functional/server-client.test.js
@@ -114,7 +114,7 @@ test('proxy requests originating from behind the broker server', t => {
         request({ url, 'method': 'post', json: true }, (err, res, body) => {
           t.equal(res.statusCode, 401, '401 statusCode');
           t.equal(body.message, 'blocked', '"blocked" body: ' + body);
-          t.equal(body.reason, 'Response does not match any accept rule, blocking websocket request', 'Block message');
+          t.equal(body.reason, 'Request does not match any accept rule, blocking websocket request', 'Block message');
           t.end();
         });
       });
@@ -137,7 +137,7 @@ test('proxy requests originating from behind the broker server', t => {
         request({ url, 'method': 'post', json: true, body }, (err, res, body) => {
           t.equal(res.statusCode, 401, '401 statusCode');
           t.equal(body.message, 'blocked', '"blocked" body: ' + body);
-          t.equal(body.reason, 'Response does not match any accept rule, blocking websocket request', 'Block message');
+          t.equal(body.reason, 'Request does not match any accept rule, blocking websocket request', 'Block message');
           t.end();
         });
       });
@@ -216,7 +216,7 @@ test('proxy requests originating from behind the broker server', t => {
           request({ url, method: 'get', json: true }, (err, res) => {
             t.equal(res.statusCode, 401, '401 statusCode');
             t.equal(res.body.message, 'blocked', 'Block message');
-            t.equal(res.body.reason, 'Response does not match any accept rule, blocking websocket request', 'Block message');
+            t.equal(res.body.reason, 'Request does not match any accept rule, blocking websocket request', 'Block message');
             t.end();
           });
         });


### PR DESCRIPTION
- [ ] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

The connection-status endpoint will now return a list of filters. 

This will help debugging Broker issues caused by the filters (usually outdated filters).