### PR TITLE
fix: downgrade primus version

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "minimist": "^1.2.5",
     "node-cache": "^5.1.0",
     "path-to-regexp": "^1.8.0",
-    "primus": "^8.0.5",
+    "primus": "^6.1.0",
     "primus-emitter": "^3.1.1",
     "prom-client": "^11.5.3",
     "qs": "^6.9.1",


### PR DESCRIPTION
Primus v8 server is not compatible with Primus v6 client.

The [heartbeats have changed from client->server to server->client](https://github.com/primus/primus/pull/534), so the websocket connections get killed every 30 seconds.

