### PR TITLE
feat: update all agent dockerfiles with new remediated image

### DIFF
--- a/dockerfiles/artifactory/Dockerfile
+++ b/dockerfiles/artifactory/Dockerfile
@@ -1,19 +1,35 @@
-FROM node:12-buster-slim
+FROM snyk/ubuntu as base
 
 MAINTAINER Snyk Ltd
 
-RUN npm install --global snyk-broker
+USER root
+
+RUN apt update && apt install -y make python gcc
 
 RUN apt-get update && apt-get install -y ca-certificates
 
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+ENV PATH=$PATH:/home/node/.npm-global/bin 
+
+RUN npm install --global snyk-broker 
+
+
+
+FROM snyk/ubuntu
+
+ENV PATH=$PATH:/home/node/.npm-global/bin 
+
+COPY --from=base /home/node/.npm-global /home/node/.npm-global
+
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
 # Don't run as root
 WORKDIR /home/node
-USER node
+USER node 
 
 # Generate default accept filter
 RUN broker init artifactory
-
-
 
 ######################################
 # Custom Broker Client configuration #

--- a/dockerfiles/azure-repos/Dockerfile
+++ b/dockerfiles/azure-repos/Dockerfile
@@ -1,14 +1,32 @@
-FROM node:12-buster-slim
+FROM snyk/ubuntu as base
 
-LABEL maintainer="Snyk Ltd"
+MAINTAINER Snyk Ltd
 
-RUN npm install --global snyk-broker
+USER root
+
+RUN apt update && apt install -y make python gcc
 
 RUN apt-get update && apt-get install -y ca-certificates
 
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+ENV PATH=$PATH:/home/node/.npm-global/bin 
+
+RUN npm install --global snyk-broker 
+
+
+
+FROM snyk/ubuntu
+
+ENV PATH=$PATH:/home/node/.npm-global/bin 
+
+COPY --from=base /home/node/.npm-global /home/node/.npm-global
+
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
 # Don't run as root
 WORKDIR /home/node
-USER node
+USER node 
 
 # Generate default accept filter
 RUN broker init azure-repos

--- a/dockerfiles/bitbucket-server/Dockerfile
+++ b/dockerfiles/bitbucket-server/Dockerfile
@@ -1,19 +1,35 @@
-FROM node:12-buster-slim
+FROM snyk/ubuntu as base
 
 MAINTAINER Snyk Ltd
 
-RUN npm install --global snyk-broker
+USER root
+
+RUN apt update && apt install -y make python gcc
 
 RUN apt-get update && apt-get install -y ca-certificates
 
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+ENV PATH=$PATH:/home/node/.npm-global/bin 
+
+RUN npm install --global snyk-broker 
+
+
+
+FROM snyk/ubuntu
+
+ENV PATH=$PATH:/home/node/.npm-global/bin 
+
+COPY --from=base /home/node/.npm-global /home/node/.npm-global
+
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
 # Don't run as root
 WORKDIR /home/node
-USER node
+USER node 
 
 # Generate default accept filter
 RUN broker init bitbucket-server
-
-
 
 ######################################
 # Custom Broker Client configuration #

--- a/dockerfiles/container-registry-agent/Dockerfile
+++ b/dockerfiles/container-registry-agent/Dockerfile
@@ -1,19 +1,35 @@
-FROM node:12-buster-slim
+FROM snyk/ubuntu as base
 
 MAINTAINER Snyk Ltd
 
-RUN npm install --global snyk-broker
+USER root
+
+RUN apt update && apt install -y make python gcc
 
 RUN apt-get update && apt-get install -y ca-certificates
 
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+ENV PATH=$PATH:/home/node/.npm-global/bin 
+
+RUN npm install --global snyk-broker 
+
+
+
+FROM snyk/ubuntu
+
+ENV PATH=$PATH:/home/node/.npm-global/bin 
+
+COPY --from=base /home/node/.npm-global /home/node/.npm-global
+
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
 # Don't run as root
 WORKDIR /home/node
-USER node
+USER node 
 
 # Generate default accept filter
 RUN broker init container-registry-agent
-
-
 
 ######################################
 # Custom Broker Client configuration #

--- a/dockerfiles/github-com/Dockerfile
+++ b/dockerfiles/github-com/Dockerfile
@@ -1,19 +1,35 @@
-FROM node:12-buster-slim
+FROM snyk/ubuntu as base
 
 MAINTAINER Snyk Ltd
 
-RUN npm install --global snyk-broker
+USER root
+
+RUN apt update && apt install -y make python gcc
 
 RUN apt-get update && apt-get install -y ca-certificates
 
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+ENV PATH=$PATH:/home/node/.npm-global/bin 
+
+RUN npm install --global snyk-broker 
+
+
+
+FROM snyk/ubuntu
+
+ENV PATH=$PATH:/home/node/.npm-global/bin 
+
+COPY --from=base /home/node/.npm-global /home/node/.npm-global
+
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
 # Don't run as root
 WORKDIR /home/node
