### PR TITLE
fix: make encoded ghe accept json /dockerfile path valid

### DIFF
--- a/test/fixtures/accept/ghe.json
+++ b/test/fixtures/accept/ghe.json
@@ -690,6 +690,18 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
+      "path": "/:name/:repo/:path*/package.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fpackage.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/package-lock.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -698,6 +710,18 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2Fpackage-lock.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/package-lock.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fpackage-lock.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -714,6 +738,18 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
+      "path": "/:name/:repo/:path*/Gemfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2FGemfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/Gemfile",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -722,6 +758,18 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2FGemfile",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/Gemfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2FGemfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -738,6 +786,18 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
+      "path": "/:name/:repo/:path*/pom.xml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fpom.xml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/*req*.txt",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -746,6 +806,18 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2F*req*.txt",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/*req*.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2F*req*.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -762,6 +834,18 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
+      "path": "/:name/:repo/:path*/yarn.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fyarn.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/build.gradle",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -770,6 +854,18 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2Fbuild.gradle",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/build.gradle",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fbuild.gradle",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -786,6 +882,18 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
+      "path": "/:name/:repo/:path*/gradle.properties",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fgradle.properties",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/Packages.props",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -794,6 +902,18 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2FPackages.props",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/Packages.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2FPackages.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -810,6 +930,18 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
+      "path": "/:name/:repo/:path*/Directory.Build.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2FDirectory.Build.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/Directory.Build.targets",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -818,6 +950,18 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2FDirectory.Build.targets",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/Directory.Build.targets",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2FDirectory.Build.targets",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -834,6 +978,18 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
+      "path": "/:name/:repo/:path*/build.sbt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fbuild.sbt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/packages.config",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -842,6 +998,18 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2Fpackages.config",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/packages.config",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fpackages.config",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -858,6 +1026,18 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
+      "path": "/:name/:repo/:path*/*.csproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2F*.csproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/*.fsproj",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -866,6 +1046,18 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2F*.fsproj",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/*.fsproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2F*.fsproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -882,6 +1074,18 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
+      "path": "/:name/:repo/:path*/*.vbproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2F*.vbproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/project.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -890,6 +1094,18 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2Fproject.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/project.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fproject.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -906,6 +1122,18 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
+      "path": "/:name/:repo/:path*/Gopkg.toml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2FGopkg.toml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/Gopkg.lock",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -914,6 +1142,18 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2FGopkg.lock",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/Gopkg.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2FGopkg.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -930,6 +1170,18 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
+      "path": "/:name/:repo/:path*/vendor.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fvendor.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/composer.lock",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -938,6 +1190,18 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2Fcomposer.lock",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/composer.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fcomposer.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -954,6 +1218,18 @@
     {
       "//": "used to update manifest or lock",
       "method": "PUT",
+      "path": "/:name/:repo/:path*/composer.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fcomposer.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/project.assets.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -962,6 +1238,18 @@
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2Fproject.assets.json",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/project.assets.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fproject.assets.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update manifest or lock",
@@ -988,6 +1276,30 @@
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/Podfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2FPodfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/Podfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2FPodfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
       "//": "used to write or update ignore rules or existing patches",
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/.snyk",
@@ -1010,6 +1322,18 @@
       "method": "GET",
       "path": "/repos/:name/:repo/contents/:path*%2FDockerfile",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to scan Dockerfile",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/Dockerfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to scan Dockerfile",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2FDockerfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to check if there's any ignore rules or existing patches",
@@ -1037,9 +1361,7 @@
       "valid": [
         {
           "header": "accept",
-          "values": [
-            "application/vnd.github.v4.sha"
-          ]
+          "values": ["application/vnd.github.v4.sha"]
         }
       ]
     },
@@ -1130,11 +1452,6 @@
           "//": "query to find open snyk pull requests, allowing auto dependency upgrade pull requests to open no more than a limited amount of pull requests",
           "path": "query",
           "regex": "{\\s*search\\(\\s*query: \"repo:[a-zA-Z0-9-_.]+\\/[a-zA-Z0-9-_.]+ is:pr state:[a-zA-Z]+ head:snyk-\\s*(is:[a-zA-Z]+)?\", type: ISSUE, last: [0-9]+\\s*\\)\\s*{\\s*edges {\\s*node {\\s*\\.\\.\\. on PullRequest {\\s*url\\s*title\\s*createdAt\\s*headRefName\\s*state\\s*mergeable\\s*body\\s*repository\\s*{\\s*name\\s*}\\s*}\\s*}\\s*}\\s*}\\s*rateLimit\\s*{\\s*limit\\s*cost\\s*remaining\\s*resetAt\\s*}\\s*}\\s*"
-        },
-        {
-          "//": "query to get file SHA",
-          "path": "query",
-          "regex": "{\\s*repository\\(\\s*owner:\\s*\"[a-zA-Z0-9-_.]+\",\\s*name:\\s*\"[a-zA-Z0-9-_.]+\"\\)\\s*{\\s*object\\(\\s*expression:\\s*\"[a-zA-Z0-9-_./]+:[a-zA-Z0-9-_./]+\"\\)\\s*{\\s*\\.\\.\\.\\s*on\\s*Blob\\s*{\\s*oid\\,\\s*}\\s*}\\s*}\\s*}\\s*"
         }
       ]
     }

--- a/test/unit/filters.test.ts
+++ b/test/unit/filters.test.ts
@@ -605,6 +605,26 @@ describe('filters', () => {
       );
     });
   });
+
+  describe('for GHE', () => {
+    const rules = JSON.parse(loadFixture(path.join('accept', 'ghe.json')));
+    const filter = Filters(rules.private);
+
+    it('should allow valid encoded /Dockerfile path to manifest', () => {
+      const url =
+        '/repos/repo-owner/repo-name/contents/%2Fsome-path%2FDockerfile?ref=master';
+      filter(
+        {
+          url,
+          method: 'GET',
+        },
+        (error, res) => {
+          expect(error).toBeNull();
+          expect(res.url).toMatch(url);
+        },
+      );
+    });
+  });
 });
 
 describe('with auth', () => {


### PR DESCRIPTION
A [customer ticket](https://snyk.zendesk.com/agent/tickets/7256) has lead to this potential solution where the current GHE `accept.json` template has suggested an invalid uri for scanning a Dockerfile with an encoded path.
This PR removes the extra irrelevant `2F` from the rule's uri path.