### PR TITLE
feat: add redirect rule to git client

### DIFF
--- a/client-templates/azure-repos/.env.sample
+++ b/client-templates/azure-repos/.env.sample
@@ -29,3 +29,13 @@ BROKER_HEALTHCHECK_PATH=/healthcheck
 
 # Azure validation url, checked by broker client systemcheck endpoint
 BROKER_CLIENT_VALIDATION_URL="https://$AZURE_REPOS_HOST/$AZURE_REPOS_ORG/_apis/git/repositories"
+
+# the host where the git server resides
+GIT_URL=$AZURE_REPOS_HOST
+
+# git credentials for cloning repos
+GIT_USERNAME=PAT
+GIT_PASSWORD=$AZURE_REPOS_TOKEN
+
+# the url of your snyk git client (including scheme and port).
+# GIT_CLIENT_URL=https://<snyk-git-client-host>:<snyk-git-client-port>

--- a/client-templates/azure-repos/accept.json.sample
+++ b/client-templates/azure-repos/accept.json.sample
@@ -255,6 +255,12 @@
         "scheme": "basic",
         "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
       }
+    },
+    {
+      "//": "used to redirect requests to snyk git client",
+      "method": "any",
+      "path": "/snykgit/*",
+      "origin": "${GIT_CLIENT_URL}"
     }
   ]
 }

--- a/client-templates/bitbucket-server/.env.sample
+++ b/client-templates/bitbucket-server/.env.sample
@@ -35,3 +35,13 @@ ACCEPT=accept.json
 
 # The path for the broker's internal healthcheck URL. Must start with a '/'.
 BROKER_HEALTHCHECK_PATH=/healthcheck
+
+# the host where the git server resides
+GIT_URL=$BITBUCKET
+
+# git credentials for cloning repos
+GIT_USERNAME=$BITBUCKET_USERNAME
+GIT_PASSWORD=$BITBUCKET_PASSWORD
+
+# the url of your snyk git client (including scheme and port).
+# GIT_CLIENT_URL=https://<snyk-git-client-host>:<snyk-git-client-port>

--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -974,6 +974,12 @@
         "username": "${BITBUCKET_USERNAME}",
         "password": "${BITBUCKET_PASSWORD}"
       }
+    },
+    {
+      "//": "used to redirect requests to snyk git client",
+      "method": "any",
+      "path": "/snykgit/*",
+      "origin": "${GIT_CLIENT_URL}"
     }
   ]
 }

--- a/client-templates/github-com/.env.sample
+++ b/client-templates/github-com/.env.sample
@@ -34,3 +34,13 @@ ACCEPT=accept.json
 
 # The path for the broker's internal healthcheck URL. Must start with a '/'.
 BROKER_HEALTHCHECK_PATH=/healthcheck
+
+# the host where the git server resides
+GIT_URL=$GITHUB
+
+# git credentials for cloning repos
+GIT_USERNAME=x-access-token
+GIT_PASSWORD=$GITHUB_TOKEN
+
+# the url of your snyk git client (including scheme and port).
+# GIT_CLIENT_URL=https://<snyk-git-client-host>:<snyk-git-client-port>

