### PR TITLE
feat: add missed url masks for supporting merge SHA functionality

### DIFF
--- a/client-templates/github-com/accept.json.sample
+++ b/client-templates/github-com/accept.json.sample
@@ -1020,6 +1020,12 @@
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
+      "//": "get pull request data for getting merge sha and tracking PR processing state",
+      "method": "GET",
+      "path": "/repos/:name/:repo/pulls/:pull_number",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
       "//": "add the individual commit for the pull requests",
       "method": "POST",
       "path": "/repos/:name/:repo/git/commits",

--- a/client-templates/github-enterprise/accept.json.sample
+++ b/client-templates/github-enterprise/accept.json.sample
@@ -696,6 +696,12 @@
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
+      "//": "get pull request data for getting merge sha and tracking PR processing state",
+      "method": "GET",
+      "path": "/repos/:name/:repo/pulls/:pull_number",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
       "//": "add the individual commit for the pull requests",
       "method": "POST",
       "path": "/repos/:name/:repo/git/commits",


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Added missed url masks for [getting PR data](https://developer.github.com/v3/pulls/#get-a-single-pull-request) from GitHub and GitHub Enterprise API.
This data needs fo covering all changes in vuln testing, that were introduced in PR (open/reopen PR to default branch). 