### PR TITLE
feat: support bigger payloads (broker server)

### DIFF
--- a/lib/server/socket.js
+++ b/lib/server/socket.js
@@ -4,7 +4,11 @@ const logger = require('../log');
 const relay = require('../relay');
 
 module.exports = ({ server, filters, config }) => {
-  const io = new Primus(server, { transformer: 'engine.io', parser: 'EJSON' });
+  const io = new Primus(server, {
+    transformer: 'engine.io',
+    parser: 'EJSON',
+    maxLength: '20971520',
+  });
   io.plugin('emitter', Emitter);
 
   const connections = new Map();


### PR DESCRIPTION
The Broker Server has a limit of 10MB per socket payload. When sending a bigger payload, the socket connection is killed.

This PR increases that max payload size from 10MB to 20MB (issue was found with 15MB payloads).

More details about this parameter:
-`maxLength` in https://github.com/primus/primus#getting-started
-`maxHttpBufferSize` in https://github.com/socketio/engine.io#methods-1 - `how many bytes or characters a message can be, before closing the session`

