### PR TITLE
fix: replace vulnerable merge function of predefine package with not vulnerable lodash.merge implementation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,8 @@
+// This is the temporary fix for https://snyk.io/vuln/SNYK-JS-PREDEFINE-1054935
+// The vulnerability is introduced via snyk-broker@* › primus@6.1.0 › fusing@1.0.0 › predefine@0.1.2
+// We require predefine early to replace vulnerable function `merge` with not vulnerable analog `lodash.merge`.
+require('predefine').merge = require('lodash.merge');
+
 require('clarify'); // clean the stacktraces
 const path = require('path');
 const yaml = require('js-yaml');

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "js-yaml": "^3.13.1",
     "lodash.escaperegexp": "^4.1.2",
     "lodash.mapvalues": "^4.6.0",
+    "lodash.merge": "^4.6.2",
     "minimatch": "^3.0.4",
     "minimist": "^1.2.5",
     "node-cache": "^5.1.0",

--- a/test/unit/predefine-pp-hotfix.test.ts
+++ b/test/unit/predefine-pp-hotfix.test.ts
@@ -1,0 +1,11 @@
+describe('predefine prototype pollution', () => {
+  it('is not exploitable', () => {
+    require('../../lib/index');
+
+    require('primus').prototype.merge(
+      {},
+      JSON.parse('{"__proto__": {"a": "b"}}'),
+    );
+    expect(({} as any).a).toBeUndefined();
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

According to Snyk broker has a [Prototype Pollution vulnerability in predefine](https://snyk.io/vuln/SNYK-JS-PREDEFINE-1054935) package introduced via `primus@6.1.0 › fusing@1.0.0 › predefine@0.1.2`. Together with @ohad2712 we verified that no user input flows to the vulnerable function `merge` directly or indirectly. To be precise, we observed some user input flows to `merge` but only of type String – which makes it not exploitable.

To make double sure we decided to replace vulnerable implementation of the `merge` function with similar function `lodash.merge`, which is not vulnerable.

To replace the function we require `predefine` package as early as possible and replace the function by directly overwriting it.

#### Where should the reviewer start?

`lib/index.js`

#### How should this be manually tested?


#### Any background context you want to provide?

https://snyk.io/vuln/SNYK-JS-PREDEFINE-1054935

**predefine**:

Vulnerable code: https://github.com/bigpipe/predefine/blob/0.1.2/index.js#L263-L294

PoC:
```javascript
const predefine = require('predefine');
predefine.merge({}, JSON.parse('{"__proto__": {"a": "b"}}'));

console.log(({}).a === 'b' ? 'exploitable' : 'unexploitable'); // exploitable
```

Merge function is not used anywhere inside the package itself, but exported as part of the API.

**fusing**:

Vulnerable code: https://github.com/bigpipe/fusing/blob/1.0/index.js#L140

`merge` function is not used anywhere inside `fusing` package as well, but re-exported as part of prototype for each class.

**primus**:

- `merge` function is used in `createServer` function as 3d argument.
- `merge` function is used in `transformers/engine.io/client.js` but the only user input seems to be the `url` property.
