### PR TITLE
fix: vulnerability in libgcrypt20

### DIFF
--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -53,4 +53,6 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
 
 RUN apt remove gpg curl xz-utils libsqlite3-0 -y && apt autoremove -y --purge
 
+RUN apt install -y libgcrypt20
+
 USER node


### PR DESCRIPTION
fix for https://snyk.io/vuln/SNYK-UBUNTU2004-LIBGCRYPT20-1583851

The vulnerability is gone with this change, please see output of snykcli 
```
snyk container test snyk/ubuntu:test-0.3 --file=./Dockerfile --show-vulnerable-paths=all                                                    ✔  snyk-main   10:40:28 

Testing snyk/ubuntu:test-0.3...

✗ Low severity vulnerability found in shadow/passwd
  Description: Time-of-check Time-of-use (TOCTOU)
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-SHADOW-577863
  Introduced through: shadow/passwd@1:4.8.1-1ubuntu5.20.04.1, adduser@3.118ubuntu2, shadow/login@1:4.8.1-1ubuntu5.20.04.1, util-linux/mount@2.34-0.1ubuntu9.1
  From: shadow/passwd@1:4.8.1-1ubuntu5.20.04.1
  From: adduser@3.118ubuntu2 > shadow/passwd@1:4.8.1-1ubuntu5.20.04.1
  From: shadow/login@1:4.8.1-1ubuntu5.20.04.1
  From: util-linux/mount@2.34-0.1ubuntu9.1 > util-linux@2.34-0.1ubuntu9.1 > shadow/login@1:4.8.1-1ubuntu5.20.04.1
  Image layer: Introduced by your base image (ubuntu:20.04)

✗ Low severity vulnerability found in pcre3/libpcre3
  Description: Uncontrolled Recursion
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-PCRE3-580031
  Introduced through: pcre3/libpcre3@2:8.39-12build1, grep@3.4-1
  From: pcre3/libpcre3@2:8.39-12build1
  From: grep@3.4-1 > pcre3/libpcre3@2:8.39-12build1
  Image layer: Introduced by your base image (ubuntu:20.04)

✗ Low severity vulnerability found in pcre3/libpcre3
  Description: Out-of-bounds Read
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-PCRE3-581164
  Introduced through: pcre3/libpcre3@2:8.39-12build1, grep@3.4-1
  From: pcre3/libpcre3@2:8.39-12build1
  From: grep@3.4-1 > pcre3/libpcre3@2:8.39-12build1
  Image layer: Introduced by your base image (ubuntu:20.04)

✗ Low severity vulnerability found in pcre3/libpcre3
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-PCRE3-583594
  Introduced through: pcre3/libpcre3@2:8.39-12build1, grep@3.4-1
  From: pcre3/libpcre3@2:8.39-12build1
  From: grep@3.4-1 > pcre3/libpcre3@2:8.39-12build1
  Image layer: Introduced by your base image (ubuntu:20.04)

✗ Low severity vulnerability found in libtasn1-6
  Description: Resource Management Errors
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-LIBTASN16-578037
  Introduced through: libtasn1-6@4.16.0-2, apt@2.0.6
  From: libtasn1-6@4.16.0-2
  From: apt@2.0.6 > gnutls28/libgnutls30@3.6.13-2ubuntu1.6 > libtasn1-6@4.16.0-2
  Image layer: Introduced by your base image (ubuntu:20.04)

✗ Low severity vulnerability found in glibc/libc-bin
  Description: Reachable Assertion
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-GLIBC-1048386
  Introduced through: glibc/libc-bin@2.31-0ubuntu9.2, meta-common-packages@meta
  From: glibc/libc-bin@2.31-0ubuntu9.2
  From: meta-common-packages@meta > glibc/libc6@2.31-0ubuntu9.2
  Image layer: Introduced by your base image (ubuntu:20.04)

✗ Low severity vulnerability found in glibc/libc-bin
  Description: Loop with Unreachable Exit Condition ('Infinite Loop')
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-GLIBC-1055780
  Introduced through: glibc/libc-bin@2.31-0ubuntu9.2, meta-common-packages@meta
  From: glibc/libc-bin@2.31-0ubuntu9.2
  From: meta-common-packages@meta > glibc/libc6@2.31-0ubuntu9.2
  Image layer: Introduced by your base image (ubuntu:20.04)

✗ Low severity vulnerability found in glibc/libc-bin
  Description: Out-of-bounds Read
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-GLIBC-1055790
  Introduced through: glibc/libc-bin@2.31-0ubuntu9.2, meta-common-packages@meta
  From: glibc/libc-bin@2.31-0ubuntu9.2
  From: meta-common-packages@meta > glibc/libc6@2.31-0ubuntu9.2
  Image layer: Introduced by your base image (ubuntu:20.04)

✗ Low severity vulnerability found in glibc/libc-bin
  Description: Reachable Assertion
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-GLIBC-1122573
  Introduced through: glibc/libc-bin@2.31-0ubuntu9.2, meta-common-packages@meta
  From: glibc/libc-bin@2.31-0ubuntu9.2
  From: meta-common-packages@meta > glibc/libc6@2.31-0ubuntu9.2
  Image layer: Introduced by your base image (ubuntu:20.04)

✗ Low severity vulnerability found in glibc/libc-bin
  Description: Double Free
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-GLIBC-1123084
  Introduced through: glibc/libc-bin@2.31-0ubuntu9.2, meta-common-packages@meta
  From: glibc/libc-bin@2.31-0ubuntu9.2
  From: meta-common-packages@meta > glibc/libc6@2.31-0ubuntu9.2
  Image layer: Introduced by your base image (ubuntu:20.04)

✗ Low severity vulnerability found in glibc/libc-bin
  Description: Improper Input Validation
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-GLIBC-576349
  Introduced through: glibc/libc-bin@2.31-0ubuntu9.2, meta-common-packages@meta
  From: glibc/libc-bin@2.31-0ubuntu9.2
  From: meta-common-packages@meta > glibc/libc6@2.31-0ubuntu9.2
  Image layer: Introduced by your base image (ubuntu:20.04)

✗ Low severity vulnerability found in glibc/libc-bin
  Description: Integer Underflow
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-GLIBC-576428
  Introduced through: glibc/libc-bin@2.31-0ubuntu9.2, meta-common-packages@meta
  From: glibc/libc-bin@2.31-0ubuntu9.2
  From: meta-common-packages@meta > glibc/libc6@2.31-0ubuntu9.2
  Image layer: Introduced by your base image (ubuntu:20.04)

✗ Low severity vulnerability found in coreutils
  Description: Improper Input Validation
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-COREUTILS-583876
  Introduced through: coreutils@8.30-3ubuntu2
  From: coreutils@8.30-3ubuntu2
  Image layer: Introduced by your base image (ubuntu:20.04)

✗ Low severity vulnerability found in bash
  Description: Improper Check for Dropped Privileges
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-BASH-581100
  Introduced through: bash@5.0-6ubuntu1.1
  From: bash@5.0-6ubuntu1.1
  Image layer: Introduced by your base image (ubuntu:20.04)



Organization:      victor.fernandez-dyd
Package manager:   deb
Target file:       ./Dockerfile
Project name:      docker-image|snyk/ubuntu
Docker image:      snyk/ubuntu:test-0.3
Platform:          linux/amd64
Base image:        ubuntu:20.04
Licenses:          enabled

Tested 97 dependencies for known issues, found 14 issues.

According to our scan, you are currently using the most secure version of the selected base image

Pro tip: use `--exclude-base-image-vulns` to exclude from display Docker base image vulnerabilities.

To remove this message in the future, please run `snyk config set disableSuggestions=true`
```