### PR TITLE
fix: CLI interface args were passed incorrectly

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -17,10 +17,10 @@ if (args.help) {
   process.exit(0);
 }
 
-if (args._[0] === 'init') {
-  init(args._[1]).then(() => process.exit(0));
-}
-
-if (args._.length === 0) {
+const command = args._[0];
+if (command === 'init') {
+  const templateName = args._[1];
+  init(templateName).then(() => process.exit(0));
+} else {
   exec(args);
 }

--- a/cli/init.js
+++ b/cli/init.js
@@ -3,8 +3,7 @@ const path = require('path');
 const root = path.resolve(__dirname, '../client-templates/');
 const logger = require('../lib/log');
 
-module.exports = async (args) => {
-  const templateName = args._[0];
+module.exports = async (templateName) => {
   if (!templateName) {
     throw new Error('init requires a template name');
   }

--- a/test/functional/init.test.js
+++ b/test/functional/init.test.js
@@ -19,7 +19,7 @@ templates.forEach((template) => {
       }
       process.chdir(path);
 
-      init({ _: [template] })
+      init(template)
         .then(() => Promise.all([fs.stat('.env'), fs.stat('accept.json')]))
         .then((stats) => {
           t.ok(stats.every(Boolean), 'all templated files created');


### PR DESCRIPTION
The args for the CLI interface were being passed through incorrectly, causing broker setup to fail. This patch should align them as expected.