### PR TITLE
feat: bump deps (no more lodash)

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
-const config = require('snyk-config')(__dirname + '/..');
+const { loadConfig } = require('snyk-config');
+const config = loadConfig(__dirname + '/..');
 
 const { expand, camelify } = require('./utils');
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lodash.escaperegexp": "^4.1.2",
     "lodash.mapvalues": "^4.6.0",
     "minimatch": "^3.0.4",
-    "node-cache": "^4.2.1",
+    "node-cache": "^5.1.0",
     "path-to-regexp": "^1.8.0",
     "primus": "^6.0.1",
     "primus-emitter": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "primus-emitter": "^3.1.1",
     "qs": "^6.9.1",
     "request": "^2.88.0",
-    "snyk-config": "^2.2.3",
+    "snyk-config": "^3.1.1",
     "then-fs": "^2.0.0",
     "tunnel": "0.0.6",
     "undefsafe": "^2.0.2",


### PR DESCRIPTION
#### What does this PR do?

Upgrading these two deps, which require minimal changes, removes our transitive dependency on `lodash`, and the need for patches.

`snyk-config` upgrade changes it to an exported function, which we can call.
`node-cache` upgrade:
1) removes deprecated api, which we aren't using
2) drops support for node <8, which we don't support