### PR TITLE
fix: replace boolean values by strings in whitelist rules

### DIFF
--- a/client-templates/azure-repos/accept.json.sample
+++ b/client-templates/azure-repos/accept.json.sample
@@ -142,11 +142,11 @@
         },
         {
           "queryParam": "download",
-          "values": [true]
+          "values": ["true"]
         },
         {
           "queryParam": "includeContent",
-          "values": [true]
+          "values": ["true"]
         }
       ],
       "auth": {
@@ -166,11 +166,11 @@
         },
         {
           "queryParam": "download",
-          "values": [false]
+          "values": ["false"]
         },
         {
           "queryParam": "includeContent",
-          "values": [false]
+          "values": ["false"]
         }
       ],
       "auth": {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Small fix of Azure broker client whitelist. Matching rules do not accept boolean values
