### PR TITLE
feat: add request header filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,33 @@ docker run --restart=always \
        snyk/broker:github-com
 ```
 
+#### Types of Filtering
+
+##### By Header
+
+Add a validation block with the following key/values:
+
+| Key | Value | Value Type | Example |
+|-|-|-|-|
+| header | The name of the header you wish to filter on. If this is defined then the named header must explicitly exist on the request otherwise it will be blocked | String | `accept` |
+| values | The header value must match one of the defined strings | Array\<String\> | `["application/vnd.github.v4.sha"]` |
+
+For example, to only allow the SHA Media Type accept header for requests to the GitHub Commits API you would add the following:
+
+```
+{
+    "method": "GET",
+    "path": "/repos/:name/:repo/commits/:ref",
+    "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}",
+    "valid": [
+        {
+            "header": "accept",
+            "values": ["application/vnd.github.v4.sha"]
+        }
+    ]
+}
+```
+
 ### Mounting Secrets
 Sometime it is required to load sensitive configurations (GitHub/Snyk's token) from a file instead from environment variables. Broker is using [dotenv](https://www.npmjs.com/package/dotenv) to load the config, so the process is relatively simple:
 * Create a file named `.env` and put your sensitive config there:

--- a/client-templates/github-com/accept.json.sample
+++ b/client-templates/github-com/accept.json.sample
@@ -1631,7 +1631,13 @@
       "//": "get the details of the commit to determine its SHA",
       "method": "GET",
       "path": "/repos/:name/:repo/commits/:ref",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}",
+      "valid": [
+        {
+          "header": "accept",
+          "values": ["application/vnd.github.v4.sha"]
+        }
+      ]
     },
     {
       "//": "get a list of all the refs to match find whether an existing PR is open",

--- a/client-templates/github-enterprise/accept.json.sample
+++ b/client-templates/github-enterprise/accept.json.sample
@@ -669,7 +669,13 @@
       "//": "get the details of the commit to determine its SHA",
       "method": "GET",
       "path": "/repos/:name/:repo/commits/:ref",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}",
+      "valid": [
+        {
+          "header": "accept",
+          "values": ["application/vnd.github.v4.sha"]
+        }
+      ]
     },
     {
       "//": "get a list of all the refs to match find whether an existing PR is open",

--- a/lib/filters/index.js
+++ b/lib/filters/index.js
@@ -8,6 +8,22 @@ const authHeader = require('../auth-header');
 const tryJSONParse = require('../try-json-parse');
 const logger = require('../log');
 
+const validateHeaders = (headerFilters, requestHeaders = []) => {
+  for (let filter of headerFilters) {
+    const headerValue = requestHeaders[filter.header];
+
+    if (!headerValue) {
+      return false;
+    }
+
+    if (!filter.values.includes(headerValue)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
 // reads config that defines
 module.exports = ruleSource => {
   let rules = [];
@@ -40,6 +56,7 @@ module.exports = ruleSource => {
     const bodyFilters = valid.filter(v => !!v.path && !v.regex);
     const bodyRegexFilters = valid.filter(v => !!v.path && !!v.regex);
     const queryFilters = valid.filter(v => !!v.queryParam);
+    const headerFilters = valid.filter(v => !!v.header);
 
     // now track if there's any values that we need to interpolate later
     const fromConfig = {};
@@ -135,6 +152,12 @@ module.exports = ruleSource => {
         }
 
         if (!isValid) {
+          return false;
+        }
+      }
+
+      if (headerFilters.length) {
+        if (!validateHeaders(headerFilters, req.headers)) {
           return false;
         }
       }

--- a/test/fixtures/accept/github.json
+++ b/test/fixtures/accept/github.json
@@ -14,6 +14,18 @@
       "method": "GET",
       "path": "/repos/:name/:repo/contents/:path*/docs/*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
-    } 
+    },
+    {
+      "//": "get the details of the commit to determine its SHA",
+      "method": "GET",
+      "path": "/repos/:name/:repo/commits/:ref",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}",
+      "valid": [
+        {
+          "header": "accept",
+          "values": ["application/vnd.github.v4.sha"]
+        }
+      ]
+    }
   ]
 }

--- a/test/fixtures/client/filters-https.json
+++ b/test/fixtures/client/filters-https.json
@@ -47,8 +47,20 @@
       "path": "/echo-query",
       "method": "GET",
       "origin": "https://localhost:${originPort}"
-    }
+    },
 
+    {
+      "//": "Block on headers",
+      "path": "/echo-param-protected/:param",
+      "method": "GET",
+      "origin": "http://localhost:${originPort}",
+      "valid": [
+        {
+          "header": "accept",
+          "values": ["valid.accept.header"]
+        }
+      ]
+    }
   ],
   "public": [
     {

--- a/test/fixtures/client/filters.json
+++ b/test/fixtures/client/filters.json
@@ -94,6 +94,18 @@
       "path": "/long/nested/partially/encoded%2Fpath%2Fto%2Ffile.ext",
       "method": "GET",
       "origin": "http://localhost:${originPort}"
+    },
+
+    {
+      "path": "/echo-param-protected/:param",
+      "method": "GET",
+      "origin": "http://localhost:${originPort}",
+      "valid": [
+        {
+          "header": "accept",
+          "values": ["valid.accept.header"]
+        }
+      ]
     }
   ],
   "public": [
@@ -143,6 +155,16 @@
             "values": ["please"]
           }
         ]
+    },
+    {
+      "path": "/echo-param-protected/:param",
+      "method": "GET",
+      "valid": [
+        {
+          "header": "accept",
+          "values": ["valid.accept.header"]
+        }
+      ]
     }
   ]
 }

--- a/test/fixtures/relay.json
+++ b/test/fixtures/relay.json
@@ -98,5 +98,16 @@
       "scheme": "token",
       "token": "1234"
     }
+  },
+  {
+    "//": "accept header whitelist",
+    "method": "GET",
+    "path": "/accept-header",
+    "valid": [
+      {
+        "header": "accept",
+        "values": ["allowed.header"]
+      }
+    ]
   }
 ]

--- a/test/fixtures/server/filters.json
+++ b/test/fixtures/server/filters.json
@@ -33,9 +33,21 @@
     {
       "path": "/test-blob/*",
       "method": "GET",
-      "origin": "http://localhost:${originPort}",
-    }
+      "origin": "http://localhost:${originPort}"
+    },
 
+    {
+      "//": "Block on headers",
+      "path": "/echo-param-protected/:param",
+      "method": "GET",
+      "origin": "http://localhost:${originPort}",
+      "valid": [
+        {
+          "header": "accept",
+          "values": ["valid.accept.header"]
+        }
+      ]
+    }
   ],
   "public": [
     {

--- a/test/utils.js
+++ b/test/utils.js
@@ -52,6 +52,10 @@ echoServer.get('/echo-param/:param', (req, res) => {
   res.send(req.params.param);
 });
 
+echoServer.get('/echo-param-protected/:param', (req, res) => {
+  res.send(req.params.param);
+});
+
 echoServer.post('/echo-body/:param?', (req, res) => {
   const contentType = req.get('Content-Type');
   if (contentType) {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adds the ability to filter by request headers using `accept.json`. The filtering is strict so, rather than just matching values, if a header is defined in the whitelist and the request does not include the expected header key it will fail.

#### How should this be manually tested?

Make a brokered request to the GitHub Commits API using the `application/vnd.github.cryptographer-preview` header and it will get blocked.