### PR TITLE
chore: convert more test files to Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepare": "npm run build && rm -rf ./dist/client-templates && cp -Rf ./client-templates ./dist",
     "start": "node .",
     "dev": "tsc-watch --project tsconfig.json --onSuccess 'node .' | ./node_modules/.bin/bunyan",
-    "test": "LOG_LEVEL=fatal CI=1 tap -j1 -R spec test/**/*.test.js --timeout 60 && jest",
+    "test": "LOG_LEVEL=fatal CI=1 tap -j1 -R spec test/**/*.test.js --timeout 60 && jest --forceExit",
     "lint": "prettier --check '{lib,test,cli}/**/*.{js,ts}' && eslint --color --cache '{cli,lib,test}/**/*.{js,ts}'",
     "check-tests": "! grep 'test.only' test/**/*.test.js -n"
   },


### PR DESCRIPTION
This is unfortunately not much of a cleanup; we're keeping the tests poorly structured and converting the syntax to Jest. Due to Jest being sensitive to running code, it no longer exits properly so we need to force it with `--forceExit`. TAP does not catch running code in this way.

Also using `as any` a little to allow us to move forward; we could fix the types, but that means moving beyond the test code, and I want to keep the changes small