### PR TITLE
fix: Correctly load version from package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,2 @@
-/node_modules
-.git*
-/test
-config.*.json
-!config.default.json
-tmp
+**
+!dist/**

--- a/cli/index.js
+++ b/cli/index.js
@@ -2,8 +2,8 @@
 const clite = require('clite');
 clite({
   commands: {
-    init: 'dist/cli/init',
-    _: 'dist/cli/exec',
+    init: 'cli/init',
+    _: 'cli/exec',
   },
   options: ['env', 'port'],
   alias: { V: 'verbose', 'v': 'version' },

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,1 +1,3 @@
-module.exports = process.env.npm_package_version || 'local';
+const { version } = require('../package.json');
+
+module.exports = version || 'local';

--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "snyk-broker",
   "description": "Broker for private communication between internal systems and outside public systems",
-  "files": [
-    "dist",
-    "client-templates"
-  ],
   "main": "dist/lib/index.js",
   "bin": {
     "snyk-broker": "./dist/cli/index.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "outDir": "./dist",
     "incremental": true,
     "pretty": true,
+    "resolveJsonModule": true,
 
     "strict": true,
     "noImplicitAny": false,


### PR DESCRIPTION
Enable tsc's `resolveJsonModule` flag to copy the package.json to dist, so we can require the package.json at the same file path as we did before using TS. This is needed because the npm package env vars are only populated when the application is run by npm, which isn't how we start broker. Also moved from using the package.json "files" field to `.npmignore`, as the nested package.json in dist/ did not play nicely when packaging