### PR TITLE
feat: add ca-certificates to all broker images

### DIFF
--- a/dockerfiles/artifactory/Dockerfile
+++ b/dockerfiles/artifactory/Dockerfile
@@ -2,8 +2,9 @@ FROM node:12-slim
 
 MAINTAINER Snyk Ltd
 
-# Install broker
 RUN npm install --global snyk-broker
+
+RUN apt-get update && apt-get install -y ca-certificates
 
 # Don't run as root
 WORKDIR /home/node

--- a/dockerfiles/bitbucket-server/Dockerfile
+++ b/dockerfiles/bitbucket-server/Dockerfile
@@ -2,8 +2,9 @@ FROM node:12-buster-slim
 
 MAINTAINER Snyk Ltd
 
-# Install broker
 RUN npm install --global snyk-broker
+
+RUN apt-get update && apt-get install -y ca-certificates
 
 # Don't run as root
 WORKDIR /home/node

--- a/dockerfiles/github-com/Dockerfile
+++ b/dockerfiles/github-com/Dockerfile
@@ -2,8 +2,9 @@ FROM node:12-buster-slim
 
 MAINTAINER Snyk Ltd
 
-# Install broker
 RUN npm install --global snyk-broker
+
+RUN apt-get update && apt-get install -y ca-certificates
 
 # Don't run as root
 WORKDIR /home/node

--- a/dockerfiles/github-enterprise/Dockerfile
+++ b/dockerfiles/github-enterprise/Dockerfile
@@ -2,8 +2,9 @@ FROM node:12-buster-slim
 
 MAINTAINER Snyk Ltd
 
-# Install broker
 RUN npm install --global snyk-broker
+
+RUN apt-get update && apt-get install -y ca-certificates
 
 # Don't run as root
 WORKDIR /home/node

--- a/dockerfiles/gitlab/Dockerfile
+++ b/dockerfiles/gitlab/Dockerfile
@@ -2,8 +2,9 @@ FROM node:12-buster-slim
 
 MAINTAINER Snyk Ltd
 
-# Install broker
 RUN npm install --global snyk-broker
+
+RUN apt-get update && apt-get install -y ca-certificates
 
 # Don't run as root
 WORKDIR /home/node

--- a/dockerfiles/jira/Dockerfile
+++ b/dockerfiles/jira/Dockerfile
@@ -2,8 +2,9 @@ FROM node:12-buster-slim
 
 MAINTAINER Snyk Ltd
 
-# Install broker
 RUN npm install --global snyk-broker
+
+RUN apt-get update && apt-get install -y ca-certificates
 
 # Don't run as root
 WORKDIR /home/node


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

`ca-certificates` was removed from the underlying images when moving to `node:12-buster-slim`, this adds the package to make commands like `update-ca-certificates` available again.