### PR TITLE
feat: Support PR statuses for brokered Azure Repos

### DIFF
--- a/client-templates/azure-repos/accept.json.sample
+++ b/client-templates/azure-repos/accept.json.sample
@@ -199,6 +199,16 @@
       }
     },
     {
+      "//": "update status of given pull request",
+      "method": "POST",
+      "path": "/:owner/_apis/git/repositories/:repo/pullRequests/:pullRef/statuses",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
+    },
+    {
       "//": "find PR for given repository",
       "method": "GET",
       "path": "/:owner/_apis/git/repositories/:repo/pullrequests",


### PR DESCRIPTION
This patch updates the Azure Repos sample accept.json to include a new rule that allows post PR statuses. Until now, Snyk only supported commit statuses, which are different from PR statuses for Azure Repos

See https://github.com/snyk/azure-repos-agent/pull/219 for the implementation of this endpoint in the Azure Repos agent