### PR TITLE
fix: sanitize origin in logs

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -63,6 +63,7 @@ const log = bunyan.createLogger({
   serializers: {
     token: sanitise,
     result: sanitise,
+    origin: sanitise,
     url: sanitise,
     httpUrl: sanitise,
     ioUrl: sanitise,

--- a/test/unit/log.test.js
+++ b/test/unit/log.test.js
@@ -31,6 +31,7 @@ test('log sanitization of sensitive information', t => {
   log.info({
     token: sensitiveInfo,
     result: sensitiveInfo,
+    origin: sensitiveInfo,
     url: sensitiveInfo,
     httpUrl: sensitiveInfo,
     ioUrl: sensitiveInfo,


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adds sanitise call onto all origin entries as origin can expose highly sensitive credentials. For Github, the origin URL includes the highly sensitive GITHUB_TOKEN which enables branch, commit, merge, repo access.

Duplicate of #231 but with the log tests updated. 

#### How should this be manually tested?

Github broker integration, turn logging onto debug.