### PR TITLE
feat: add Bearer auth support in accept.json

### DIFF
--- a/README.npm.md
+++ b/README.npm.md
@@ -281,6 +281,29 @@ For token based auth, this would be provided like so:
 }
 ```
 
+For bearer based auth (e.g: BitBucket Server personal access tokens), this would be provided like so:
+```json
+{
+  "private": [
+    {
+      "method": "GET",
+      "path": "/myself",
+      "origin": "https://${HOST}",
+      "auth": {
+        "scheme": "bearer",
+        "bearer": "${BEARER}"
+      }
+    },
+  ],
+  "public": [
+    {
+      "method": "any",
+      "path": "/*"
+    }
+  ]
+}
+```
+
 ### Private rules
 
 Private filters are for requests that come from the broker server into your client and ask for resources inside your private infrastructure (such as a github enterprise instance).

--- a/client-templates/bitbucket-server/.env.sample
+++ b/client-templates/bitbucket-server/.env.sample
@@ -7,6 +7,14 @@ BITBUCKET_USERNAME=<username>
 # your personal password to your bitbucket server account
 BITBUCKET_PASSWORD=<password>
 
+# your personal access token (PAT) to your bitbucket server account
+# this can be used instead of username/password basic auth
+# if you decide to
+# this requires modifying the accept.json file to support Bearer auth
+# please refer to the README.npm.md file in the "For bearer based auth"
+# to see example of the auth configuration that needs to be done in accept.json file
+# BITBUCKET_PERSONAL_ACCESS_TOKEN=<personal-access-token>
+
 # the host where your Bitbucket Server is running, excluding scheme.
 # for bitbucket.yourdomain.com
 # this should be "bitbucket.yourdomain.com"

--- a/lib/auth-header.js
+++ b/lib/auth-header.js
@@ -1,6 +1,6 @@
 const replace = require('./replace-vars');
 
-module.exports = ({scheme, token, username, password}) => {
+module.exports = ({scheme, token, bearer, username, password}) => {
   const config = require('./config');
 
   if (scheme === 'token') {
@@ -9,5 +9,8 @@ module.exports = ({scheme, token, username, password}) => {
   if (scheme === 'basic') {
     const basicAuth = [replace(username, config), replace(password, config)].join(':');
     return `Basic ${new Buffer(basicAuth).toString('base64')}`;
+  }
+  if (scheme === 'bearer') {
+    return `Bearer ${replace(bearer, config)}`;
   }
 };

--- a/test/fixtures/relay.json
+++ b/test/fixtures/relay.json
@@ -109,5 +109,14 @@
         "values": ["allowed.header"]
       }
     ]
+  },
+  {
+    "//": "token auth route",
+    "method": "GET",
+    "path": "/bearer-auth",
+    "auth": {
+      "scheme": "bearer",
+      "bearer": "1234"
+    }
   }
 ]

--- a/test/unit/filters.test.js
+++ b/test/unit/filters.test.js
@@ -8,14 +8,14 @@ const jsonBuffer = (body) => Buffer.from(JSON.stringify(body));
 test('Filter on URL', t => {
   t.test('for GitHub private filters', (t) => {
     t.plan(4);
-    
+
     const ruleSource = require(__dirname + '/../fixtures/accept/github.json');
     const filter = Filters(ruleSource.private);
     t.pass('Filters loaded');
 
     t.test('should allow valid /repos path to manifest', (t) => {
       const url = '/repos/angular/angular/contents/package.json';
-      
+
       filter({
         url,
         method: 'GET',
@@ -23,7 +23,7 @@ test('Filter on URL', t => {
         t.equal(error, null, 'no error');
         t.isLike(res.url, url, 'contains expected path');
       });
-  
+
       t.end();
     });
 
@@ -35,7 +35,7 @@ test('Filter on URL', t => {
         t.equal(error.message, 'blocked', 'has been blocked');
         t.equal(res, undefined, 'no follow allowed');
       });
-  
+
       t.end();
     });
 
@@ -333,7 +333,7 @@ test('Filter on querystring', t => {
 
       t.end();
     });
-      
+
     t.end();
   });
 });
@@ -415,7 +415,7 @@ test('Filter on query and body', t => {
       t.end();
     });
 
-    t.test('should ignore any non-manifest files after the fragment identifier', (t) => {    
+    t.test('should ignore any non-manifest files after the fragment identifier', (t) => {
       filter({
         url: '/filtered-on-query-and-body?filePath=/path/to/package.json#/sensitive/file.js',
         method: 'POST',
@@ -437,7 +437,7 @@ test('Filter on query and body', t => {
 
 test('Filter on headers', t => {
   t.plan(3);
-  
+
   t.test('should block if the provided header does not match those specified in the whitelist', (t) => {
     const filter = Filters(require(__dirname + '/../fixtures/relay.json'));
 
@@ -488,7 +488,7 @@ test('Filter on headers', t => {
         t.equal(error, null, 'no error');
         t.isLike(res.url, url, 'contains expected path');
       });
-  
+
       t.end();
     });
 
@@ -503,7 +503,7 @@ test('Filter on headers', t => {
         t.equal(error.message, 'blocked', 'has been blocked');
         t.equal(res, undefined, 'no follow allowed');
       });
-  
+
       t.end();
     });
   });
@@ -512,7 +512,7 @@ test('Filter on headers', t => {
 test('filter with auth', t => {
   const filter = Filters(require(__dirname + '/../fixtures/relay.json'));
 
-  t.plan(5);
+  t.plan(7);
   t.pass('filters loaded');
 
   filter({
@@ -530,5 +530,13 @@ test('filter with auth', t => {
   }, (error, res) => {
     t.equal(error, null, 'no error');
     t.equal(res.auth, 'Token 1234', 'token auth header returned');
+  });
+
+  filter({
+    url: '/bearer-auth',
+    method: 'GET',
+  }, (error, res) => {
+    t.equal(error, null, 'no error');
+    t.equal(res.auth, 'Bearer 1234', 'bearer auth header returned');
   });
 });


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR adds the option to configure PAT (e.g BB Server PAT that uses Bearer auth) authentication in accept JSON on top of token and basic-auth.