### PR TITLE
Feat: container registry agent support for DigitalOcean CR

### DIFF
--- a/bin/container-registry-agent/docker-entrypoint.sh
+++ b/bin/container-registry-agent/docker-entrypoint.sh
@@ -10,6 +10,9 @@ if [[ -z "$CR_CREDENTIALS" ]]; then
   if [[ "$CR_TYPE" == "ElasticCR" || "$CR_TYPE" == "ecr" ]]; then
     FORMAT='{"type":"%s","roleArn":"%s","extra":{"region":"%s","externalId":"%s"}}\n'
     JSON=$(printf "$FORMAT" "$CR_TYPE" "$CR_ROLE_ARN" "$CR_REGION" "$CR_EXTERNAL_ID")
+  elif [[ "$CR_TYPE" == "digitalocean-cr" ]]; then
+    FORMAT='{"type":"%s", "username":"%s", "password":"%s", "registryBase":"%s"}\n'
+    JSON=$(printf "$FORMAT" "$CR_TYPE" "$CR_TOKEN" "$CR_TOKEN" "$CR_BASE")
   else
     FORMAT='{"type":"%s", "username":"%s", "password":"%s", "registryBase":"%s"}\n'
     JSON=$(printf "$FORMAT" "$CR_TYPE" "$CR_USERNAME" "$CR_PASSWORD" "$CR_BASE")

--- a/test/bin/container-registry-agent/docker-entrypoint-test.sh
+++ b/test/bin/container-registry-agent/docker-entrypoint-test.sh
@@ -9,7 +9,7 @@ testCredentialsAreUnchangedIfAlreadySet() {
 
   . ../../bin/container-registry-agent/docker-entrypoint.sh
 
-  assertEquals "${CR_CREDENTIALS}" "already set"
+  assertEquals "already set" "${CR_CREDENTIALS}"
 }
 
 testEcrCredentialsSetup() {
@@ -22,7 +22,7 @@ testEcrCredentialsSetup() {
   . ../../bin/container-registry-agent/docker-entrypoint.sh
 
   EXPECTED='{"type":"ecr","roleArn":"arn:role:...","extra":{"region":"eu-west-3","externalId":"1234567890"}}'
-  assertEquals "$(echo ${CR_CREDENTIALS} | base64 -d)" "$EXPECTED"
+  assertEquals "$EXPECTED" "$(echo ${CR_CREDENTIALS} | base64 -d)"
 }
 
 testDigitalOceanCredentialsSetup() {
@@ -34,7 +34,7 @@ testDigitalOceanCredentialsSetup() {
   . ../../bin/container-registry-agent/docker-entrypoint.sh
 
   EXPECTED='{"type":"digitalocean-cr", "username":"token", "password":"token", "registryBase":"cr.com/my"}'
-  assertEquals  "$EXPECTED" "$(echo ${CR_CREDENTIALS} | base64 -d)"
+  assertEquals "$EXPECTED" "$(echo ${CR_CREDENTIALS} | base64 -d)"
 }
 
 testStandardCredentialsSetup() {
@@ -47,7 +47,7 @@ testStandardCredentialsSetup() {
   . ../../bin/container-registry-agent/docker-entrypoint.sh
 
   EXPECTED='{"type":"DockerHub", "username":"user", "password":"pass", "registryBase":"cr.com/my"}'
-  assertEquals "$(echo ${CR_CREDENTIALS} | base64 -d)" "$EXPECTED"
+  assertEquals "$EXPECTED" "$(echo ${CR_CREDENTIALS} | base64 -d)"
 }
 
 . ./shunit2

--- a/test/bin/container-registry-agent/docker-entrypoint-test.sh
+++ b/test/bin/container-registry-agent/docker-entrypoint-test.sh
@@ -25,6 +25,18 @@ testEcrCredentialsSetup() {
   assertEquals "$(echo ${CR_CREDENTIALS} | base64 -d)" "$EXPECTED"
 }
 
+testDigitalOceanCredentialsSetup() {
+  CR_TYPE="digitalocean-cr"
+  CR_TOKEN="token"
+  CR_BASE="cr.com/my"
+  unset CR_CREDENTIALS
+
+  . ../../bin/container-registry-agent/docker-entrypoint.sh
+
+  EXPECTED='{"type":"digitalocean-cr", "username":"token", "password":"token", "registryBase":"cr.com/my"}'
+  assertEquals  "$EXPECTED" "$(echo ${CR_CREDENTIALS} | base64 -d)"
+}
+
 testStandardCredentialsSetup() {
   CR_TYPE="DockerHub"
   CR_USERNAME="user"


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This is continuation of #328.

It adds support for newly added DigitalOcean CR, which has specific credentials format.

Additionally, order of args in test assertions is fixed in the last commit.