### PR TITLE
fix: sanitise origin in logs

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -63,6 +63,7 @@ const log = bunyan.createLogger({
   serializers: {
     token: sanitise,
     result: sanitise,
+    origin: sanitise,
     url: sanitise,
     httpUrl: sanitise,
     ioUrl: sanitise,


### PR DESCRIPTION
Sanitise origin which contains the highly sensitive GITHUB_TOKEN in Github integrations.

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adds sanitise call onto all origin entries as origin can expose highly sensitive credentials. For Github, the origin URL includes the highly sensitive GITHUB_TOKEN which enables branch, commit, merge, repo access.

#### Where should the reviewer start?

One line change. Maybe an additional test case should be added for completeness.

#### How should this be manually tested?

Github broker integration, turn logging onto debug.

#### Any background context you want to provide?

Found this whilst looking through all Snyk broker calls (turned log mode = debug).

The Github Origin is https://{GITHUB_TOKEN}@{GITHUB_API}/....