### PR TITLE
fix: wrap websocket response handler to prevent broker crashing

### DIFF
--- a/lib/relay.js
+++ b/lib/relay.js
@@ -150,14 +150,23 @@ function requestHandler(filterRules) {
             .status(ioResponse.status)
             .set(ioResponse.headers);
 
-          // keep chunked http requests without content-length header
-          const isChunked =
-            undefsafe(ioResponse, 'headers.transfer-encoding') === 'chunked';
-          if (isChunked) {
-            httpResponse.write(ioResponse.body);
-            httpResponse.end();
-          } else {
-            httpResponse.send(ioResponse.body);
+          const encodingType = undefsafe(
+            ioResponse,
+            'headers.transfer-encoding',
+          );
+          try {
+            // keep chunked http requests without content-length header
+            if (encodingType === 'chunked') {
+              httpResponse.write(ioResponse.body);
+              httpResponse.end();
+            } else {
+              httpResponse.send(ioResponse.body);
+            }
+          } catch (err) {
+            logger.error(
+              { ...logContext, encodingType, err },
+              'error forwarding response',
+            );
           }
         },
       );
@@ -366,7 +375,9 @@ function responseHandler(filterRules, config, io) {
 }
 
 function isJson(responseHeaders) {
-  return responseHeaders['content-type'] ? responseHeaders['content-type'].includes('json') : false;
+  return responseHeaders['content-type']
+    ? responseHeaders['content-type'].includes('json')
+    : false;
 }
 
 function logResponse(logContext, status, response, config = null) {


### PR DESCRIPTION
This patch introduces wrapping sending websocket response back with `try..catch`.
This will help us mitigate the problem with unexpected error:
`TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of
type string or an instance of Buffer or Uint8Array. Received an instance of Object`

- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

