### PR TITLE
feat: reject paths with path traversal

### DIFF
--- a/lib/filters/index.js
+++ b/lib/filters/index.js
@@ -1,6 +1,7 @@
 const minimatch = require('minimatch');
 const pathRegexp = require('path-to-regexp');
 const qs = require('qs');
+const path = require('path');
 const undefsafe = require('undefsafe');
 const replace = require('../replace-vars');
 const authHeader = require('../auth-header');
@@ -32,7 +33,7 @@ module.exports = ruleSource => {
   // array of entries with
   const tests = rules.map(entry => {
     const keys = [];
-    let { method, origin, path, valid, stream } = entry;
+    let { method, origin, path: entryPath, valid, stream } = entry;
     method = (method || 'get').toLowerCase();
     valid = valid || [];
 
@@ -44,7 +45,7 @@ module.exports = ruleSource => {
     const fromConfig = {};
 
     // slightly bespoke version of replace-vars.js
-    path = (path || '').replace(/(\${.*?})/g, (_, match) => {
+    entryPath = (entryPath || '').replace(/(\${.*?})/g, (_, match) => {
       const key = match.slice(2, -1); // ditch the wrappers
       fromConfig[key] = config[key] || '';
       return ':' + key;
@@ -52,16 +53,21 @@ module.exports = ruleSource => {
 
     origin = replace(origin, config);
 
-    if (path[0] !== '/') {
-      path = '/' + path;
+    if (entryPath[0] !== '/') {
+      entryPath = '/' + entryPath;
     }
 
-    logger.info({ method, path }, 'adding new filter rule');
-    const regexp = pathRegexp(path, keys);
+    logger.info({ method, path: entryPath }, 'adding new filter rule');
+    const regexp = pathRegexp(entryPath, keys);
 
     return (req) => {
       // check the request method
       if (req.method.toLowerCase() !== method && method !== 'any') {
+        return false;
+      }
+
+      // Do not allow directory traversal
+      if (path.normalize(req.url) !== req.url) {
         return false;
       }
 
@@ -133,7 +139,7 @@ module.exports = ruleSource => {
         }
       }
 
-      logger.debug({ path, origin, url, querystring }, 'rule matched');
+      logger.debug({ path: entryPath, origin, url, querystring }, 'rule matched');
 
       querystring = (querystring) ? `?${querystring}` : '';
       return {

--- a/test/fixtures/accept/github.json
+++ b/test/fixtures/accept/github.json
@@ -8,6 +8,12 @@
       "method": "GET",
       "path": "/repos/:name/:repo/contents/:path*/package.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to whitelist a folder",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/docs/*",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     } 
   ]
 }

--- a/test/unit/filters.test.js
+++ b/test/unit/filters.test.js
@@ -7,7 +7,7 @@ const jsonBuffer = (body) => Buffer.from(JSON.stringify(body));
 
 test('Filter on URL', t => {
   t.test('for GitHub private filters', (t) => {
-    t.plan(3);
+    t.plan(4);
     
     const ruleSource = require(__dirname + '/../fixtures/accept/github.json');
     const filter = Filters(ruleSource.private);
@@ -36,6 +36,18 @@ test('Filter on URL', t => {
         t.equal(res, undefined, 'no follow allowed');
       });
   
+      t.end();
+    });
+
+    t.test('should block when path includes directory traversal', (t) => {
+      filter({
+        url: '/repos/angular/angular/contents/path/to/docs/../../sensitive/file.js',
+        method: 'GET',
+      }, (error, res) => {
+        t.equal(error.message, 'blocked', 'has been blocked');
+        t.equal(res, undefined, 'no follow allowed');
+      });
+
       t.end();
     });
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
The GitHub API will follow dot-dot-slash (`../`) sequences and there is currently no sanitisation of this in the broker.
Whilst none of the existing examples suggest to do this, if a client was to whitelist a folder (e.g. `/path/to/docs/*`) then path traversal could be used to access a sensitive file e.g.
`/path/to/docs/../../path/to/sensitive/file.js`.

This changes that so that if a [normalized path](https://nodejs.org/api/path.html#path_path_normalize_path) does not match the original path then the request is rejected.