### PR TITLE
feat: systemcheck for container integration

### DIFF
--- a/bin/container-registry-agent/docker-entrypoint.sh
+++ b/bin/container-registry-agent/docker-entrypoint.sh
@@ -20,6 +20,9 @@ if [[ -z "$CR_CREDENTIALS" ]]; then
 
   export CR_CREDENTIALS=$(echo $JSON | base64 -w0)
 fi
+if [[ $BROKER_CLIENT_VALIDATION_URL ]]; then
+  export BROKER_CLIENT_VALIDATION_AUTHORIZATION_HEADER=$CR_CREDENTIALS
+fi
 
 # execute main command
 exec "$@"

--- a/test/bin/container-registry-agent/docker-entrypoint-test.sh
+++ b/test/bin/container-registry-agent/docker-entrypoint-test.sh
@@ -50,4 +50,31 @@ testStandardCredentialsSetup() {
   assertEquals "$EXPECTED" "$(echo ${CR_CREDENTIALS} | base64 -d)"
 }
 
+testSystemCheckSetup() {
+  CR_TYPE="DockerHub"
+  CR_USERNAME="user"
+  CR_PASSWORD="pass"
+  CR_BASE="cr.com/my"
+  BROKER_CLIENT_VALIDATION_URL="http://dra.url/systemcheck"
+  unset CR_CREDENTIALS
+
+  . ../../bin/container-registry-agent/docker-entrypoint.sh
+
+  EXPECTED='{"type":"DockerHub", "username":"user", "password":"pass", "registryBase":"cr.com/my"}'
+  assertEquals "$EXPECTED" "$(echo ${BROKER_CLIENT_VALIDATION_AUTHORIZATION_HEADER} | base64 -d)"
+}
+
+testSystemCheckAuthNotSetIfNoValidationUrl() {
+  CR_TYPE="DockerHub"
+  CR_USERNAME="user"
+  CR_PASSWORD="pass"
+  CR_BASE="cr.com/my"
+  unset CR_CREDENTIALS
+  unset BROKER_CLIENT_VALIDATION_URL
+  unset BROKER_CLIENT_VALIDATION_AUTHORIZATION_HEADER
+
+  . ../../bin/container-registry-agent/docker-entrypoint.sh
+  assertEquals "" "$(echo ${BROKER_CLIENT_VALIDATION_AUTHORIZATION_HEADER})"
+}
+
 . ./shunit2


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
If a user sets `BROKER_CLIENT_VALIDATION_URL` then we also set
`BROKER_CLIENT_VALIDATION_AUTHORIZATION_HEADER` with whatever is in
CR_CREDENTIALS. The CRA will process the credentials in the systemcheck
endpoint.