-USER node
+USER node 
 
 # Generate default accept filter
 RUN broker init github-com
-
-
 
 ######################################
 # Custom Broker Client configuration #

--- a/dockerfiles/github-enterprise/Dockerfile
+++ b/dockerfiles/github-enterprise/Dockerfile
@@ -1,19 +1,35 @@
-FROM node:12-buster-slim
+FROM snyk/ubuntu as base
 
 MAINTAINER Snyk Ltd
 
-RUN npm install --global snyk-broker
+USER root
+
+RUN apt update && apt install -y make python gcc
 
 RUN apt-get update && apt-get install -y ca-certificates
 
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+ENV PATH=$PATH:/home/node/.npm-global/bin 
+
+RUN npm install --global snyk-broker 
+
+
+
+FROM snyk/ubuntu
+
+ENV PATH=$PATH:/home/node/.npm-global/bin 
+
+COPY --from=base /home/node/.npm-global /home/node/.npm-global
+
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
 # Don't run as root
 WORKDIR /home/node
-USER node
+USER node 
 
 # Generate default accept filter
 RUN broker init github-enterprise
-
-
 
 ######################################
 # Custom Broker Client configuration #

--- a/dockerfiles/gitlab/Dockerfile
+++ b/dockerfiles/gitlab/Dockerfile
@@ -1,19 +1,35 @@
-FROM node:12-buster-slim
+FROM snyk/ubuntu as base
 
 MAINTAINER Snyk Ltd
 
-RUN npm install --global snyk-broker
+USER root
+
+RUN apt update && apt install -y make python gcc
 
 RUN apt-get update && apt-get install -y ca-certificates
 
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+ENV PATH=$PATH:/home/node/.npm-global/bin 
+
+RUN npm install --global snyk-broker 
+
+
+
+FROM snyk/ubuntu
+
+ENV PATH=$PATH:/home/node/.npm-global/bin 
+
+COPY --from=base /home/node/.npm-global /home/node/.npm-global
+
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
 # Don't run as root
 WORKDIR /home/node
-USER node
+USER node 
 
 # Generate default accept filter
 RUN broker init gitlab
-
-
 
 ######################################
 # Custom Broker Client configuration #

--- a/dockerfiles/jira/Dockerfile
+++ b/dockerfiles/jira/Dockerfile
@@ -1,19 +1,35 @@
-FROM node:12-buster-slim
+FROM snyk/ubuntu as base
 
 MAINTAINER Snyk Ltd
 
-RUN npm install --global snyk-broker
+USER root
+
+RUN apt update && apt install -y make python gcc
 
 RUN apt-get update && apt-get install -y ca-certificates
 
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+ENV PATH=$PATH:/home/node/.npm-global/bin 
+
+RUN npm install --global snyk-broker 
+
+
+
+FROM snyk/ubuntu
+
+ENV PATH=$PATH:/home/node/.npm-global/bin 
+
+COPY --from=base /home/node/.npm-global /home/node/.npm-global
+
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
 # Don't run as root
 WORKDIR /home/node
-USER node
+USER node 
 
 # Generate default accept filter
 RUN broker init jira
-
-
 
 ######################################
 # Custom Broker Client configuration #

--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -1,0 +1,55 @@
+# This image is the base image that all other broker clients are built on top of.
+# The following image is reachable through the snyk/ubuntu:latest image in DockerHub.
+# Note that there's no need to build it; All broker client Dockerfiles use the snyk/ubuntu:latest.
+
+FROM ubuntu 
+
+RUN groupadd --gid 1000 node \
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node \
+  && apt update && apt upgrade -y && apt install gpg curl xz-utils -y
+
+ENV NODE_VERSION 12.20.1
+
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+  amd64) ARCH='x64';; \
+  ppc64el) ARCH='ppc64le';; \
+  s390x) ARCH='s390x';; \
+  arm64) ARCH='arm64';; \
+  armhf) ARCH='armv7l';; \
+  i386) ARCH='x86';; \
+  *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  # gpg keys listed at https://github.com/nodejs/node#release-keys
+  && set -ex \
+  && for key in \
+  4ED778F539E3634C779C87C6D7062848A1AB005C \
+  94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+  1C050899334244A8AF75E53792EF661D867B9DFA \
+  71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+  8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+  C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+  C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
+  DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+  A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+  108F52B48DB57BB0CC439B2997B01419BD92F80A \
+  B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+  ; do \
+  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+  gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+  gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  # smoke tests
+  && node --version \
+  && npm --version
+
+RUN apt remove gpg curl xz-utils libsqlite3-0 -y && apt autoremove -y --purge
+
+USER node


### PR DESCRIPTION
Updates all dockerfiles to use base image with a reduced vuln count.

The update includes a new much remediated image (built on top of an ubuntu image) vs. the original image in use. We assessed the vulns in both images and determined they can not be exploited when used to run the broker.

![image (12)](https://user-images.githubusercontent.com/12063304/105866514-be0f4080-5ffc-11eb-974a-e1dacd4f6b81.png)