### PR TITLE
chore: add maxlength comment

### DIFF
--- a/lib/server/socket.js
+++ b/lib/server/socket.js
@@ -8,7 +8,7 @@ module.exports = ({ server, filters, config }) => {
   const io = new Primus(server, {
     transformer: 'engine.io',
     parser: 'EJSON',
-    maxLength: '20971520',
+    maxLength: '20971520', // support up to 20MB in response bodies
   });
   io.plugin('emitter', Emitter);
 


### PR DESCRIPTION
Was introduced in https://github.com/snyk/broker/pull/326

Almost removed in https://github.com/snyk/broker/pull/340, so adding a comment to explain why this is there.