### PR TITLE
fix: artifactory systmecheck endpoint

### DIFF
--- a/client-templates/artifactory/.env.sample
+++ b/client-templates/artifactory/.env.sample
@@ -21,3 +21,4 @@ RES_BODY_URL_SUB=http://<yourdomain.artifactory.com>/artifactory
 
 # Artifactory validation url, checked by broker client systemcheck endpoint
 BROKER_CLIENT_VALIDATION_URL=https://$ARTIFACTORY_URL/api/system/ping
+BROKER_CLIENT_VALIDATION_JSON_DISABLED=true

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -49,6 +49,7 @@ module.exports = ({ port = null, config = {}, filters = {} }) => {
       config.brokerClientValidationMethod || 'GET';
     const brokerClientValidationTimeoutMs =
       config.brokerClientValidationTimeoutMs || 5000;
+    const isJsonResponse = !config.brokerClientValidationJsonDisabled;
 
     const data = {
       brokerClientValidationUrl: logger.sanitise(
@@ -79,7 +80,7 @@ module.exports = ({ port = null, config = {}, filters = {} }) => {
         headers: validationRequestHeaders,
         method: brokerClientValidationMethod,
         timeout: brokerClientValidationTimeoutMs,
-        json: true,
+        json: isJsonResponse,
         agentOptions: {
           ca: config.caCert, // Optional CA cert
         },


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This patch fixing 406 error of `/api/system/ping` endpoint. It returns `text/plain` response
and not allow to pass `application/json` header.

