### PR TITLE
fix: mitigate engine.io DoS vulnerability by reducing HTTP buffer size

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -10,4 +10,8 @@ ignore:
     - primus > fusing > predefine:
         reason: Fixed in https://github.com/snyk/broker/pull/336
         expires: '2022-07-06T09:47:29.283Z'
+  'SNYK-JS-ENGINEIO-1056749':
+    - engine.io:
+        reason: Fixed in https://github.com/snyk/broker/pull/340
+        expires: '2022-07-06T09:47:29.283Z'
 patch: {}

--- a/lib/server/socket.js
+++ b/lib/server/socket.js
@@ -8,7 +8,13 @@ module.exports = ({ server, filters, config }) => {
   const io = new Primus(server, {
     transformer: 'engine.io',
     parser: 'EJSON',
-    maxLength: '20971520',
+    // engine.io < 4.0.0 is vulnerable to Denial of Service attack. To mitigate
+    // the vulnerability we reduce HTTP buffer size down to 1mb as it is done
+    // in the official fix commit.
+    // For more details:
+    // - https://app.snyk.io/vuln/SNYK-JS-ENGINEIO-1056749
+    // - https://github.com/socketio/engine.io/commit/734f9d1268840722c41219e69eb58318e0b2ac6b
+    maxLength: 1e6,
   });
   io.plugin('emitter', Emitter);
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

We use `engine.io` < 4.0.0 which is [vulnerable to DoS](https://app.snyk.io/vuln/SNYK-JS-ENGINEIO-1056749). To mitigate the vulnerability we reduce HTTP buffer side down to 1mb as it is done in [the official fix commit](https://github.com/socketio/engine.io/commit/734f9d1268840722c41219e69eb58318e0b2ac6b).

__Note:__ it's okay to keep this change even after updating `engine.io` to >= 4.0.0 because it should not affect anything.

#### Any background context you want to provide?

https://app.snyk.io/vuln/SNYK-JS-ENGINEIO-1056749
