### PR TITLE
fix: dockerfile name variations

### DIFF
--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -725,7 +725,7 @@
     {
       "//": "used to scan Dockerfile",
       "method": "GET",
-      "path": "/projects/:project/repos/:repo/browse*/Dockerfile",
+      "path": "/projects/:project/repos/:repo/browse*/*Dockerfile*",
       "origin": "https://${BITBUCKET_API}",
       "auth": {
         "scheme": "basic",
@@ -736,7 +736,7 @@
     {
       "//": "used to scan Dockerfile",
       "method": "GET",
-      "path": "/projects/:project/repos/:repo/browse*%2FDockerfile",
+      "path": "/projects/:project/repos/:repo/browse*%2F*Dockerfile*",
       "origin": "https://${BITBUCKET_API}",
       "auth": {
         "scheme": "basic",

--- a/client-templates/github-com/accept.json.sample
+++ b/client-templates/github-com/accept.json.sample
@@ -1098,25 +1098,25 @@
     {
       "//": "used to scan Dockerfile",
       "method": "GET",
-      "path": "/repos/:name/:repo/contents/:path*/Dockerfile",
+      "path": "/repos/:name/:repo/contents/:path*/Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
       "//": "used to scan Dockerfile",
       "method": "GET",
-      "path": "/repos/:name/:repo/contents/:path*%2FDockerfile",
+      "path": "/repos/:name/:repo/contents/:path*%2FDockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
       "//": "used to scan Dockerfile",
       "method": "GET",
-      "path": "/:name/:repo/:path*/Dockerfile",
+      "path": "/:name/:repo/:path*/Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to scan Dockerfile",
       "method": "GET",
-      "path": "/:name/:repo/:path*%2FDockerfile",
+      "path": "/:name/:repo/:path*%2FDockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
@@ -1843,25 +1843,25 @@
     {
       "//": "used to update Dockerfile",
       "method": "PUT",
-      "path": "/repos/:name/:repo/contents/:path*/Dockerfile",
+      "path": "/repos/:name/:repo/contents/:path*/Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
       "//": "used to update Dockerfile",
       "method": "PUT",
-      "path": "/repos/:name/:repo/contents/:path*%2FDockerfile",
+      "path": "/repos/:name/:repo/contents/:path*%2FDockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
       "//": "used to update Dockerfile",
       "method": "PUT",
-      "path": "/:name/:repo/:path*/Dockerfile",
+      "path": "/:name/:repo/:path*/Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update Dockerfile",
       "method": "PUT",
-      "path": "/:name/:repo/:path*%2FDockerfile",
+      "path": "/:name/:repo/:path*%2FDockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {

--- a/client-templates/github-enterprise/accept.json.sample
+++ b/client-templates/github-enterprise/accept.json.sample
@@ -762,25 +762,25 @@
     {
       "//": "used to scan Dockerfile",
       "method": "GET",
-      "path": "/repos/:name/:repo/contents/:path*/Dockerfile",
+      "path": "/repos/:name/:repo/contents/:path*/Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
       "//": "used to scan Dockerfile",
       "method": "GET",
-      "path": "/repos/:name/:repo/contents/:path*%2FDockerfile",
+      "path": "/repos/:name/:repo/contents/:path*%2FDockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
       "//": "used to scan Dockerfile",
       "method": "GET",
-      "path": "/:name/:repo/:path*/Dockerfile",
+      "path": "/:name/:repo/:path*/Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to scan Dockerfile",
       "method": "GET",
-      "path": "/:name/:repo/:path*%2FDockerfile",
+      "path": "/:name/:repo/:path*%2FDockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
@@ -1170,25 +1170,25 @@
     {
       "//": "used to update Dockerfile",
       "method": "PUT",
-      "path": "/repos/:name/:repo/contents/:path*/Dockerfile",
+      "path": "/repos/:name/:repo/contents/:path*/Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
       "//": "used to update Dockerfile",
       "method": "PUT",
-      "path": "/repos/:name/:repo/contents/:path*%2FDockerfile",
+      "path": "/repos/:name/:repo/contents/:path*%2FDockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
       "//": "used to update Dockerfile",
       "method": "PUT",
-      "path": "/:name/:repo/:path*/Dockerfile",
+      "path": "/:name/:repo/:path*/Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update Dockerfile",
       "method": "PUT",
-      "path": "/:name/:repo/:path*%2FDockerfile",
+      "path": "/:name/:repo/:path*%2FDockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {

--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -413,13 +413,13 @@
     {
       "//": "used to scan Dockerfile",
       "method": "GET",
-      "path": "/api/v4/projects/:project/repository/files*/Dockerfile",
+      "path": "/api/v4/projects/:project/repository/files*/*Dockerfile*",
       "origin": "https://${GITLAB}"
     },
     {
       "//": "used to scan Dockerfile",
       "method": "GET",
-      "path": "/api/v4/projects/:project/repository/files*%2FDockerfile",
+      "path": "/api/v4/projects/:project/repository/files*%2F*Dockerfile*",
       "origin": "https://${GITLAB}"
     },
     {
@@ -853,13 +853,13 @@
     {
       "//": "used to create Dockerfile",
       "method": "POST",
-      "path": "/api/v4/projects/:project/repository/files*/Dockerfile",
+      "path": "/api/v4/projects/:project/repository/files*/*Dockerfile*",
       "origin": "https://${GITLAB}"
     },
     {
       "//": "used to create Dockerfile",
       "method": "POST",
-      "path": "/api/v4/projects/:project/repository/files*%2FDockerfile",
+      "path": "/api/v4/projects/:project/repository/files*%2F*Dockerfile*",
       "origin": "https://${GITLAB}"
     },
     {
@@ -1290,13 +1290,13 @@
     {
       "//": "used to update Dockerfile",
       "method": "PUT",
-      "path": "/api/v4/projects/:project/repository/files*/Dockerfile",
+      "path": "/api/v4/projects/:project/repository/files*/*Dockerfile*",
       "origin": "https://${GITLAB}"
     },
     {
       "//": "used to update Dockerfile",
       "method": "PUT",
-      "path": "/api/v4/projects/:project/repository/files*%2FDockerfile",
+      "path": "/api/v4/projects/:project/repository/files*%2F*Dockerfile*",
       "origin": "https://${GITLAB}"
     },
     {


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Modifies accept.json samples so that Dockerfiles with filename prefixes or postfixes (e.g `nginx.dockerfile`, `Dockerfile-test` are also available when using broker. 

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?
[Jira Ticket](https://snyksec.atlassian.net/browse/MAGMA-1217)

#### Screenshots


#### Additional questions
