### PR TITLE
chore: remove auth headers to prevent leakage

### DIFF
--- a/lib/is-object.js
+++ b/lib/is-object.js
@@ -1,0 +1,3 @@
+
+// null is also considered as an object, so we assert truth
+module.exports = (v)=> typeof v === 'object' && !!v;

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -6,6 +6,7 @@ const uuid = require('uuid/v4');
 const Filters = require('./filters');
 const replace = require('./replace-vars');
 const tryJSONParse = require('./try-json-parse');
+const isObject = require('./is-object');
 const logger = require('./log');
 const version = require('./version');
 const stream = require('stream');
@@ -16,6 +17,10 @@ module.exports = {
   response: responseHandler,
   streamingResponse: streamResponseHandler,
 };
+
+function stringifyIfObject(value) {
+  return isObject(value) ? JSON.stringify(value) : value;
+}
 
 const streams = new NodeCache({
   stdTTL: 18000,  // 5 hours
@@ -197,6 +202,7 @@ function responseHandler(filterRules, config, io) {
         logContext.userAgentHeaderSet = true;
       }
 
+      headers.authorization = {};
       if (result.auth) {
         headers.authorization = result.auth;
         logContext.authHeaderSetByRuleAuth = true;
@@ -270,6 +276,7 @@ function responseHandler(filterRules, config, io) {
       }
 
       logger.debug(logContext, 'sending websocket request over HTTP connection');
+      headers.authorization = stringifyIfObject(headers.authorization);
 
       var req = {
         url: result.url,


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
When dispatching requests from our broker server to the broker clients, we may relay auth headers. This solves it 