--- a/client-templates/github-com/accept.json.sample
+++ b/client-templates/github-com/accept.json.sample
@@ -1968,6 +1968,12 @@
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
+      "//": "used to redirect requests to snyk git client",
+      "method": "any",
+      "path": "/snykgit/*",
+      "origin": "${GIT_CLIENT_URL}"
+    },
+    {
       "//": "query graphql",
       "method": "POST",
       "path": "/graphql",

--- a/client-templates/github-enterprise/.env.sample
+++ b/client-templates/github-enterprise/.env.sample
@@ -31,3 +31,13 @@ ACCEPT=accept.json
 
 # The path for the broker's internal healthcheck URL. Must start with a '/'.
 BROKER_HEALTHCHECK_PATH=/healthcheck
+
+# the host where the git server resides
+GIT_URL=$GITHUB
+
+# git credentials for cloning repos
+GIT_USERNAME=x-access-token
+GIT_PASSWORD=$GITHUB_TOKEN
+
+# the url of your snyk git client (including scheme and port).
+# GIT_CLIENT_URL=https://<snyk-git-client-host>:<snyk-git-client-port>

--- a/client-templates/github-enterprise/accept.json.sample
+++ b/client-templates/github-enterprise/accept.json.sample
@@ -1296,6 +1296,12 @@
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
+      "//": "used to redirect requests to snyk git client",
+      "method": "any",
+      "path": "/snykgit/*",
+      "origin": "${GIT_CLIENT_URL}"
+    },
+    {
       "//": "query graphql",
       "method": "POST",
       "path": "/graphql",

--- a/client-templates/gitlab/.env.sample
+++ b/client-templates/gitlab/.env.sample
@@ -23,3 +23,13 @@ ACCEPT=accept.json
 
 # The path for the broker's internal healthcheck URL. Must start with a '/'.
 BROKER_HEALTHCHECK_PATH=/healthcheck
+
+# the host where the git server resides
+GIT_URL=$GITLAB
+
+# git credentials for cloning repos
+GIT_USERNAME=oauth2
+GIT_PASSWORD=$GITLAB_TOKEN
+
+# the url of your snyk git client (including scheme and port).
+# GIT_CLIENT_URL=https://<snyk-git-client-host>:<snyk-git-client-port>

--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -1454,6 +1454,12 @@
       "method": "GET",
       "path": "/api/v4/projects/:project/repository/commits/:sha",
       "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to redirect requests to snyk git client",
+      "method": "any",
+      "path": "/snykgit/*",
+      "origin": "${GIT_CLIENT_URL}"
     }
   ]
 }

--- a/dockerfiles/azure-repos/Dockerfile
+++ b/dockerfiles/azure-repos/Dockerfile
@@ -10,15 +10,15 @@ RUN apt-get update && apt-get install -y ca-certificates
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 
-ENV PATH=$PATH:/home/node/.npm-global/bin 
+ENV PATH=$PATH:/home/node/.npm-global/bin
 
-RUN npm install --global snyk-broker 
+RUN npm install --global snyk-broker
 
 
 
 FROM snyk/ubuntu
 
-ENV PATH=$PATH:/home/node/.npm-global/bin 
+ENV PATH=$PATH:/home/node/.npm-global/bin
 
 COPY --from=base /home/node/.npm-global /home/node/.npm-global
 
@@ -26,7 +26,7 @@ COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificat
 
 # Don't run as root
 WORKDIR /home/node
-USER node 
+USER node
 
 # Generate default accept filter
 RUN broker init azure-repos

--- a/dockerfiles/bitbucket-server/Dockerfile
+++ b/dockerfiles/bitbucket-server/Dockerfile
@@ -10,15 +10,15 @@ RUN apt-get update && apt-get install -y ca-certificates
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 
-ENV PATH=$PATH:/home/node/.npm-global/bin 
+ENV PATH=$PATH:/home/node/.npm-global/bin
 
-RUN npm install --global snyk-broker 
+RUN npm install --global snyk-broker
 
 
 
 FROM snyk/ubuntu
 
-ENV PATH=$PATH:/home/node/.npm-global/bin 
+ENV PATH=$PATH:/home/node/.npm-global/bin
 
 COPY --from=base /home/node/.npm-global /home/node/.npm-global
 
@@ -26,7 +26,7 @@ COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificat
 
 # Don't run as root
 WORKDIR /home/node
-USER node 
+USER node
 
 # Generate default accept filter
 RUN broker init bitbucket-server

--- a/dockerfiles/github-com/Dockerfile
+++ b/dockerfiles/github-com/Dockerfile
@@ -10,15 +10,15 @@ RUN apt-get update && apt-get install -y ca-certificates
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 
-ENV PATH=$PATH:/home/node/.npm-global/bin 
+ENV PATH=$PATH:/home/node/.npm-global/bin
 
-RUN npm install --global snyk-broker 
+RUN npm install --global snyk-broker
 
 
 
 FROM snyk/ubuntu
 
