### PR TITLE
feat: use less vulnerable node:12-buster-slim

### DIFF
--- a/dockerfiles/azure-repos/Dockerfile
+++ b/dockerfiles/azure-repos/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-slim
+FROM node:12-buster-slim
 
 LABEL maintainer="Snyk Ltd"
 


### PR DESCRIPTION
#### What does this PR do?
Use less vulnerable base `node:12-buster-slim` image instead `node:12-slim`

