### PR TITLE
Use CA_CERT for /systemcheck endpoint

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -75,6 +75,9 @@ module.exports = ({ port = null, config = {}, filters = {} }) => {
       method: brokerClientValidationMethod,
       timeout: brokerClientValidationTimeoutMs,
       json: true,
+      agentOptions: {
+        ca: config.caCert, // Optional CA cert
+      },
     }, (error, response) => {
       // test logic requires to surface internal data
       // which is best not exposed in production

--- a/test/utils.js
+++ b/test/utils.js
@@ -15,6 +15,11 @@ const { app: echoServer, server } = webserver({
   httpsCert: process.env.TEST_CERT, // Optional
 });
 
+echoServer.get('/test', (req, res) => {
+  res.status(200);
+  res.send('All good');
+});
+
 echoServer.get(
   '/test-blob/1',
   (req, res) => {


### PR DESCRIPTION
`CA_CERT` envvar was ignored for `/systemcheck` endpoint, which resulted in false negatives when checking whether self-signed certificates are setup correctly