### PR TITLE
fix: azure repos - missing org context for git url

### DIFF
--- a/client-templates/azure-repos/.env.sample
+++ b/client-templates/azure-repos/.env.sample
@@ -31,7 +31,7 @@ BROKER_HEALTHCHECK_PATH=/healthcheck
 BROKER_CLIENT_VALIDATION_URL="https://$AZURE_REPOS_HOST/$AZURE_REPOS_ORG/_apis/git/repositories"
 
 # the host where the git server resides
-GIT_URL=$AZURE_REPOS_HOST
+GIT_URL=$AZURE_REPOS_HOST/$AZURE_REPOS_ORG
 
 # git credentials for cloning repos
 GIT_USERNAME=PAT


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Add missing azure org parameter on git_url config

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
