### PR TITLE
fix: replace partial chunk

### DIFF
--- a/lib/relay.js
+++ b/lib/relay.js
@@ -140,7 +140,7 @@ function requestHandler(filterRules) {
         (ioResponse) => {
           logContext.ioStatus = ioResponse.status;
           logContext.ioHeaders = ioResponse.headers;
-          logContext.ioRequestBodyType = typeof ioResponse.body
+          logContext.ioRequestBodyType = typeof ioResponse.body;
 
           const logMsg = 'sending response back to HTTP connection';
           if (ioResponse.status <= 200) {
@@ -369,7 +369,8 @@ function responseHandler(filterRules, config, io) {
 
         const status = (response && response.statusCode) || 500;
         if (config.RES_BODY_URL_SUB && isJson(response.headers)) {
-          responseBody = replaceUrlPartialChunk(responseBody, null, config);
+          const replaced = replaceUrlPartialChunk(responseBody, null, config);
+          responseBody = replaced.newChunk;
         }
         logResponse(logContext, status, response, config);
         emit({ status, body: responseBody, headers: response.headers });

--- a/test/functional/server-client.test.js
+++ b/test/functional/server-client.test.js
@@ -46,6 +46,7 @@ test('proxy requests originating from behind the broker server', (t) => {
   process.env.GIT_URL = process.env.GITHUB;
   process.env.GIT_USERNAME = process.env.USERNAME;
   process.env.GIT_PASSWORD = process.env.PASSWORD;
+  process.env.RES_BODY_URL_SUB = `http://private`;
   const client = app.main({ port: port() });
 
   // wait for the client to successfully connect to the server and identify itself
@@ -420,19 +421,22 @@ test('proxy requests originating from behind the broker server', (t) => {
         });
       });
 
-      t.test('successfully redirect exact bytes of POST body to git client', (t) => {
-        const url = `http://localhost:${serverPort}/broker/${token}/snykgit/echo-body`;
-        const body = Buffer.from(
-          JSON.stringify({ some: { example: 'json' } }, null, 5),
-        );
-        const headers = { 'Content-Type': 'application/json' };
-        request({ url, method: 'post', headers, body }, (err, res) => {
-          const responseBody = Buffer.from(res.body);
-          t.equal(res.statusCode, 200, '200 statusCode');
-          t.same(responseBody, body, 'body brokered exactly');
-          t.end();
-        });
-      });
+      t.test(
+        'successfully redirect exact bytes of POST body to git client',
+        (t) => {
+          const url = `http://localhost:${serverPort}/broker/${token}/snykgit/echo-body`;
+          const body = Buffer.from(
+            JSON.stringify({ some: { example: 'json' } }, null, 5),
+          );
+          const headers = { 'Content-Type': 'application/json' };
+          request({ url, method: 'post', headers, body }, (err, res) => {
+            const responseBody = Buffer.from(res.body);
+            t.equal(res.statusCode, 200, '200 statusCode');
+            t.same(responseBody, body, 'body brokered exactly');
+            t.end();
+          });
+        },
+      );
 
       t.test('successfully GET from git client', (t) => {
         const url = `http://localhost:${serverPort}/broker/${token}/snykgit/echo-param/xyz`;


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Fix bug replacing 'RES_BODY_URL_SUB' in relay.
The function returns an object with newChunk.
This should have been assigned to responseBody instead of the entire
object.

The effect of this was to transform our responses from a string to an object,
which when we attempt to write to the http response it throws 'ERR_INVALID_ARG_TYPE'.

Added 'RES_BODY_URL_SUB' env var to server-client functional test to
assert desired behaviour.

#### How should this be manually tested?
Without the fix to relay, you can now see the functional server-client test fail.