-ENV PATH=$PATH:/home/node/.npm-global/bin 
+ENV PATH=$PATH:/home/node/.npm-global/bin
 
 COPY --from=base /home/node/.npm-global /home/node/.npm-global
 
@@ -26,7 +26,7 @@ COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificat
 
 # Don't run as root
 WORKDIR /home/node
-USER node 
+USER node
 
 # Generate default accept filter
 RUN broker init github-com
@@ -50,7 +50,6 @@ ENV GITHUB_TOKEN <github-token>
 # The URL of your broker client (including scheme and port)
 # This will be used as the webhook payload URL coming in from GitHub
 # ENV BROKER_CLIENT_URL http://<broker.client.hostname>:$PORT
-
 
 EXPOSE $PORT
 

--- a/dockerfiles/github-enterprise/Dockerfile
+++ b/dockerfiles/github-enterprise/Dockerfile
@@ -10,15 +10,15 @@ RUN apt-get update && apt-get install -y ca-certificates
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 
-ENV PATH=$PATH:/home/node/.npm-global/bin 
+ENV PATH=$PATH:/home/node/.npm-global/bin
 
-RUN npm install --global snyk-broker 
+RUN npm install --global snyk-broker
 
 
 
 FROM snyk/ubuntu
 
-ENV PATH=$PATH:/home/node/.npm-global/bin 
+ENV PATH=$PATH:/home/node/.npm-global/bin
 
 COPY --from=base /home/node/.npm-global /home/node/.npm-global
 
@@ -26,7 +26,7 @@ COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificat
 
 # Don't run as root
 WORKDIR /home/node
-USER node 
+USER node
 
 # Generate default accept filter
 RUN broker init github-enterprise

--- a/dockerfiles/gitlab/Dockerfile
+++ b/dockerfiles/gitlab/Dockerfile
@@ -10,15 +10,15 @@ RUN apt-get update && apt-get install -y ca-certificates
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 
-ENV PATH=$PATH:/home/node/.npm-global/bin 
+ENV PATH=$PATH:/home/node/.npm-global/bin
 
-RUN npm install --global snyk-broker 
+RUN npm install --global snyk-broker
 
 
 
 FROM snyk/ubuntu
 
-ENV PATH=$PATH:/home/node/.npm-global/bin 
+ENV PATH=$PATH:/home/node/.npm-global/bin
 
 COPY --from=base /home/node/.npm-global /home/node/.npm-global
 
@@ -26,7 +26,7 @@ COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificat
 
 # Don't run as root
 WORKDIR /home/node
-USER node 
+USER node
 
 # Generate default accept filter
 RUN broker init gitlab
@@ -53,7 +53,6 @@ ENV GITLAB your.gitlab.server.hostname
 # The URL of your broker client (including scheme and port)
 # This will be used as the webhook payload URL coming in from Gitlab
 # ENV BROKER_CLIENT_URL http://<broker.client.hostname>:$PORT
-
 
 EXPOSE $PORT
 

--- a/lib/log.js
+++ b/lib/log.js
@@ -62,6 +62,18 @@ function sanitise(raw) {
     raw = sanitiseConfigVariable(raw, 'CR_AGENT_URL');
   }
 
+  if (config.GIT_USERNAME) {
+    raw = sanitiseConfigVariable(raw, 'GIT_USERNAME');
+  }
+
+  if (config.GIT_PASSWORD) {
+    raw = sanitiseConfigVariable(raw, 'GIT_PASSWORD');
+  }
+
+  if (config.GIT_CLIENT_URL) {
+    raw = sanitiseConfigVariable(raw, 'GIT_CLIENT_URL');
+  }
+
   return raw;
 }
 

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -17,18 +17,18 @@ module.exports = ({ config = {}, port = null, filters = {} }) => {
     config,
   });
 
