### PR TITLE
fix: Remove unused container scan /v1 endpoints

### DIFF
--- a/client-templates/container-registry-agent/accept.json.sample
+++ b/client-templates/container-registry-agent/accept.json.sample
@@ -6,16 +6,6 @@
     "path": "/api/v1/import/app"
   },
   {
-    "//": "image scan result callback (v1)",
-    "method": "POST",
-    "path": "/api/v1/import/scan-result"
-  },
-  {
-    "//": "image scan done callback (v1)",
-    "method": "POST",
-    "path": "/api/v1/import/scan-done"
-  },
-  {
     "//": "image scan done callback (v2)",
     "method": "POST",
     "path": "/api/v2/import/done"


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR removes endpoints that were added to replace the /api/v2/import/result and /api/v2/import/done, in an attempt to free the /v2 endpoint for the new Snyk API. Eventually, it has been decided to not break current functionality for customers, and therefore we do not use these endpoints.

#### Any background context you want to provide?

Internal Slack thread: https://snyk.slack.com/archives/CBXS33GJY/p1621421246050600?thread_ts=1621363044.032300&cid=CBXS33GJY
