### PR TITLE
feat: add gradle lockfile in client templates

### DIFF
--- a/client-templates/azure-repos/accept.json.sample
+++ b/client-templates/azure-repos/accept.json.sample
@@ -104,6 +104,8 @@
             "**%2Frequirements%2F*.txt",
             "**/build.gradle",
             "**%2Fbuild.gradle",
+            "**/gradle.lockfile",
+            "**%2Fgradle.lockfile",
             "**/build.sbt",
             "**%2Fbuild.sbt",
             "**/.snyk",

--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -263,6 +263,28 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/gradle.lockfile",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fgradle.lockfile",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/projects/:project/repos/:repo/browse*/gradle.properties",
       "origin": "https://${BITBUCKET_API}",
       "auth": {

--- a/client-templates/github-com/accept.json.sample
+++ b/client-templates/github-com/accept.json.sample
@@ -76,6 +76,14 @@
         },
         {
           "path": "commits.*.added.*",
+          "value": "gradle.lockfile"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "gradle.lockfile"
+        },
+        {
+          "path": "commits.*.added.*",
           "value": "gradle.properties"
         },
         {
@@ -581,6 +589,30 @@
       "//": "used to determine the full dependency tree",
       "method": "GET",
       "path": "/:name/:repo/:path*%2Fbuild.gradle",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/gradle.lockfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fgradle.lockfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/gradle.lockfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fgradle.lockfile",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
@@ -1302,6 +1334,30 @@
       "//": "used to update manifest or lock",
       "method": "PUT",
       "path": "/:name/:repo/:path*%2Fbuild.gradle",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/gradle.lockfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fgradle.lockfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/gradle.lockfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fgradle.lockfile",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {

--- a/client-templates/github-enterprise/accept.json.sample
+++ b/client-templates/github-enterprise/accept.json.sample
@@ -76,6 +76,14 @@
         },
         {
           "path": "commits.*.added.*",
+          "value": "gradle.lockfile"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "gradle.lockfile"
+        },
+        {
+          "path": "commits.*.added.*",
           "value": "gradle.properties"
         },
         {
@@ -478,6 +486,18 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/gradle.lockfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fgradle.lockfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/repos/:name/:repo/contents/:path*/gradle.properties",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
@@ -833,6 +853,18 @@
       "//": "used to update manifest or lock",
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2Fbuild.gradle",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/gradle.lockfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fgradle.lockfile",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {

--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -161,6 +161,18 @@
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/gradle.lockfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fgradle.lockfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
       "path": "/api/v4/projects/:project/repository/files*/gradle.properties",
       "origin": "https://${GITLAB}"
     },
@@ -449,6 +461,8 @@
             "**%2Frequirements%2F*.txt",
             "**/build.gradle",
             "**%2Fbuild.gradle",
+            "**/gradle.lockfile",
+            "**%2Fgradle.lockfile",
             "**/build.sbt",
             "**%2Fbuild.sbt",
             "**/.snyk",
@@ -582,6 +596,18 @@
       "//": "used to create manifest file",
       "method": "POST",
       "path": "/api/v4/projects/:project/repository/files*%2Fbuild.gradle",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/gradle.lockfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2Fgradle.lockfile",
       "origin": "https://${GITLAB}"
     },
     {
@@ -861,6 +887,8 @@
             "**%2F*req*.txt",
             "**/build.gradle",
             "**%2Fbuild.gradle",
+            "**/gradle.lockfile",
+            "**%2Fgradle.lockfile",
             "**/build.sbt",
             "**%2Fbuild.sbt",
             "**/.snyk",
@@ -993,6 +1021,18 @@
       "//": "used to update manifest file",
       "method": "PUT",
       "path": "/api/v4/projects/:project/repository/files*%2Fbuild.gradle",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/gradle.lockfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2Fgradle.lockfile",
       "origin": "https://${GITLAB}"
     },
     {
@@ -1272,6 +1312,8 @@
             "**%2F*req*.txt",
             "**/build.gradle",
             "**%2Fbuild.gradle",
+            "**/gradle.lockfile",
+            "**%2Fgradle.lockfile",
             "**/build.sbt",
             "**%2Fbuild.sbt",
             "**/.snyk",


### PR DESCRIPTION
Add `gradle.lockfile` sample in all SCM integrations' client-templates `accept.json.sample`
files, in order to enable customers using broker of successfully scan
their gradle projects containing lockfiles.