### PR TITLE
feat: increase reconnect waiting time

### DIFF
--- a/lib/client/socket.js
+++ b/lib/client/socket.js
@@ -27,7 +27,27 @@ module.exports = ({ url, token, filters, config, identifyingMetadata }) => {
     },
     pathname : `/primus/${token}`,
   });
-  const io = new Socket(url);
+
+  // Will exponentially back-off from 0.5 seconds to a maximum of 20 minutes
+  // Retry for a total period of around 4.5 hours
+  const io = new Socket(url, {
+    reconnect: {
+      factor: 1.5,
+      retries: 30,
+      max: 20 * 60 * 1000,
+    },
+  });
+
+  io.on('reconnect scheduled', (opts) => {
+    const attemptIn = Math.floor(opts.scheduled / 1000);
+    logger.warn(`Reconnect retry #${opts.attempt} of ${opts.retries} in about ${attemptIn}s`);
+  });
+
+  io.on('reconnect failed', () => {
+    io.end();
+    logger.error('Reconnect failed');
+    process.exit(1);
+  });
 
   logger.info({ url }, 'broker client is connecting to broker server');
 


### PR DESCRIPTION
- [X] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Due to the latest outage, there was an issue with Broker clients reconnecting back to the Broker server. During investigation was uncovered that Broker client will try to reconnect for around 16-18 minutes (re-connect time is randomized).
To improve the user experience during outages, the time of waiting is increased by changing the number of retries and decreasing exponential growth factor.

Previously, we were using the default Primius strategy: 10 retries with exponential growth factor 2.
In this PR, retries are increased to 20 and factor is decreased to 1.5. Which gives us a window between one and one and a half hours to reconnect.
Added logging for each attempt and proximate time till retry.

Added graceful process shutdown to add visibility on the customer side to restart Broker client as their Docker container will be down (after re-running Docker container there will be another 1-1.5h for reconnecting if Broker server is still not up)