### PR TITLE
feat: remove Accept-Encoding header to not corrupt gzip encoded requests

### DIFF
--- a/lib/relay.js
+++ b/lib/relay.js
@@ -262,6 +262,7 @@ function responseHandler(filterRules, config, io) {
         'x-forwarded-proto',
         'content-length',
         'host',
+        'accept-encoding',
       ].map(_ => delete headers[_]);
 
       if (brokerToken) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "eslint": "^5.16.0",
+    "compression": "^1.7.4",
     "proxyquire": "^1.7.10",
     "require-reload": "^0.2.2",
     "sinon": "^1.17.5",

--- a/test/functional/server-client.test.js
+++ b/test/functional/server-client.test.js
@@ -44,7 +44,7 @@ test('proxy requests originating from behind the broker server', t => {
   server.io.on('connection', socket => {
     socket.on('identify', clientData => {
       const token = clientData.token;
-      t.plan(24);
+      t.plan(26);
 
       t.test('identification', t => {
         const filters = require(`${clientRootPath}/${ACCEPT}`);
@@ -285,6 +285,27 @@ test('proxy requests originating from behind the broker server', t => {
           const encodedAuth = Buffer.from(auth, 'base64').toString('utf-8');
           t.equal(encodedAuth, `${process.env.USERNAME}:${process.env.PASSWORD}`,
             'auth header is set correctly');
+          t.end();
+        });
+      });
+
+      t.test('ignores accept-encoding (gzip)', t => {
+        const paramRequiringCompression = 'hello-'.repeat(200);
+        const url = `http://localhost:${serverPort}/broker/${token}/echo-param/${paramRequiringCompression}`;
+        request({ url, method: 'get', gzip: true }, (err, res) => {
+          t.equal(res.statusCode, 200, '200 statusCode');
+          t.equal(res.body, paramRequiringCompression, 'body');
+          t.end();
+        });
+      });
+
+      t.test('ignores accept-encoding (deflate)', t => {
+        const paramRequiringCompression = 'hello-'.repeat(200);
+        const headers = {'Accept-Encoding': 'deflate'};
+        const url = `http://localhost:${serverPort}/broker/${token}/echo-param/${paramRequiringCompression}`;
+        request({ url, method: 'get', headers }, (err, res) => {
+          t.equal(res.statusCode, 200, '200 statusCode');
+          t.equal(res.body, paramRequiringCompression, 'body');
           t.end();
         });
       });

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,3 +1,4 @@
+const compression = require('compression');
 // process.stdout.write('\033c'); // clear the screen
 const webserver = require('../lib/webserver');
 
@@ -14,6 +15,8 @@ const { app: echoServer, server } = webserver({
   httpsKey: process.env.TEST_KEY, // Optional
   httpsCert: process.env.TEST_CERT, // Optional
 });
+
+echoServer.use(compression());
 
 echoServer.get('/test', (req, res) => {
   res.status(200);


### PR DESCRIPTION
#### What does this PR do?
Remove Accept-Encoding header to not corrupt gzip encoded requests

While working with @darscan on this we found out that broker was never passing back into the client compressed content. So broker-client was always decompressing it and sending back the decoded content, but leaving in headers 'Content-Encoding': 'gzip,deflate'. This was making npm cli to freak out as it couldn't decode already decoded content.

This PR removes 'Accept-Encoding' header which means that content will always be plain for now

Renaming and adding test from that PR
https://github.com/snyk/broker/pull/221