### PR TITLE
feat: add url to blocked error

### DIFF
--- a/lib/relay.js
+++ b/lib/relay.js
@@ -75,7 +75,9 @@ function requestHandler(filterRules) {
         logContext.error = error;
         logger.warn(logContext, reason);
         // TODO: respect request headers, block according to content-type
-        return res.status(401).send({message: error.message, reason});
+        return res
+          .status(401)
+          .send({ message: error.message, reason, url: req.url });
       }
 
       req.url = result.url;
@@ -178,6 +180,7 @@ function responseHandler(filterRules, config, io) {
           body: {
             message: error.message,
             reason,
+            url,
           },
         });
       }

--- a/test/functional/client-server.test.js
+++ b/test/functional/client-server.test.js
@@ -80,6 +80,7 @@ test('proxy requests originating from behind the broker client', t => {
           t.equal(res.statusCode, 401, '401 statusCode');
           t.equal(body.message, 'blocked', '"blocked" body: ' + body);
           t.equal(body.reason, 'Request does not match any accept rule, blocking HTTP request', 'Block message');
+          t.equal(body.url, '/not-allowed', 'Blocked url');
           t.end();
         });
       });

--- a/test/functional/server-client.test.js
+++ b/test/functional/server-client.test.js
@@ -115,6 +115,7 @@ test('proxy requests originating from behind the broker server', t => {
           t.equal(res.statusCode, 401, '401 statusCode');
           t.equal(body.message, 'blocked', '"blocked" body: ' + body);
           t.equal(body.reason, 'Response does not match any accept rule, blocking websocket request', 'Block message');
+          t.equal(body.url, '/not-allowed', 'Blocked url');
           t.end();
         });
       });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adds the target url (this is actually a path, doesn't contain the origin) to the Broker errors so that we can understand why was a request blocked.