### PR TITLE
fix: container registry agent list tags path

### DIFF
--- a/client-templates/container-registry-agent/accept.json.sample
+++ b/client-templates/container-registry-agent/accept.json.sample
@@ -43,7 +43,7 @@
   {
     "//": "lists tags/images in a repository",
     "method": "GET",
-    "path": "/list/:repo",
+    "path": "/list/*",
     "origin": "${CR_AGENT_URL}"
   },
   {


### PR DESCRIPTION
- [X] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adjust the list tags path to allow repo paths that contain slashes. This is required to support Harbor CR in a brokered environment.

