### PR TITLE
fix: ignore prototype pollution vulnerability in predefine

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -6,4 +6,8 @@ ignore:
     - primus > setheader > debug:
         reason: Not vulnerable as `primus` doesn't run in debug mode
         expires: '2019-10-10T18:14:53.642Z'
+  'SNYK-JS-PREDEFINE-1054935':
+    - primus > fusing > predefine:
+        reason: Fixed in https://github.com/snyk/broker/pull/336
+        expires: '2022-07-06T09:47:29.283Z'
 patch: {}


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Ignore prototype pollution vulnerability in predefine introduced by `primus@6.1.0 > fusing@1.0.0 > predefine@0.1.2` because it fixed in https://github.com/snyk/broker/pull/336

#### Where should the reviewer start?

https://github.com/snyk/broker/pull/336

#### Any background context you want to provide?

https://github.com/snyk/broker/pull/336