### PR TITLE
Feat/improved observability

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,8 @@ const app = (module.exports = {
   main: main,
 });
 
+require('@snyk/node-dump-stacks');
+
 function main({ port, client, config = {} } = {}) {
   // note: the config is loaded in the main function to allow us to mock in tests
   if (process.env.TAP) {

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -1,0 +1,14 @@
+import { Gauge } from 'prom-client';
+
+const socketConnectionGauge = new Gauge({
+  name: 'broker_socket_connection_total',
+  help: 'Number of active socket connections',
+});
+
+export function incrementSocketConnectionGauge() {
+  socketConnectionGauge.inc(1);
+}
+
+export function decrementSocketConnectionGauge() {
+  socketConnectionGauge.dec(1);
+}

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -20,7 +20,7 @@ module.exports = ({ config = {}, port = null, filters = {} }) => {
 
   // basic prometheus metrics
   const metricsMiddleware = promBundle({
-    buckets: [0.1, 0.4, 0.7, 1, 1.5, 2, 2.5, 5, 10, 30],
+    buckets: [0.5, 1, 2, 5, 10, 30, 60, 120, 300],
     includeMethod: true,
     includePath: false,
     metricsPath: '/metrics',

--- a/lib/server/socket.js
+++ b/lib/server/socket.js
@@ -3,6 +3,10 @@ const Emitter = require('primus-emitter');
 const logger = require('../log');
 const relay = require('../relay');
 const { maskToken } = require('../token');
+const {
+  incrementSocketConnectionGauge,
+  decrementSocketConnectionGauge,
+} = require('../metrics');
 
 module.exports = ({ server, filters, config }) => {
   const io = new Primus(server, {
@@ -44,6 +48,7 @@ module.exports = ({ server, filters, config }) => {
           logger.info({ maskedToken }, 'removing client');
           connections.delete(token);
         }
+        decrementSocketConnectionGauge();
       }
     };
 
@@ -81,6 +86,8 @@ module.exports = ({ server, filters, config }) => {
 
       socket.on('chunk', streamingResponse(token));
       socket.on('request', response(token));
+
+      incrementSocketConnectionGauge();
     });
 
     ['close', 'end', 'disconnect'].forEach((e) => socket.on(e, () => close(e)));

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
+    "@snyk/node-dump-stacks": "^1.3.0",
     "@types/minimist": "^1.2.0",
     "@types/request": "^2.48.5",
     "body-parser": "^1.19.0",


### PR DESCRIPTION
Improving observability:
- Fixed bucket sizes so that requests that take longer than 30 seconds are covered
- Log event loop blocks (disabled by default, use `DUMP_STACKS_ENABLED` to enable). Using[ this library](https://github.com/snyk/node-dump-stacks)
- Added prometheus gauge to track active socket connections (only relevant when running in server mode)