### PR TITLE
feat: comment out default envvars in dockerfiles

### DIFF
--- a/dockerfiles/artifactory/Dockerfile
+++ b/dockerfiles/artifactory/Dockerfile
@@ -10,15 +10,15 @@ RUN apt-get update && apt-get install -y ca-certificates
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 
-ENV PATH=$PATH:/home/node/.npm-global/bin 
+ENV PATH=$PATH:/home/node/.npm-global/bin
 
-RUN npm install --global snyk-broker 
+RUN npm install --global snyk-broker
 
 
 
 FROM snyk/ubuntu
 
-ENV PATH=$PATH:/home/node/.npm-global/bin 
+ENV PATH=$PATH:/home/node/.npm-global/bin
 
 COPY --from=base /home/node/.npm-global /home/node/.npm-global
 
@@ -26,7 +26,7 @@ COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificat
 
 # Don't run as root
 WORKDIR /home/node
-USER node 
+USER node
 
 # Generate default accept filter
 RUN broker init artifactory
@@ -38,15 +38,15 @@ RUN broker init artifactory
 ######################################
 
 # Your unique Broker identifier
-ENV BROKER_TOKEN <broker-token>
+# ENV BROKER_TOKEN <broker-token>
 
 # Your Artifactory URL to artifactory
 # NOTA BENE: without `/` character in the end of URL
-ENV ARTIFACTORY_URL <yourdomain>.artifactory.com/artifactory
+# ENV ARTIFACTORY_URL <yourdomain>.artifactory.com/artifactory
 
 # Provide RES_BODY_URL_SUB with the URL of the artifactory without credentials and http protocol
 # This URL substitution is required for NPM integration
-ENV RES_BODY_URL_SUB=http://<yourdomain>.artifactory.com/artifactory
+# ENV RES_BODY_URL_SUB=http://<yourdomain>.artifactory.com/artifactory
 
 # The port used by the broker client to accept internal connections
 # Default value is 7341

--- a/dockerfiles/azure-repos/Dockerfile
+++ b/dockerfiles/azure-repos/Dockerfile
@@ -38,23 +38,23 @@ RUN broker init azure-repos
 ######################################
 
 # https://dev.azure.com/{azure-repos-org}
-ENV AZURE_REPOS_ORG <azure-repos-org>
+# ENV AZURE_REPOS_ORG <azure-repos-org>
 # Guide how to get/create the token https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=preview-page
 # Scopes: Ensure Custom defined is selected and under Code select Read & write
-ENV AZURE_REPOS_TOKEN <azure-repos-token>
+# ENV AZURE_REPOS_TOKEN <azure-repos-token>
 # NOTA BENE: without `/` character in the end of URL
-ENV AZURE_REPOS_HOST dev.azure.com
+# ENV AZURE_REPOS_HOST dev.azure.com
 
 # Your unique Broker identifier
-ENV BROKER_TOKEN <broker-token>
+# ENV BROKER_TOKEN <broker-token>
 
 # The port used by the broker client to accept internal connections
 # Default value is 7341
-ENV PORT 7341
+# ENV PORT 7341
 
 # The URL of your broker client (including scheme and port)
 # This will be used as the webhook payload URL
-ENV BROKER_CLIENT_URL "https://<broker.client.hostname>:$PORT"
+# ENV BROKER_CLIENT_URL "https://<broker.client.hostname>:$PORT"
 
 EXPOSE $PORT
 

--- a/dockerfiles/bitbucket-server/Dockerfile
+++ b/dockerfiles/bitbucket-server/Dockerfile
@@ -38,19 +38,19 @@ RUN broker init bitbucket-server
 ######################################
 
 # Your unique broker identifier
-ENV BROKER_TOKEN <broker-token>
+# ENV BROKER_TOKEN <broker-token>
 
 # Your personal username to your bitbucket server account
-ENV BITBUCKET_USERNAME <username>
+# ENV BITBUCKET_USERNAME <username>
 
 # Your personal password to your bitbucket server account
-ENV BITBUCKET_PASSWORD <password>
+# ENV BITBUCKET_PASSWORD <password>
 
 # Your Bitbucket Server host, excluding scheme
-ENV BITBUCKET your.bitbucket.server.hostname
+# ENV BITBUCKET your.bitbucket.server.hostname
 
 # The Bitbucket server API URL
-ENV BITBUCKET_API $BITBUCKET/rest/api/1.0
+# ENV BITBUCKET_API $BITBUCKET/rest/api/1.0
 
 # The port used by the broker client to accept internal connections
 # Default value is 7341

--- a/dockerfiles/container-registry-agent/Dockerfile
+++ b/dockerfiles/container-registry-agent/Dockerfile
@@ -10,15 +10,15 @@ RUN apt-get update && apt-get install -y ca-certificates
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 
-ENV PATH=$PATH:/home/node/.npm-global/bin 
+ENV PATH=$PATH:/home/node/.npm-global/bin
 
-RUN npm install --global snyk-broker 
+RUN npm install --global snyk-broker
 
 
 
 FROM snyk/ubuntu
 
-ENV PATH=$PATH:/home/node/.npm-global/bin 
+ENV PATH=$PATH:/home/node/.npm-global/bin
 
 COPY --from=base /home/node/.npm-global /home/node/.npm-global
 
@@ -26,7 +26,7 @@ COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificat
 
 # Don't run as root
 WORKDIR /home/node
