### PR TITLE
chore: remove unused ghe broker rules

### DIFF
--- a/client-templates/github-enterprise/accept.json.sample
+++ b/client-templates/github-enterprise/accept.json.sample
@@ -690,18 +690,6 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
-      "path": "/:name/:repo/:path*/package.json",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2Fpackage.json",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/package-lock.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -710,18 +698,6 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2Fpackage-lock.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*/package-lock.json",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2Fpackage-lock.json",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -738,18 +714,6 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
-      "path": "/:name/:repo/:path*/Gemfile.lock",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2FGemfile.lock",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/Gemfile",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -758,18 +722,6 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2FGemfile",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*/Gemfile",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2FGemfile",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -786,18 +738,6 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
-      "path": "/:name/:repo/:path*/pom.xml",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2Fpom.xml",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/*req*.txt",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -806,18 +746,6 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2F*req*.txt",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*/*req*.txt",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2F*req*.txt",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -834,18 +762,6 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
-      "path": "/:name/:repo/:path*/yarn.lock",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2Fyarn.lock",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/build.gradle",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -854,18 +770,6 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2Fbuild.gradle",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*/build.gradle",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2Fbuild.gradle",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -882,18 +786,6 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
-      "path": "/:name/:repo/:path*/gradle.properties",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2Fgradle.properties",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/Packages.props",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -902,18 +794,6 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2FPackages.props",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*/Packages.props",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2FPackages.props",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -930,18 +810,6 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
-      "path": "/:name/:repo/:path*/Directory.Build.props",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2FDirectory.Build.props",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/Directory.Build.targets",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -950,18 +818,6 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2FDirectory.Build.targets",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*/Directory.Build.targets",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2FDirectory.Build.targets",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -978,18 +834,6 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
-      "path": "/:name/:repo/:path*/build.sbt",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2Fbuild.sbt",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/packages.config",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -998,18 +842,6 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2Fpackages.config",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*/packages.config",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2Fpackages.config",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -1026,18 +858,6 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
-      "path": "/:name/:repo/:path*/*.csproj",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2F*.csproj",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/*.fsproj",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -1046,18 +866,6 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2F*.fsproj",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*/*.fsproj",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2F*.fsproj",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -1074,18 +882,6 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
-      "path": "/:name/:repo/:path*/*.vbproj",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2F*.vbproj",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/project.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -1094,18 +890,6 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2Fproject.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*/project.json",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2Fproject.json",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -1122,18 +906,6 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
-      "path": "/:name/:repo/:path*/Gopkg.toml",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2FGopkg.toml",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/Gopkg.lock",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -1142,18 +914,6 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2FGopkg.lock",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*/Gopkg.lock",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2FGopkg.lock",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -1170,18 +930,6 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
-      "path": "/:name/:repo/:path*/vendor.json",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2Fvendor.json",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/composer.lock",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -1190,18 +938,6 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2Fcomposer.lock",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*/composer.lock",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2Fcomposer.lock",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -1218,18 +954,6 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
-      "path": "/:name/:repo/:path*/composer.json",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2Fcomposer.json",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/project.assets.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -1238,18 +962,6 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2Fproject.assets.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*/project.assets.json",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2Fproject.assets.json",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -1276,30 +988,6 @@
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*/Podfile",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2FPodfile",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*/Podfile.lock",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to update manifest or lock",
-      "method": "PUT",
-      "path": "/:name/:repo/:path*%2FPodfile.lock",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
       "//": "used to write or update ignore rules or existing patches",
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/.snyk",
@@ -1322,18 +1010,6 @@
       "method": "GET",
       "path": "/repos/:name/:repo/contents/:path*%2F2FDockerfile",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
-    },
-    {
-      "//": "used to scan Dockerfile",
-      "method": "GET",
-      "path": "/:name/:repo/:path*/Dockerfile",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
-    },
-    {
-      "//": "used to scan Dockerfile",
-      "method": "GET",
-      "path": "/:name/:repo/:path*%2FDockerfile",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to check if there's any ignore rules or existing patches",
@@ -1361,7 +1037,9 @@
       "valid": [
         {
           "header": "accept",
-          "values": ["application/vnd.github.v4.sha"]
+          "values": [
+            "application/vnd.github.v4.sha"
+          ]
         }
       ]
     },


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

The GITHUB_RAW endpoint is only used for Github (not enterprise) and was unused in this config. Guess it got here accidentally by replicating github.com rules into the enterprise accept.json.

- Snyk never calls this endpoint for a GHE integration
- the .env.sample doesn't mention this property so probably it's not set in any GHE Broker client
- the raw endpoint Snyk uses is always `raw.githubusercontent.com` so no way that would work with GHE
