### PR TITLE
chore: sem-rel needs node 10 now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache: npm
 notifications:
   email: false
 node_js:
-  - 8
+  - 10
 script:
   - ./lintVerifier.sh
   - npm test


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

* Updates CI to use node10 to catch up with a change in `semantic-release` that wasn't backwards-compatible with node8