-   // basic prometheus metrics	
-   const metricsMiddleware = promBundle({	
-    buckets: [0.1, 0.4, 0.7, 1, 1.5, 2, 2.5, 5, 10, 30],	
-    includeMethod: true,	
-    includePath: false,	
-    metricsPath: '/metrics',	
-    promClient: {	
-      collectDefaultMetrics: {	
-        timeout: 3000	
-      }	
-    },	
-  });	
+  // basic prometheus metrics
+  const metricsMiddleware = promBundle({
+    buckets: [0.1, 0.4, 0.7, 1, 1.5, 2, 2.5, 5, 10, 30],
+    includeMethod: true,
+    includePath: false,
+    metricsPath: '/metrics',
+    promClient: {
+      collectDefaultMetrics: {
+        timeout: 3000,
+      },
+    },
+  });
 
   app.use(metricsMiddleware);
 

--- a/test/fixtures/client/filters.json
+++ b/test/fixtures/client/filters.json
@@ -106,6 +106,13 @@
           "values": ["valid.accept.header"]
         }
       ]
+    },
+
+    {
+      "//": "used to redirect requests to snyk git client",
+      "method": "any",
+      "path": "/snykgit/*",
+      "origin": "${GIT_CLIENT_URL}"
     }
   ],
   "public": [

--- a/test/functional/server-client.test.js
+++ b/test/functional/server-client.test.js
@@ -42,13 +42,17 @@ test('proxy requests originating from behind the broker server', (t) => {
   process.env.ORIGIN_PORT = echoServerPort;
   process.env.USERNAME = 'user@email.com';
   process.env.PASSWORD = 'aB}#/:%40*1';
+  process.env.GIT_CLIENT_URL = `http://localhost:${echoServerPort}`;
+  process.env.GIT_URL = process.env.GITHUB;
+  process.env.GIT_USERNAME = process.env.USERNAME;
+  process.env.GIT_PASSWORD = process.env.PASSWORD;
   const client = app.main({ port: port() });
 
   // wait for the client to successfully connect to the server and identify itself
   server.io.on('connection', (socket) => {
     socket.on('identify', (clientData) => {
       const token = clientData.token;
-      t.plan(26);
+      t.plan(30);
 
       t.test('identification', (t) => {
         const filters = require(`${clientRootPath}/${ACCEPT}`);
@@ -404,6 +408,49 @@ test('proxy requests originating from behind the broker server', (t) => {
             t.end();
           },
         );
+      });
+
+      t.test('successfully redirect POST request to git client', (t) => {
+        const url = `http://localhost:${serverPort}/broker/${token}/snykgit/echo-body`;
+        const body = { some: { example: 'json' } };
+        request({ url, method: 'post', json: true, body }, (err, res) => {
+          t.equal(res.statusCode, 200, '200 statusCode');
+          t.same(res.body, body, 'body brokered');
+          t.end();
+        });
+      });
+
+      t.test('successfully redirect exact bytes of POST body to git client', (t) => {
+        const url = `http://localhost:${serverPort}/broker/${token}/snykgit/echo-body`;
+        const body = Buffer.from(
+          JSON.stringify({ some: { example: 'json' } }, null, 5),
+        );
+        const headers = { 'Content-Type': 'application/json' };
+        request({ url, method: 'post', headers, body }, (err, res) => {
+          const responseBody = Buffer.from(res.body);
+          t.equal(res.statusCode, 200, '200 statusCode');
+          t.same(responseBody, body, 'body brokered exactly');
+          t.end();
+        });
+      });
+
+      t.test('successfully GET from git client', (t) => {
+        const url = `http://localhost:${serverPort}/broker/${token}/snykgit/echo-param/xyz`;
+        request({ url, method: 'get' }, (err, res) => {
+          t.equal(res.statusCode, 200, '200 statusCode');
+          t.equal(res.body, 'xyz', 'body brokered');
+          t.end();
+        });
+      });
+
+      t.test('allow request to git client with valid param', (t) => {
+        const url = `http://localhost:${serverPort}/broker/${token}/snykgit/echo-query`;
+        const qs = { proxyMe: 'please' };
+        request({ url, method: 'get', json: true, qs }, (err, res) => {
+          t.equal(res.statusCode, 200, '200 statusCode');
+          t.same(res.body, qs, 'querystring brokered');
+          t.end();
+        });
       });
 
       t.test('clean up', (t) => {

--- a/test/unit/log.test.ts
+++ b/test/unit/log.test.ts
@@ -15,6 +15,9 @@ describe('log', () => {
     const crAgentUrl = (process.env.CR_AGENT_URL =
       'CONTAINER_REGISTRY_AGENT_URL');
     const crCredentials = (process.env.CR_CREDENTIALS = 'CR_CREDS');
+    const gitUsername = (process.env.GIT_USERNAME = 'G_USER');
+    const gitPassword = (process.env.GIT_PASSWORD = 'G_PASS');
+    const gitClientUrl = (process.env.GIT_CLIENT_URL = 'http://git-client-url.com');
 
     const log = require('../../lib/log');
 
@@ -30,6 +33,9 @@ describe('log', () => {
       artifactoryUrl,
       crAgentUrl,
       crCredentials,
+      gitUsername,
+      gitPassword,
+      gitClientUrl,
     ].join();
     const sanitizedTokens =
       '${BROKER_TOKEN},${GITHUB_TOKEN},${GITLAB_TOKEN},${AZURE_REPOS_TOKEN}';
@@ -37,6 +43,9 @@ describe('log', () => {
     const sanitizedJira = '${JIRA_USERNAME},${JIRA_PASSWORD}';
     const sanitizedArtifactory = '${ARTIFACTORY_URL}';
     const sanitizedCRData = '${CR_AGENT_URL},${CR_CREDENTIALS}';
+    const sanitizedGitUsername = '${GIT_USERNAME}';
+    const sanitizedGitPassword = '${GIT_PASSWORD}';
+    const sanitizedGitClientUrl = '${GIT_CLIENT_URL}';
 
     // setup logger output capturing
     const logs: string[] = [];
@@ -72,6 +81,9 @@ describe('log', () => {
     expect(logged).not.toMatch(artifactoryUrl);
     expect(logged).not.toMatch(crAgentUrl);
     expect(logged).not.toMatch(crCredentials);
+    expect(logged).not.toMatch(gitUsername);
+    expect(logged).not.toMatch(gitPassword);
+    expect(logged).not.toMatch(gitClientUrl);
 
     // assert sensitive data is masked
     expect(logged).toMatch(sanitizedBitBucket);
@@ -79,5 +91,8 @@ describe('log', () => {
     expect(logged).toMatch(sanitizedJira);
     expect(logged).toMatch(sanitizedArtifactory);
     expect(logged).toMatch(sanitizedCRData);
+    expect(logged).toMatch(sanitizedGitUsername);
+    expect(logged).toMatch(sanitizedGitPassword);
+    expect(logged).toMatch(sanitizedGitClientUrl);
   });
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,5 +1,6 @@
 const compression = require('compression');
 const webserver = require('../lib/webserver');
+const express = require('express');
 
 let p = 9876;
 
@@ -18,12 +19,14 @@ export function createTestServer() {
 
   echoServer.use(compression());
 
-  echoServer.get('/test', (req, res) => {
+  const echoServerRoutes = express();
+
+  echoServerRoutes.get('/test', (req, res) => {
     res.status(200);
     res.send('All good');
   });
 
-  echoServer.get('/test-blob/1', (req, res) => {
+  echoServerRoutes.get('/test-blob/1', (req, res) => {
     res.setHeader('test-orig-url', req.originalUrl);
     res.status(299);
 
@@ -34,25 +37,25 @@ export function createTestServer() {
     res.send(buf);
   });
 
-  echoServer.get('/test-blob/2', (req, res) => {
+  echoServerRoutes.get('/test-blob/2', (req, res) => {
     res.setHeader('test-orig-url', req.originalUrl);
     res.status(500);
     res.send('Test Error');
   });
 
-  echoServer.get('/basic-auth', (req, res) => {
+  echoServerRoutes.get('/basic-auth', (req, res) => {
     res.send(req.headers.authorization);
   });
 
-  echoServer.get('/echo-param/:param', (req, res) => {
+  echoServerRoutes.get('/echo-param/:param', (req, res) => {
     res.send(req.params.param);
   });
 
-  echoServer.get('/echo-param-protected/:param', (req, res) => {
+  echoServerRoutes.get('/echo-param-protected/:param', (req, res) => {
     res.send(req.params.param);
   });
 
-  echoServer.post('/echo-body/:param?', (req, res) => {
+  echoServerRoutes.post('/echo-body/:param?', (req, res) => {
     const contentType = req.get('Content-Type');
     if (contentType) {
       res.type(contentType);
@@ -60,28 +63,30 @@ export function createTestServer() {
     res.send(req.body);
   });
 
-  echoServer.post('/echo-headers/:param?', (req, res) => {
+  echoServerRoutes.post('/echo-headers/:param?', (req, res) => {
     res.json(req.headers);
   });
 
-  echoServer.get('/echo-query/:param?', (req, res) => {
+  echoServerRoutes.get('/echo-query/:param?', (req, res) => {
     res.json(req.query);
   });
 
-  echoServer.get('/long/nested/*', (req, res) => {
+  echoServerRoutes.get('/long/nested/*', (req, res) => {
     res.send(req.originalUrl);
   });
 
-  echoServer.get(
+  echoServerRoutes.get(
     '/repos/owner/repo/contents/folder/package.json',
     (req, res) => {
       res.json({ headers: req.headers, query: req.query, url: req.url });
     },
   );
 
-  echoServer.all('*', (req, res) => {
+  echoServerRoutes.all('*', (req, res) => {
     res.send(false);
   });
+
+  echoServer.use(['/snykgit', '/'], echoServerRoutes);
 
   return {
     echoServerPort,


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
As part of the efforts to allow on-prem customers to have Snyk Code analysis results, we've built a support service that can be run alongside the Broker Client to clone the repositories and upload the code to our servers to be analyzed. In order to support this solution, we've updated the Broker Client to be aware of this new architecture and redirect all the requests to a specific endpoint towards the new snyk git client.

The expected behaviour at the moment is:
- a new `GIT_CLIENT_URL` variable is introduced in the `.env` file to be specified by the customer during the deployment, alongside three support variables `GIT_URL`, `GIT_USERNAME`, `GIT_PASSWORD` that are just used to capture under a common name different SCM-related variables that already present.
- every request towards `/snykgit/*` is redirected to the relative `snykgit/*` path on the git client.
- the creds in the body of the request and part of the girURI will be replaced by the above mentioned environment variables (this is  not done in this PR)
- no change is required for the Snyk Broker Server, but beta customers will need to update their broker client version and configuration together with deploying the new git client to benefit from on-prem code analyses.

Possible future scenarios:
- we expect other products and teams to start using the snyk git client in the future after the communication protocol is established. For this reasons we want the broker changes to be simple and allow us a variety of approaches end-to-end. 

#### Where should the reviewer start?
There are some design choices that may be useful to review for maintainability and longevity of the product:
- use of a path specification to specify the direction of the forwarding (scm vs git-client). This could also be achieved through a custom header, if that's advisable.
- use of env variables to have a common scm-agnostic name reference to info that is already present elsewhere in the config (e.g. GITHUB_TOKEN => GIT_PASSWORD)
- the only env variable that has been added to the dockerfiles examples is the `GIT_CLIENT_URL`. 

#### How should this be manually tested?
- We did test the code locally and added some tests for the new functionality, however the end-to-end interaction with real SCMs has not being tested at all (all the e2e tests have been performed for a brokered github.com integration).

#### Any background context you want to provide?
We had multiple design iterations for possible on-prem analysis flow, all of which included some changes to the broker client.

(https://docs.google.com/presentation/d/16U72rCxbrTO_lCBqU6FeNDwpzkPvwsXvJGncjF8PmtM/edit?usp=sharing) or chat with us at [#feat-code-access-2021](https://snyk.slack.com/archives/C01T8J66QMS)
