### PR TITLE
fix: remove env variable from azure-repos Dockerfile

### DIFF
--- a/dockerfiles/azure-repos/Dockerfile
+++ b/dockerfiles/azure-repos/Dockerfile
@@ -29,7 +29,6 @@ ENV AZURE_REPOS_HOST dev.azure.com
 
 # Your unique Broker identifier
 ENV BROKER_TOKEN <broker-token>
-ENV BROKER_CLIENT_VALIDATION_BASIC_AUTH "PAT:$AZURE_REPOS_TOKEN"
 
 # The port used by the broker client to accept internal connections
 # Default value is 7341


### PR DESCRIPTION
Remove `BROKER_CLIENT_VALIDATION_BASIC_AUTH` env variable in Dockerfile. That's done to prevent run misconfigured docker image