### PR TITLE
feat: require node 10 or higher

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock=false
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "broker": "./dist/cli/index.js"
   },
   "engines": {
-    "node": "12"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Versions lower than Node 10 are not supported by our websocket library (see [this](https://github.com/socketio/engine.io/blob/fe5d97fc3d7a26d34bce786a97962fae3d7ce17f/package.json#L74)) so enforcing Node>=10 will help with spotting issues early.