### PR TITLE
fix: added rateLimit to allowed github graphql query params

### DIFF
--- a/client-templates/github-com/accept.json.sample
+++ b/client-templates/github-com/accept.json.sample
@@ -1783,7 +1783,7 @@
         {
           "//": "query to find open snyk pull requests, allowing auto dependency upgrade pull requests to open no more than a limited amount of pull requests",
           "path": "query",
-          "regex": "{\\s*search\\(\\s*query: \"repo:[a-zA-Z0-9-_.]+\\/[a-zA-Z0-9-_.]+ is:pr state:[a-zA-Z]+ head:snyk-\\s*(is:[a-zA-Z]+)?\", type: ISSUE, last: [0-9]+\\s*\\)\\s*{\\s*edges {\\s*node {\\s*\\.\\.\\. on PullRequest {\\s*url\\s*title\\s*createdAt\\s*headRefName\\s*state\\s*mergeable\\s*body\\s*repository\\s*{\\s*name\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*"
+          "regex": "{\\s*search\\(\\s*query: \"repo:[a-zA-Z0-9-_.]+\\/[a-zA-Z0-9-_.]+ is:pr state:[a-zA-Z]+ head:snyk-\\s*(is:[a-zA-Z]+)?\", type: ISSUE, last: [0-9]+\\s*\\)\\s*{\\s*edges {\\s*node {\\s*\\.\\.\\. on PullRequest {\\s*url\\s*title\\s*createdAt\\s*headRefName\\s*state\\s*mergeable\\s*body\\s*repository\\s*{\\s*name\\s*}\\s*}\\s*}\\s*}\\s*}\\s*rateLimit\\s*{\\s*limit\\s*cost\\s*remaining\\s*resetAt\\s*}\\s*}\\s*"
         }
       ]
     }

--- a/client-templates/github-enterprise/accept.json.sample
+++ b/client-templates/github-enterprise/accept.json.sample
@@ -1445,7 +1445,7 @@
         {
           "//": "query to find open snyk pull requests, allowing auto dependency upgrade pull requests to open no more than a limited amount of pull requests",
           "path": "query",
-          "regex": "{\\s*search\\(\\s*query: \"repo:[a-zA-Z0-9-_.]+\\/[a-zA-Z0-9-_.]+ is:pr state:[a-zA-Z]+ head:snyk-\\s*(is:[a-zA-Z]+)?\", type: ISSUE, last: [0-9]+\\s*\\)\\s*{\\s*edges {\\s*node {\\s*\\.\\.\\. on PullRequest {\\s*url\\s*title\\s*createdAt\\s*headRefName\\s*state\\s*mergeable\\s*body\\s*repository\\s*{\\s*name\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*"
+          "regex": "{\\s*search\\(\\s*query: \"repo:[a-zA-Z0-9-_.]+\\/[a-zA-Z0-9-_.]+ is:pr state:[a-zA-Z]+ head:snyk-\\s*(is:[a-zA-Z]+)?\", type: ISSUE, last: [0-9]+\\s*\\)\\s*{\\s*edges {\\s*node {\\s*\\.\\.\\. on PullRequest {\\s*url\\s*title\\s*createdAt\\s*headRefName\\s*state\\s*mergeable\\s*body\\s*repository\\s*{\\s*name\\s*}\\s*}\\s*}\\s*}\\s*}\\s*rateLimit\\s*{\\s*limit\\s*cost\\s*remaining\\s*resetAt\\s*}\\s*}\\s*"
         }
       ]
     }

--- a/test/fixtures/client/github/graphql/find-pull-requests-closed.txt
+++ b/test/fixtures/client/github/graphql/find-pull-requests-closed.txt
@@ -17,4 +17,10 @@
                  }
              }
         }
+        rateLimit {
+            limit
+            cost
+            remaining
+            resetAt
+        }
   }

--- a/test/fixtures/client/github/graphql/find-pull-requests-open.txt
+++ b/test/fixtures/client/github/graphql/find-pull-requests-open.txt
@@ -17,4 +17,10 @@
                }
           }
       }
+      rateLimit {
+        limit
+        cost
+        remaining
+        resetAt
+      }
   }

--- a/test/fixtures/relay.json
+++ b/test/fixtures/relay.json
@@ -76,7 +76,7 @@
       {
         "//": "query to find open snyk pull requests, allowing auto dependency upgrade pull requests to open no more than a limited amount of pull requests",
         "path": "query",
-        "regex": "{\\s*search\\(\\s*query: \"repo:[a-zA-Z0-9-_.]+\\/[a-zA-Z0-9-_.]+ is:pr state:[a-zA-Z]+ head:snyk-\\s*(is:[a-zA-Z]+)?\", type: ISSUE, last: [0-9]+\\s*\\)\\s*{\\s*edges {\\s*node {\\s*\\.\\.\\. on PullRequest {\\s*url\\s*title\\s*createdAt\\s*headRefName\\s*state\\s*mergeable\\s*body\\s*repository\\s*{\\s*name\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*"
+        "regex": "{\\s*search\\(\\s*query: \"repo:[a-zA-Z0-9-_.]+\\/[a-zA-Z0-9-_.]+ is:pr state:[a-zA-Z]+ head:snyk-\\s*(is:[a-zA-Z]+)?\", type: ISSUE, last: [0-9]+\\s*\\)\\s*{\\s*edges {\\s*node {\\s*\\.\\.\\. on PullRequest {\\s*url\\s*title\\s*createdAt\\s*headRefName\\s*state\\s*mergeable\\s*body\\s*repository\\s*{\\s*name\\s*}\\s*}\\s*}\\s*}\\s*}\\s*rateLimit\\s*{\\s*limit\\s*cost\\s*remaining\\s*resetAt\\s*}\\s*}\\s*"
       }
     ]
   },


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This change enables the broker to call the graphql pull request node with rateLimit parameter. Previously not having
this in the regexp would block outgoing requests with rateLimit present.

#### Where should the reviewer start?

Taking a look at whether the right files were changed. The broker should be able to call graphql endpoint without being blocked.

#### How should this be manually tested?

-

#### Any background context you want to provide?

-

#### Screenshots

-

#### Additional questions

-