### PR TITLE
fix: discard any information in url after a fragment identifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /node_modules/
 .env
 .nyc_output
+.vscode
 coverage
 /test/fixtures/certs/tmp
 accept.json

--- a/lib/filters/index.js
+++ b/lib/filters/index.js
@@ -64,8 +64,12 @@ module.exports = ruleSource => {
       if (req.method.toLowerCase() !== method && method !== 'any') {
         return false;
       }
+
+      // Discard any fragments before further processing
+      const mainURI = req.url.split('#')[0];
+
       // query params might contain additional "?"s, only split on the 1st one
-      const parts = req.url.split('?');
+      const parts = mainURI.split('?');
       let [url, querystring] = [parts[0], parts.slice(1).join('?')];
       const res = regexp.exec(url);
       if (!res) {
@@ -140,11 +144,12 @@ module.exports = ruleSource => {
     };
   });
 
-  return (url, callback) => {
+  return (payload, callback) => {
     let res = false;
     logger.debug({ rulesCount: tests.length }, 'looking for a rule match');
+
     for (const test of tests) {
-      res = test(url);
+      res = test(payload);
       if (res) {
         break;
       }

--- a/test/fixtures/accept/github.json
+++ b/test/fixtures/accept/github.json
@@ -1,0 +1,13 @@
+{
+  "//": "Cut down example accept.json for GitHub to test filter logic",
+  "public": [],
+  "private":
+  [
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/package.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    } 
+  ]
+}

--- a/test/fixtures/relay.json
+++ b/test/fixtures/relay.json
@@ -28,10 +28,7 @@
     "valid": [
       {
         "queryParam": "filePath",
-        "values": [
-          "**/package.json",
-          "**/yarn.lock"
-        ]
+        "values": ["**/package.json", "**/yarn.lock"]
       }
     ]
   },
@@ -41,10 +38,7 @@
     "valid": [
       {
         "queryParam": "filePath",
-        "values": [
-          "**/package.json",
-          "**/yarn.lock"
-        ]
+        "values": ["**/package.json", "**/yarn.lock"]
       },
       {
         "path": "commits.*.added.*",

--- a/test/unit/filters.test.js
+++ b/test/unit/filters.test.js
@@ -5,6 +5,46 @@ const Filters = require('../../lib/filters');
 
 const jsonBuffer = (body) => Buffer.from(JSON.stringify(body));
 
+test('Filter on URL', t => {
+  t.test('for GitHub private filters', (t) => {
+    t.plan(3);
+    
+    const ruleSource = require(__dirname + '/../fixtures/accept/github.json');
+    const filter = Filters(ruleSource.private);
+    t.pass('Filters loaded');
+
+    t.test('should allow valid /repos path to manifest', (t) => {
+      const url = '/repos/angular/angular/contents/package.json';
+      
+      filter({
+        url,
+        method: 'GET',
+      }, (error, res) => {
+        t.equal(error, null, 'no error');
+        t.isLike(res.url, url, 'contains expected path');
+      });
+  
+      t.end();
+    });
+
+    t.test('should block when manifest appears after fragment identifier', (t) => {
+      filter({
+        url: '/repos/angular/angular/contents/test-main.js#/package.json',
+        method: 'GET',
+      }, (error, res) => {
+        t.equal(error.message, 'blocked', 'has been blocked');
+        t.equal(res, undefined, 'no follow allowed');
+      });
+  
+      t.end();
+    });
+
+    t.end();
+  });
+
+  t.end();
+});
+
 test('filter on body', t => {
   const filter = Filters(require(__dirname + '/../fixtures/relay.json'));
 
@@ -214,10 +254,10 @@ test('filter on body', t => {
 
 });
 
-test('filter on querystring', t => {
+test('Filter on querystring', t => {
   const filter = Filters(require(__dirname + '/../fixtures/relay.json'));
 
-  t.plan(9);
+  t.plan(10);
   t.pass('filters loaded');
 
   filter({
@@ -253,12 +293,43 @@ test('filter on querystring', t => {
     t.equal(error.message, 'blocked', 'has been blocked');
     t.equal(res, undefined, 'no follow allowed');
   });
+
+  t.test('fragment identifiers validation', (t) => {
+    t.plan(2);
+
+    t.test('should not allow access to sensitive files by putting the manifest after a fragment', (t) => {
+      filter({
+        url: '/filtered-on-query?filePath=/path/to/sensitive/file#package.json',
+        method: 'GET',
+      }, (error, res) => {
+        t.equal(error.message, 'blocked', 'errors as expected');
+        t.equal(res, undefined, 'follow not allowed');
+      });
+
+      t.end();
+    });
+
+    t.test('should ignore any non-manifest files after the fragment identifier', (t) => {
+      filter({
+        url: '/filtered-on-query?filePath=/path/to/package.json#/some-other-file',
+        method: 'GET',
+      }, (error, res) => {
+        t.equal(error, null, 'no error');
+        t.equal(res.url, '/filtered-on-query?filePath=/path/to/package.json',
+          'contains the expected manifest in the query string');
+      });
+
+      t.end();
+    });
+      
+    t.end();
+  });
 });
 
-test('filter on query and body', t => {
+test('Filter on query and body', t => {
   const filter = Filters(require(__dirname + '/../fixtures/relay.json'));
 
-  t.plan(9);
+  t.plan(10);
   t.pass('filters loaded');
 
   filter({
@@ -312,6 +383,43 @@ test('filter on query and body', t => {
   }, (error, res) => {
     t.equal(error.message, 'blocked', 'has been blocked');
     t.equal(res, undefined, 'no follow allowed');
+  });
+
+  t.test('fragment identifiers validation', (t) => {
+    t.plan(2);
+
+    t.test('should not allow access to sensitive files by putting the manifest after a fragment', (t) => {
+      filter({
+        url: '/filtered-on-query-and-body?filePath=/path/to/sensitive/file.js#package.json',
+        method: 'POST',
+        body: jsonBuffer({
+          commits: []
+        })
+      }, (error, res) => {
+        t.equal(error.message, 'blocked', 'errors as expected');
+        t.equal(res, undefined, 'follow not allowed');
+      });
+
+      t.end();
+    });
+
+    t.test('should ignore any non-manifest files after the fragment identifier', (t) => {    
+      filter({
+        url: '/filtered-on-query-and-body?filePath=/path/to/package.json#/sensitive/file.js',
+        method: 'POST',
+        body: jsonBuffer({
+          commits: []
+        })
+      }, (error, res) => {
+        t.equal(error, null, 'no error');
+        t.equal(res.url, '/filtered-on-query-and-body?filePath=/path/to/package.json',
+          'contains the expected manifest in the query string');
+      });
+
+      t.end();
+    });
+
+    t.end();
   });
 });
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Currently information after a fragment identifier in the url provided to the broker client is not sanitised and could theoretically be exploited (only by a malicious Snyk Broker Server) with a path that matches a filter because it has a manifest file after the fragment.

This sanitises the URL by removing any information found after a fragment identifier (`#`) in the provided path.

#### Where should the reviewer start?
See the new tests in `test/unit/filters.test.js`

#### How should this be manually tested?
A request to broker client providing the following path should fail:
`/repos/owner/repo/contents/sensitive-file.js#/package.json`
