### PR TITLE
chore: codeowners -> comet

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @snyk/comet


### PR DESCRIPTION
We thought this was used heavily for integrations, so would be Comet, but the R&D Teams page explicitly lists Comet as the owner of Broker, anyway. Woo!