### PR TITLE
fix: Resolve 401 error with Artificatory CR Integration

### DIFF
--- a/client-templates/artifactory-cr/accept.json.sample
+++ b/client-templates/artifactory-cr/accept.json.sample
@@ -24,7 +24,12 @@
       "//": "Query the V2 API",
       "method": "GET",
       "path": "/v2/*",
-      "origin": "https://${ARTIFACTORYCR_HOSTNAME}"
+      "origin": "https://${ARTIFACTORYCR_HOSTNAME}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${ARTIFACTORYCR_USERNAME}",
+        "password": "${ARTIFACTORYCR_PASSWORD}"
+      }
     }
   ]
 }


### PR DESCRIPTION
Please credit THG if change is accepted.

- [ Y ] Ready for review
- [ Y ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Fix for Artifactory CR integration. Snyk is not calling the v2/token endpoint and using the Token for auth. As a result, you need to add the auth basic scheme to every v2/* call otherwise you will get 401 unauthorised.

Tested that adding this resolves the issue with authentication.

#### Where should the reviewer start?

Review if v2/token is called by snyk server and whether or not it is used in subsequent calls to confirm hypothesis.

#### How should this be manually tested?

Need a local testing artifactory CR instance

#### Any background context you want to provide?

Have tried this in production and proven that 401 Unauthorised errors is due to lack of auth on the calls. Alternatively can also use a JFROG API key instead.

#### Screenshots


#### Additional questions

First PR we submitted was accepted but merged in without credit. Please ensure this doesn't happen again for this change.
