### PR TITLE
test: github big file rule

### DIFF
--- a/test/fixtures/accept/github-big-files.json
+++ b/test/fixtures/accept/github-big-files.json
@@ -1,0 +1,18 @@
+{
+  "//": "Cut down example accept.json for GitHub to test filter logic",
+  "public": [],
+  "private": [
+    {
+      "//": "query graphql",
+      "method": "POST",
+      "path": "/graphql",
+      "valid": [
+        {
+          "//": "query to get file SHA",
+          "path": "query",
+          "regex": "{\\s*repository\\(\\s*owner:\\s*\"[a-zA-Z0-9-_.]+\",\\s*name:\\s*\"[a-zA-Z0-9-_.]+\"\\)\\s*{\\s*object\\(\\s*expression:\\s*\"[a-zA-Z0-9-_.\/]+:[a-zA-Z0-9-_.\/]+\"\\)\\s*{\\s*\\.\\.\\.\\s*on\\s*Blob\\s*{\\s*oid\\,\\s*}\\s*}\\s*}\\s*}\\s*"
+        }
+      ]
+    }
+  ]
+}

--- a/test/unit/filters.test.ts
+++ b/test/unit/filters.test.ts
@@ -641,3 +641,28 @@ describe('with auth', () => {
     );
   });
 });
+
+describe('Github big files (optional rules)', () => {
+  const rules = JSON.parse(
+    loadFixture(path.join('accept', 'github-big-files.json')),
+  );
+  const filter = Filters(rules.private);
+
+  it('should allow the get file sha API', (done) => {
+    filter(
+      {
+        url: '/graphql',
+        method: 'POST',
+        body: jsonBuffer({
+          query:
+            '{\n        repository(owner: "some-owner", name: "some-name") {\n          object(expression: "refs/heads/some-thing:a/path/to/package-lock.json") {\n            ... on Blob {\n              oid,\n            }\n          }\n        }\n      }',
+        }),
+      },
+      (error, res) => {
+        expect(error).toBeNull();
+        expect(res.url).toEqual('/graphql');
+        done();
+      },
+    );
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adds a test for a rule that allows getting file shas via the github graphql API - the file sha is used as a parameter for the blobs (big files) API.

The rule is not part of the default accept.json but useful for some Broker users that need to support big files.