### PR TITLE
feat: add dockerfile update in client templates

### DIFF
--- a/client-templates/azure-repos/accept.json.sample
+++ b/client-templates/azure-repos/accept.json.sample
@@ -139,7 +139,9 @@
             "**/go.mod",
             "**%2Fgo.mod",
             "**/go.sum",
-            "**%2Fgo.sum"
+            "**%2Fgo.sum",
+            "**/Dockerfile",
+            "**%2FDockerfile"
           ]
         },
         {

--- a/client-templates/github-com/accept.json.sample
+++ b/client-templates/github-com/accept.json.sample
@@ -1841,6 +1841,30 @@
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
+      "//": "used to update Dockerfile",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/Dockerfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update Dockerfile",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2FDockerfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update Dockerfile",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/Dockerfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update Dockerfile",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2FDockerfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
       "//": "used to write or update ignore rules or existing patches",
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/.snyk",

--- a/client-templates/github-enterprise/accept.json.sample
+++ b/client-templates/github-enterprise/accept.json.sample
@@ -760,6 +760,30 @@
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
+      "//": "used to scan Dockerfile",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/Dockerfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to scan Dockerfile",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FDockerfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to scan Dockerfile",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/Dockerfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to scan Dockerfile",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2FDockerfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
       "//": "used to update manifest or lock",
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*/package.json",
@@ -1141,18 +1165,6 @@
       "//": "used to write or update ignore rules or existing patches",
       "method": "PUT",
       "path": "/repos/:name/:repo/contents/:path*%2F.snyk",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
-    },
-    {
-      "//": "used to scan Dockerfile",
-      "method": "GET",
-      "path": "/repos/:name/:repo/contents/:path*/Dockerfile",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
-    },
-    {
-      "//": "used to scan Dockerfile",
-      "method": "GET",
-      "path": "/repos/:name/:repo/contents/:path*%2FDockerfile",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {

--- a/client-templates/github-enterprise/accept.json.sample
+++ b/client-templates/github-enterprise/accept.json.sample
@@ -1156,6 +1156,30 @@
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
+      "//": "used to update Dockerfile",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/Dockerfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update Dockerfile",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2FDockerfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update Dockerfile",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/Dockerfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update Dockerfile",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2FDockerfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
       "//": "used to check if there's any ignore rules or existing patches",
       "method": "GET",
       "path": "/repos/:name/:repo/contents/:path*/.snyk",

--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -851,6 +851,18 @@
       "origin": "https://${GITLAB}"
     },
     {
+      "//": "used to create Dockerfile",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/Dockerfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create Dockerfile",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2FDockerfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
       "//": "used to create ignore rules or patches",
       "method": "POST",
       "path": "/api/v4/projects/:project/repository/files*/.snyk",
@@ -1273,6 +1285,18 @@
       "//": "used to update manifest file",
       "method": "PUT",
       "path": "/api/v4/projects/:project/repository/files*%2Fgo.sum",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update Dockerfile",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/Dockerfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update Dockerfile",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2FDockerfile",
       "origin": "https://${GITLAB}"
     },
     {


### PR DESCRIPTION
#### What does this PR do?

* Add `Dockerfile` update sample in all SCM integration' client-templates `accept.json.sample` files, in order to enable customers using broker to successfully update their Dockerfiles using Dockerfile Fix PR.

* Add `Dockerfile` get sample in GitHub Enterprise client-templates `accept.json.sample` file, in order to enable customers using broker to successfully scan their Dockerfiles.

#### SCM integration
* Azure Repos
* Bitbucket Server
* GitHub Com
* GitHub Enterprise
* GitLab