### PR TITLE
fix: sanitise CR env variables

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -62,6 +62,34 @@ function sanitise(raw) {
     raw = sanitiseConfigVariable(raw, 'CR_AGENT_URL');
   }
 
+  if (config.CR_BASE) {
+    raw = sanitiseConfigVariable(raw, 'CR_BASE');
+  }
+
+  if (config.CR_USERNAME) {
+    raw = sanitiseConfigVariable(raw, 'CR_USERNAME');
+  }
+
+  if (config.CR_PASSWORD) {
+    raw = sanitiseConfigVariable(raw, 'CR_PASSWORD');
+  }
+
+  if (config.CR_TOKEN) {
+    raw = sanitiseConfigVariable(raw, 'CR_TOKEN');
+  }
+
+  if (config.CR_ROLE_ARN) {
+    raw = sanitiseConfigVariable(raw, 'CR_ROLE_ARN');
+  }
+
+  if (config.CR_EXTERNAL_ID) {
+    raw = sanitiseConfigVariable(raw, 'CR_EXTERNAL_ID');
+  }
+
+  if (config.CR_REGION) {
+    raw = sanitiseConfigVariable(raw, 'CR_REGION');
+  }
+
   if (config.GIT_USERNAME) {
     raw = sanitiseConfigVariable(raw, 'GIT_USERNAME');
   }
@@ -88,7 +116,7 @@ function sanitiseHeaders(headers) {
   }
   if (hdrs['X-Broker-Token']) {
     hdrs['X-Broker-Token'] = '${BROKER_TOKEN}';
-  };
+  }
   return sanitiseObject(hdrs);
 }
 

--- a/test/unit/log.test.ts
+++ b/test/unit/log.test.ts
@@ -12,9 +12,15 @@ describe('log', () => {
     const azureReposToken = (process.env.AZURE_REPOS_TOKEN = 'AZURE_TOKEN');
     const artifactoryUrl = (process.env.ARTIFACTORY_URL =
       'http://basic:auth@artifactory.com');
-    const crAgentUrl = (process.env.CR_AGENT_URL =
-      'CONTAINER_REGISTRY_AGENT_URL');
+    const crAgentUrl = (process.env.CR_AGENT_URL = 'CONTAINER_AGENT_URL');
     const crCredentials = (process.env.CR_CREDENTIALS = 'CR_CREDS');
+    const crUsername = (process.env.CR_USERNAME = 'CONTAINER_USERNAME');
+    const crPassword = (process.env.CR_PASSWORD = 'CONTAINER_PASSWORD');
+    const crToken = (process.env.CR_TOKEN = 'CONTAINER_TOKEN');
+    const crRoleArn = (process.env.CR_ROLE_ARN = 'CONTAINER_ROLE_ARN');
+    const crExternalId = (process.env.CR_EXTERNAL_ID = 'CONTAINER_EXTERNAL_ID');
+    const crRegion = (process.env.CR_REGION = 'CONTAINER_REGION');
+    const crBase = (process.env.CR_BASE = 'CONTAINER_BASE');
     const gitUsername = (process.env.GIT_USERNAME = 'G_USER');
     const gitPassword = (process.env.GIT_PASSWORD = 'G_PASS');
     const gitClientUrl = (process.env.GIT_CLIENT_URL = 'http://git-client-url.com');
@@ -33,6 +39,13 @@ describe('log', () => {
       artifactoryUrl,
       crAgentUrl,
       crCredentials,
+      crUsername,
+      crPassword,
+      crToken,
+      crRoleArn,
+      crExternalId,
+      crRegion,
+      crBase,
       gitUsername,
       gitPassword,
       gitClientUrl,
@@ -42,7 +55,8 @@ describe('log', () => {
     const sanitizedBitBucket = '${BITBUCKET_USERNAME},${BITBUCKET_PASSWORD}';
     const sanitizedJira = '${JIRA_USERNAME},${JIRA_PASSWORD}';
     const sanitizedArtifactory = '${ARTIFACTORY_URL}';
-    const sanitizedCRData = '${CR_AGENT_URL},${CR_CREDENTIALS}';
+    const sanitizedCRData =
+      '${CR_AGENT_URL},${CR_CREDENTIALS},${CR_USERNAME},${CR_PASSWORD},${CR_TOKEN},${CR_ROLE_ARN},${CR_EXTERNAL_ID},${CR_REGION},${CR_BASE}';
     const sanitizedGitUsername = '${GIT_USERNAME}';
     const sanitizedGitPassword = '${GIT_PASSWORD}';
     const sanitizedGitClientUrl = '${GIT_CLIENT_URL}';
@@ -81,6 +95,13 @@ describe('log', () => {
     expect(logged).not.toMatch(artifactoryUrl);
     expect(logged).not.toMatch(crAgentUrl);
     expect(logged).not.toMatch(crCredentials);
+    expect(logged).not.toMatch(crUsername);
+    expect(logged).not.toMatch(crPassword);
+    expect(logged).not.toMatch(crToken);
+    expect(logged).not.toMatch(crRoleArn);
+    expect(logged).not.toMatch(crExternalId);
+    expect(logged).not.toMatch(crRegion);
+    expect(logged).not.toMatch(crBase);
     expect(logged).not.toMatch(gitUsername);
     expect(logged).not.toMatch(gitPassword);
     expect(logged).not.toMatch(gitClientUrl);


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Add sanitisation to recently added env variables for Container integration.
It doesn't seem to be logged anywhere, but adding this just in case.

