### PR TITLE
chore: fix release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,8 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - attach_workspace:
+          at: ~/broker
       - run:
           name: Release to GitHub
           command: npx semantic-release
@@ -68,7 +70,7 @@ workflows:
       - test:
           name: Test
           requires:
-          - Install DEV
+            - Install DEV
       - release:
           name: Release to GitHub
           context: nodejs-app-release


### PR DESCRIPTION
`node_modules` are necessary to compile the typescript for the release build.


https://app.circleci.com/pipelines/github/snyk/broker/16/workflows/2664c3ee-7147-4a33-b044-57e062fb57d8/jobs/48