### PR TITLE
Add :pullRef (PR ID) to path for updating fix pr

### DIFF
--- a/client-templates/azure-repos/accept.json.sample
+++ b/client-templates/azure-repos/accept.json.sample
@@ -235,7 +235,7 @@
     {
       "//": "update existing PR in given repository",
       "method": "PATCH",
-      "path": "/:owner/_apis/git/repositories/:repo/pullrequests",
+      "path": "/:owner/_apis/git/repositories/:repo/pullrequests/:pullRef",
       "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
       "auth": {
         "scheme": "basic",


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Fixes the rule which allows for Fix PRs to be updated in Azure Repos.
It was missing a bit to allow for the PR ID.
The URLs for this API look like: `<base-url...>/<project-name>/_apis/git/repositories/<repo>/pullrequests/<pr-id>`

So we need to account for the `/<pr-id>` part.