-USER node 
+USER node
 
 # Prepare image entrypoint
 COPY --chown=node:node ./bin/container-registry-agent/docker-entrypoint.sh ./docker-entrypoint.sh
@@ -41,14 +41,14 @@ RUN broker init container-registry-agent
 ######################################
 
 # Your unique broker identifier, copied from snyk.io org settings page
-ENV BROKER_TOKEN <broker-token>
+# ENV BROKER_TOKEN <broker-token>
 
 # The URL of your broker client (including scheme and port), used by container
 # registry agent to call back to Snyk through brokered connection
-ENV BROKER_CLIENT_URL "https://<broker-client-host>:<broker-client-port>"
+# ENV BROKER_CLIENT_URL "https://<broker-client-host>:<broker-client-port>"
 
 # The URL of your container registry agent
-ENV CR_AGENT_URL <agent-host>:<agent-port>
+# ENV CR_AGENT_URL <agent-host>:<agent-port>
 
 # The port used by the broker client to accept internal connections
 # Default value is 7341

--- a/dockerfiles/github-com/Dockerfile
+++ b/dockerfiles/github-com/Dockerfile
@@ -38,10 +38,10 @@ RUN broker init github-com
 ######################################
 
 # Your unique broker identifier, copied from snyk.io org settings page
-ENV BROKER_TOKEN <broker-token>
+# ENV BROKER_TOKEN <broker-token>
 
 # Your personal access token to your github.com / GHE account
-ENV GITHUB_TOKEN <github-token>
+# ENV GITHUB_TOKEN <github-token>
 
 # The port used by the broker client to accept webhooks
 # Default value is 7341

--- a/dockerfiles/github-enterprise/Dockerfile
+++ b/dockerfiles/github-enterprise/Dockerfile
@@ -38,19 +38,19 @@ RUN broker init github-enterprise
 ######################################
 
 # Your unique broker identifier, copied from snyk.io org settings page
-ENV BROKER_TOKEN <broker-token>
+# ENV BROKER_TOKEN <broker-token>
 
 # Your personal access token to your github.com / GHE account
-ENV GITHUB_TOKEN <github-token>
+# ENV GITHUB_TOKEN <github-token>
 
 # The host where your GitHub Enterprise is running, excluding scheme.
-ENV GITHUB=your.ghe.domain.com
+# ENV GITHUB=your.ghe.domain.com
 
 # Github API endpoint, excluding scheme.
-ENV GITHUB_API your.ghe.domain.com/api/v3
+# ENV GITHUB_API your.ghe.domain.com/api/v3
 
 # Github GraphQL API endpoint, excluding scheme.
-ENV GITHUB_GRAPHQL your.ghe.domain.com/api
+# ENV GITHUB_GRAPHQL your.ghe.domain.com/api
 
 # The port used by the broker client to accept webhooks
 # Default value is 7341

--- a/dockerfiles/gitlab/Dockerfile
+++ b/dockerfiles/gitlab/Dockerfile
@@ -38,13 +38,13 @@ RUN broker init gitlab
 ######################################
 
 # Your unique broker identifier
-ENV BROKER_TOKEN <broker-token>
+# ENV BROKER_TOKEN <broker-token>
 
 # your personal token to your Gitlab server account
-ENV GITLAB_TOKEN <gitlab-token>
+# ENV GITLAB_TOKEN <gitlab-token>
 
 # The Gitlab server API URL
-ENV GITLAB your.gitlab.server.hostname
+# ENV GITLAB your.gitlab.server.hostname
 
 # The port used by the broker client to accept internal connections
 # Default value is 7341

--- a/dockerfiles/jira/Dockerfile
+++ b/dockerfiles/jira/Dockerfile
@@ -10,15 +10,15 @@ RUN apt-get update && apt-get install -y ca-certificates
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 
-ENV PATH=$PATH:/home/node/.npm-global/bin 
+ENV PATH=$PATH:/home/node/.npm-global/bin
 
-RUN npm install --global snyk-broker 
+RUN npm install --global snyk-broker
 
 
 
 FROM snyk/ubuntu
 
-ENV PATH=$PATH:/home/node/.npm-global/bin 
+ENV PATH=$PATH:/home/node/.npm-global/bin
 
 COPY --from=base /home/node/.npm-global /home/node/.npm-global
 
@@ -26,7 +26,7 @@ COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificat
 
 # Don't run as root
 WORKDIR /home/node
-USER node 
+USER node
 
 # Generate default accept filter
 RUN broker init jira
@@ -38,14 +38,14 @@ RUN broker init jira
 ######################################
 
 # Your unique broker identifier
-ENV BROKER_TOKEN <broker-token>
+# ENV BROKER_TOKEN <broker-token>
 
 # Your personal credentials to your jira
-ENV JIRA_USERNAME <username>
-ENV JIRA_PASSWORD <password>
+# ENV JIRA_USERNAME <username>
+# ENV JIRA_PASSWORD <password>
 
 # Your Jira Server host
-ENV JIRA_HOSTNAME your.jira.server.hostname
+# ENV JIRA_HOSTNAME your.jira.server.hostname
 
 # The port used by the broker client to accept internal connections
 # Default value is 7341


### PR DESCRIPTION
To allow broker configuration by mounting a .env file.
If you do that today, those default ENV variables will override it. We should keep them only as comments.
