### PR TITLE
fix: add sanitization logic for artifactory url

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -50,6 +50,10 @@ function sanitise(raw) {
     raw = sanitiseConfigVariable(raw, 'AZURE_REPOS_TOKEN');
   }
 
+  if (config.ARTIFACTORY_URL) {
+    raw = sanitiseConfigVariable(raw, 'ARTIFACTORY_URL');
+  }
+
   return raw;
 }
 

--- a/test/unit/log.test.ts
+++ b/test/unit/log.test.ts
@@ -10,6 +10,8 @@ describe('log', () => {
     const jiraUser = (process.env.JIRA_USERNAME = 'JRA_USER');
     const jiraPass = (process.env.JIRA_PASSWORD = 'JRA_PASS');
     const azureReposToken = (process.env.AZURE_REPOS_TOKEN = 'AZURE_TOKEN');
+    const artifactoryUrl = (process.env.ARTIFACTORY_URL =
+      'http://basic:auth@artifactory.com');
 
     const log = require('../../lib/log');
 
@@ -22,11 +24,13 @@ describe('log', () => {
       bbPass,
       jiraUser,
       jiraPass,
+      artifactoryUrl,
     ].join();
     const sanitizedTokens =
       '${BROKER_TOKEN},${GITHUB_TOKEN},${GITLAB_TOKEN},${AZURE_REPOS_TOKEN}';
     const sanitizedBitBucket = '${BITBUCKET_USERNAME},${BITBUCKET_PASSWORD}';
     const sanitizedJira = '${JIRA_USERNAME},${JIRA_PASSWORD}';
+    const sanitizedArtifactory = '${ARTIFACTORY_URL}';
 
     // setup logger output capturing
     const logs: string[] = [];
@@ -59,10 +63,12 @@ describe('log', () => {
     expect(logged).not.toMatch(jiraUser);
     expect(logged).not.toMatch(jiraPass);
     expect(logged).not.toMatch(azureReposToken);
+    expect(logged).not.toMatch(artifactoryUrl);
 
     // assert sensitive data is masked
     expect(logged).toMatch(sanitizedBitBucket);
     expect(logged).toMatch(sanitizedTokens);
     expect(logged).toMatch(sanitizedJira);
+    expect(logged).toMatch(sanitizedArtifactory);
   });
 });


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This patch needs to prevent logging of artifactory url, which might contain basic auth credentials.

