### PR TITLE
feat: Add container registry agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,47 @@ ENV JIRA_HOSTNAME       your.jira.domain.com
 ENV PORT                8000
 ```
 
+### Container registry agent
+
+To use the Broker client with a container registry agent deployment, run `docker
+pull snyk/broker:container-registry-agent`. The following environment variables
+are mandatory to configure the Broker client:
+
+- `BROKER_TOKEN` - The Snyk Broker token, obtained from your Container registry integration settings (app.snyk.io).
+- `BROKER_CLIENT_URL` - The URL of your broker client (including scheme and - port) used by container registry agent to call back to Snyk.
+- `CR_AGENT_URL` - The hostname of your container registry agent.
+- `CR_CREDENTIALS` - Base64-encoded credentials json used by agent to access container registry.
+- `PORT` - The local port at which the Broker client accepts connections. Default is 7341.
+
+#### Command-line arguments
+
+You can run the docker container by providing the relevant configuration:
+
+```console
+docker run --restart=always \
+           -p 8000:8000 \
+           -e BROKER_TOKEN=secret-broker-token \
+           -e BROKER_CLIENT_URL=http://my.broker.client:8000 \
+           -e CR_AGENT_URL=agent-url \
+           -e CR_CREDENTIALS=base64-encoded-credentials-json \
+           -e PORT=8000 \
+       snyk/broker:container-registry-agent
+```
+
+#### Derived docker image
+
+Another option is to build your own docker image and override relevant environment variables:
+
+```dockerfile
+FROM snyk/broker:container-registry-agent
+
+ENV BROKER_TOKEN          secret-broker-token
+ENV BROKER_CLIENT_URL     http://my.broker.client:8000
+ENV CR_AGENT_URL          agent-hostname
+ENV CR_CREDENTIALS        base64-encoded-credentials-json
+ENV PORT                  8000
+```
+
 ### Monitoring
 
 #### Healthcheck

--- a/client-templates/container-registry-agent/.env.sample
+++ b/client-templates/container-registry-agent/.env.sample
@@ -1,0 +1,22 @@
+# Your unique broker identifier, copied from snyk.io org settings page
+BROKER_TOKEN=<broker-token>
+
+# The URL of the Snyk broker server
+BROKER_SERVER_URL=https://broker.snyk.io
+
+# The path for the broker's internal healthcheck URL
+BROKER_HEALTHCHECK_PATH=/healthcheck
+
+# The URL of your broker client (including scheme and port), used by container
+# registry agent to call back to Snyk through brokered connection
+BROKER_CLIENT_URL="https://<broker-client-host>:<broker-client-port>"
+
+# The URL of your container registry agent
+CR_AGENT_URL=<agent-host>:<agent-port>
+
+# Base64-encoded credentials json used to access container registry via agent
+CR_CREDENTIALS=<base64-encoded-credentials-json>
+
+# Detailed accept rules that allow Snyk to make API calls to container registry
+# agent, and agent to call back to Snyk
+ACCEPT=accept.json

--- a/client-templates/container-registry-agent/accept.json.sample
+++ b/client-templates/container-registry-agent/accept.json.sample
@@ -1,0 +1,62 @@
+{
+  "public": [
+  {
+    "//": "image scan callback (v1)",
+    "method": "POST",
+      "path": "/api/v1/import/app"
+  },
+  {
+    "//": "image scan callback (v2)",
+    "method": "POST",
+    "path": "/api/v2/import/done"
+  },
+  {
+    "//": "image scan callback (v2)",
+    "method": "POST",
+    "path": "/api/v2/import/result"
+  }
+  ],
+  "private": [
+  {
+    "method": "GET",
+    "path": "/healthcheck",
+    "origin": "${CR_AGENT_URL}"
+  },
+  {
+    "//": "validates credentials with connection to container registry",
+    "method": "GET",
+    "path": "/validate-credentials",
+    "origin": "${CR_AGENT_URL}"
+  },
+  {
+    "//": "returns image state id used in recurring or re-tests",
+    "method": "GET",
+    "path": "/get-state-identifier",
+    "origin": "${CR_AGENT_URL}"
+  },
+  {
+    "//": "lists repositories in container registry",
+    "method": "GET",
+    "path": "/list",
+    "origin": "${CR_AGENT_URL}"
+  },
+  {
+    "//": "lists tags/images in a repository",
+    "method": "GET",
+    "path": "/list/:repo",
+    "origin": "${CR_AGENT_URL}"
+  },
+  {
+    "//": "accepts image scan requests (v1)",
+    "method": "POST",
+    "path": "/discover",
+    "origin": "${CR_AGENT_URL}"
+  },
+  {
+    "//": "accepts image scan requests (v2)",
+    "method": "POST",
+    "path": "/scan",
+    "origin": "${CR_AGENT_URL}"
+  }
+  ]
+}

--- a/dockerfiles/container-registry-agent/Dockerfile
+++ b/dockerfiles/container-registry-agent/Dockerfile
@@ -1,0 +1,43 @@
+FROM node:12-buster-slim
+
+MAINTAINER Snyk Ltd
+
+RUN npm install --global snyk-broker
+
+RUN apt-get update && apt-get install -y ca-certificates
+
+# Don't run as root
+WORKDIR /home/node
+USER node
+
+# Generate default accept filter
+RUN broker init container-registry-agent
+
+
+
+######################################
+# Custom Broker Client configuration #
+# Redefine in derived Dockerfile,    #
+# or provide as runtime args `-e`    #
+######################################
+
+# Your unique broker identifier, copied from snyk.io org settings page
+ENV BROKER_TOKEN <broker-token>
+
+# The URL of your broker client (including scheme and port), used by container
+# registry agent to call back to Snyk through brokered connection
+ENV BROKER_CLIENT_URL "https://<broker-client-host>:<broker-client-port>"
+
+# The URL of your container registry agent
+ENV CR_AGENT_URL <agent-host>:<agent-port>
+
+# Base64-encoded credentials json used to access container registry via agent
+ENV CR_CREDENTIALS <base64-encoded-credentials-json>
+
+# The port used by the broker client to accept internal connections
+# Default value is 7341
+# ENV PORT 7341
+
+EXPOSE $PORT
+
+CMD ["broker", "--verbose"]


### PR DESCRIPTION
Add broker support for container-registry-agent by providing:
* template: accept.json, env
* Dockerfile to build image
* README section

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules