### PR TITLE
fix: mitigate engine.io DoS vulnerability by removing vulnerable transport

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -9,5 +9,8 @@ ignore:
   'SNYK-JS-PREDEFINE-1054935':
     - primus > fusing > predefine:
         reason: Fixed in https://github.com/snyk/broker/pull/336
+  'SNYK-JS-ENGINEIO-1056749':
+    - engine.io:
+        reason: Fixed in https://github.com/snyk/broker/pull/338
         expires: '2022-07-06T09:47:29.283Z'
 patch: {}

--- a/lib/server/socket.js
+++ b/lib/server/socket.js
@@ -7,6 +7,13 @@ const { maskToken } = require('../token');
 module.exports = ({ server, filters, config }) => {
   const io = new Primus(server, {
     transformer: 'engine.io',
+    transport: {
+      // By default transports are ['polling', 'websocket'],
+      // but we keep only `websocket` because  `polling` in `engine.io` < 4.0.0
+      // is vulnerable to Denial of Service attack.
+      // For more details: https://app.snyk.io/vuln/SNYK-JS-ENGINEIO-1056749
+      transports: ['websocket'],
+    },
     parser: 'EJSON',
     maxLength: '20971520',
   });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

We use `engine.io` < 4.0.0 which is [vulnerable to DoS](https://app.snyk.io/vuln/SNYK-JS-ENGINEIO-1056749). The vulnerability is introduced via `polling` transport. As far as we use `engine.io` only for server to server communication we can  safely remove `polling` and keep only `websocket` transport. Which will make this vulnerability unexploitable.

__Note:__ it's okay to keep this change even after updating `engine.io` to >= 4.0.0 because it should not affect anything.

#### Any background context you want to provide?

https://app.snyk.io/vuln/SNYK-JS-ENGINEIO-1056749

