### PR TITLE
feat: remove repository commits API from GitLab whitelist

### DIFF
--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -1226,12 +1226,6 @@
       "origin": "https://${GITLAB}"
     },
     {
-      "//": "used to create commits for fix merge request",
-      "method": "POST",
-      "path": "/api/v4/projects/:project/repository/commits",
-      "origin": "https://${GITLAB}"
-    },
-    {
       "//": "used to create merge request for fix merge request",
       "method": "POST",
       "path": "/api/v4/projects/:project/merge_requests",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Removes the whitelist entries for the Repository Commits API in GitLab now that usage has been replaced with Repository Files calls.