### PR TITLE
fix: allowing brokered artifactory to communicate w/ Snyk

### DIFF
--- a/client-templates/artifactory/.env.sample
+++ b/client-templates/artifactory/.env.sample
@@ -5,7 +5,7 @@ BROKER_TOKEN=<broker-token>
 ARTIFACTORY_URL=yourdomain.artifactory.com/artifactory
 
 # The URL of the Snyk broker server
-BROKER_SERVER_URL=https://broker-container.snyk.io
+BROKER_SERVER_URL=https://broker.snyk.io
 
 # the fine detail accept rules that allow Snyk to make API requests to your
 # artifactory instance


### PR DESCRIPTION
- [X] Ready for review

#### What does this PR do?
Artifactory broker uri was aimed at the container broker (which doesn't exist anymore); Was swapped for the standard `broker.snyk.io`

