### PR TITLE
fix: remove default RES_BODY_URL_SUB env var

### DIFF
--- a/client-templates/artifactory/.env.sample
+++ b/client-templates/artifactory/.env.sample
@@ -17,7 +17,7 @@ BROKER_HEALTHCHECK_PATH=/healthcheck
 
 # Provide RES_BODY_URL_SUB with the URL of the artifactory without credentials and http protocol
 # This URL substitution is required for NPM integration
-RES_BODY_URL_SUB=http://<yourdomain.artifactory.com>/artifactory
+# RES_BODY_URL_SUB=http://<yourdomain.artifactory.com>/artifactory
 
 # Artifactory validation url, checked by broker client systemcheck endpoint
 BROKER_CLIENT_VALIDATION_URL=https://$ARTIFACTORY_URL/api/system/ping


### PR DESCRIPTION


- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
RES_BODY_URL_SUB causes ERR_INVALID_ARG_TYPE errors because replaceUrlPartialChunk produces an 'object' for httpResponse.write, which is expecting a 'string' or 'Buffer'.

Removing this env var fixes the artifactory broker client image for non npm users (maven). A separate PR will fix replaceUrlPartialChunk so that this works in all scenarios.

