### PR TITLE
feat: internal broker url for rewrites

### DIFF
--- a/lib/replace-vars.js
+++ b/lib/replace-vars.js
@@ -11,13 +11,20 @@ function replace(input, source) {
 }
 
 function replaceUrlPartialChunk(chunk, prevPartial, config) {
-  const replaceRegExp = new RegExp(config.RES_BODY_URL_SUB, 'g');
-  const replaceWith = `${config.BROKER_SERVER_URL}/broker/${config.BROKER_TOKEN}`;
+  // 1/ make sure no protocol is present
+  const protocolFreeURI = config.RES_BODY_URL_SUB.replace(/(^\w+:|^)\/\//, '');
+
+  // 2/ create a regex to match all feasible protocols
+  const replaceRegExp = new RegExp(`(\\w+:)//${protocolFreeURI}`, 'g');
+
+  // 3/ create replacement string
+  const replaceWith = `http://internal-broker-server/broker/${config.BROKER_TOKEN}`;
 
   if (prevPartial) {
     chunk = prevPartial + chunk;
   }
 
+  // 4/ replace
   chunk = chunk.replace(replaceRegExp, replaceWith);
 
   const lastStringInChunk = chunk.split('"').pop();

--- a/test/unit/replace-vars.test.ts
+++ b/test/unit/replace-vars.test.ts
@@ -8,9 +8,11 @@ describe('replacePartialChunk', () => {
   };
 
   it('Replaces string completely in chunk', () => {
-    const chunk = 'Replace the "http://replac.ed/get/some/artifact" url please.';
+    const chunk =
+      'Replace the "http://replac.ed/get/some/artifact" url please.';
     const prevPartial = null;
-    const expectedChunk = 'Replace the "broker.com/broker/a-tok-en/get/some/artifact" url please.';
+    const expectedChunk =
+      'Replace the "http://internal-broker-server/broker/a-tok-en/get/some/artifact" url please.';
 
     expect(replaceUrlPartialChunk(chunk, prevPartial, config)).toEqual({
       newChunk: expectedChunk,
@@ -32,7 +34,8 @@ describe('replacePartialChunk', () => {
   it('Replaces partial at start of chunk if matched with prevPartial', () => {
     const chunk = 'c.ed/get/some/artifact" url please.';
     const prevPartial = 'http://repla';
-    const expectedChunk = 'broker.com/broker/a-tok-en/get/some/artifact" url please.';
+    const expectedChunk =
+      'http://internal-broker-server/broker/a-tok-en/get/some/artifact" url please.';
 
     expect(replaceUrlPartialChunk(chunk, prevPartial, config)).toEqual({
       newChunk: expectedChunk,
@@ -50,5 +53,4 @@ describe('replacePartialChunk', () => {
       partial: undefined,
     });
   });
-
 });


### PR DESCRIPTION
- [x] Ready for review

#### What does this PR do?
Allow usage of internal domain name for snyk-hosted broker server
>This should come AFTER the ops pr https://github.com/snyk/ops/pull/3301 and BEFORE https://github.com/snyk/npm-deps/pull/427
