### PR TITLE
feat: enabling usage of accept-all.json through an env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 coverage
 /test/fixtures/certs/tmp
 accept.json
+accept-snippets.json
 package-lock.json
 /dist
 .eslintcache

--- a/client-templates/azure-repos/accept-snippets.json.sample
+++ b/client-templates/azure-repos/accept-snippets.json.sample
@@ -1,0 +1,276 @@
+{
+  "public": [
+    {
+      "//": "used for pushing up webhooks from Azure",
+      "method": "POST",
+      "path": "/webhook/azure-repos/:webhookId"
+    }
+  ],
+  "private": [
+    {
+      "//": "get list of projects for given organisation",
+      "method": "GET",
+      "path": "/_apis/projects",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
+    },
+    {
+      "//": "get specific repository for given organisation",
+      "method": "GET",
+      "path": "/:owner/_apis/git/repositories/:repo",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
+    },
+    {
+      "//": "get list of repositories for given organisation",
+      "method": "GET",
+      "path": "/:owner/_apis/git/repositories",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
+    },
+    {
+      "//": "get list of refs",
+      "method": "GET",
+      "path": "/:owner/_apis/git/repositories/:repo/refs",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
+    },
+    {
+      "//": "search through repositories of given organisation",
+      "method": "GET",
+      "path": "_apis/git/repositories",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
+    },
+    {
+      "//": "create hook",
+      "method": "POST",
+      "path": "/_apis/hooks/subscriptions",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
+    },
+    {
+      "//": "delete hook",
+      "method": "DELETE",
+      "path": "/_apis/hooks/subscriptions/:subscriptionId",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
+    },
+    {
+      "//": "get file content. restrict by file types",
+      "method": "GET",
+      "path": "/:owner/_apis/git/repositories/:repo/items",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "valid": [
+        {
+          "queryParam": "path",
+          "values": [
+            "**/package.json",
+            "**%2Fpackage.json",
+            "**/yarn.lock",
+            "**%2Fyarn.lock",
+            "**/package-lock.json",
+            "**%2Fpackage-lock.json",
+            "**/Gemfile",
+            "**%2FGemfile",
+            "**/Gemfile.lock",
+            "**%2FGemfile.lock",
+            "**/pom.xml",
+            "**%2Fpom.xml",
+            "**/*req*.txt",
+            "**%2F*req*.txt",
+            "**/requirements/*.txt",
+            "**%2Frequirements%2F*.txt",
+            "**/build.gradle",
+            "**%2Fbuild.gradle",
+            "**/gradle.lockfile",
+            "**%2Fgradle.lockfile",
+            "**/build.sbt",
+            "**%2Fbuild.sbt",
+            "**/.snyk",
+            "**%2F.snyk",
+            "**/packages.config",
+            "**%2Fpackages.config",
+            "**/*.csproj",
+            "**%2F*.csproj",
+            "**/*.vbproj",
+            "**%2F*.vbproj",
+            "**/*.fsproj",
+            "**%2F*.fsproj",
+            "**/project.json",
+            "**%2Fproject.json",
+            "**/Gopkg.toml",
+            "**%2FGopkg.toml",
+            "**/Gopkg.lock",
+            "**%2FGopkg.lock",
+            "**/vendor.json",
+            "**%2Fvendor.json",
+            "**/composer.lock",
+            "**%2Fcomposer.lock",
+            "**/composer.json",
+            "**%2Fcomposer.json",
+            "**/project.assets.json",
+            "**%2Fproject.assets.json",
+            "**/Podfile",
+            "**%2FPodfile",
+            "**/Podfile.lock",
+            "**%2FPodfile.lock",
+            "**/go.mod",
+            "**%2Fgo.mod",
+            "**/go.sum",
+            "**%2Fgo.sum",
+            "**/Dockerfile",
+            "**%2FDockerfile"
+          ]
+        },
+        {
+          "queryParam": "recursionLevel",
+          "values": ["none"]
+        },
+        {
+          "queryParam": "download",
+          "values": ["true"]
+        },
+        {
+          "queryParam": "includeContent",
+          "values": ["true"]
+        }
+      ],
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
+    },
+    {
+      "//": "get list of files for given repository",
+      "method": "GET",
+      "path": "/:owner/_apis/git/repositories/:repo/items",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "valid": [
+        {
+          "queryParam": "recursionLevel",
+          "values": ["full"]
+        },
+        {
+          "queryParam": "download",
+          "values": ["false"]
+        },
+        {
+          "queryParam": "includeContent",
+          "values": ["false"]
+        }
+      ],
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
+    },
+    {
+      "//": "get list of commits for given repository",
+      "method": "GET",
+      "path": "/:owner/_apis/git/repositories/:repo/commits",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
+    },
+    {
+      "//": "update status of given commit",
+      "method": "POST",
+      "path": "/:owner/_apis/git/repositories/:repo/commits/:commitId/statuses",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
+    },
+    {
+      "//": "update status of given pull request",
+      "method": "POST",
+      "path": "/:owner/_apis/git/repositories/:repo/pullRequests/:pullRef/statuses",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
+    },
+    {
+      "//": "find PR for given repository",
+      "method": "GET",
+      "path": "/:owner/_apis/git/repositories/:repo/pullrequests",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
+    },
+    {
+      "//": "create new PR in given repository",
+      "method": "POST",
+      "path": "/:owner/_apis/git/repositories/:repo/pullrequests",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
+    },
+    {
+      "//": "update existing PR in given repository",
+      "method": "PATCH",
+      "path": "/:owner/_apis/git/repositories/:repo/pullrequests/:pullRef",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
+    },
+    {
+      "//": "push new commit in given repository",
+      "method": "POST",
+      "path": "/:owner/_apis/git/repositories/:repo/pushes",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
+    },
+    {
+      "//": "used to redirect requests to snyk git client",
+      "method": "any",
+      "path": "/snykgit/*",
+      "origin": "${GIT_CLIENT_URL}"
+    },
+    {
+      "//": "needed for code snippets",
+      "method": "GET",
+      "path": "/:owner/_apis/git/repositories/:repo/items",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
+    }
+  ]
+}

--- a/client-templates/bitbucket-server/accept-snippets.json.sample
+++ b/client-templates/bitbucket-server/accept-snippets.json.sample
@@ -1,0 +1,996 @@
+{
+  "public": [
+    {
+      "//": "used for pushing up webhooks from bitbucket-server",
+      "method": "POST",
+      "path": "/webhook/bitbucket-server/:webhookId"
+    }
+  ],
+  "private": [
+    {
+      "//": "list the user's projects",
+      "method": "GET",
+      "path": "/projects",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "list the project's repos",
+      "method": "GET",
+      "path": "/projects/:projectKey/repos",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "list the user's repos",
+      "method": "GET",
+      "path": "/repos",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "fetch a given repo",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "read all file names to find manifests",
+      "method": "GET",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/files/:searchPath?",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/package.json",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fpackage.json",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/package-lock.json",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fpackage-lock.json",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/Gemfile.lock",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2FGemfile.lock",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/Gemfile",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2FGemfile",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/pom.xml",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fpom.xml",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/*req*.txt",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2F*req*.txt",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/requirements/*.txt",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Frequirements%2F*.txt",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/yarn.lock",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fyarn.lock",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/build.gradle",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fbuild.gradle",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/gradle.lockfile",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fgradle.lockfile",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/gradle.properties",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fgradle.properties",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/Packages.props",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2FPackages.props",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/Directory.Build.props",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2FDirectory.Build.props",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/Directory.Build.targets",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2FDirectory.Build.targets",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/build.sbt",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fbuild.sbt",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/packages.config",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fpackages.config",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/*.csproj",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2F*.csproj",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/*.vbproj",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2F*.vbproj",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/*.fsproj",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2F*.fsproj",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/project.json",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fproject.json",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/Gopkg.toml",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2FGopkg.toml",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/Gopkg.lock",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2FGopkg.lock",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/vendor.json",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fvendor.json",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/composer.lock",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fcomposer.lock",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/composer.json",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fcomposer.json",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/project.assets.json",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fproject.assets.json",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/Podfile",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2FPodfile",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/Podfile.lock",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2FPodfile.lock",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/go.mod",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fgo.mod",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/go.sum",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2Fgo.sum",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to scan Dockerfile",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/*Dockerfile*",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to scan Dockerfile",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2F*Dockerfile*",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to check if there's any ignore rules or existing patches",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*/.snyk",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to check if there's any ignore rules or existing patches",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/browse*%2F.snyk",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "get list of API capabilities",
+      "method": "GET",
+      "path": "/rest/capabilities",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "allow webhooks to be added, to allow commits to be checked by Snyk. Rules for what is sent to Snyk are controlled in the `public` accept filters",
+      "method": "POST",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/webhooks",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "allow webhooks to be deleted, used to cleanup when a user deactivates or deletes a project",
+      "method": "DELETE",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/webhooks/:webhookId",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to create commit status messages",
+      "method": "POST",
+      "path": "/rest/build-status/1.0/commits/:sha",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to create a new branch for fix PRs",
+      "method": "POST",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/branches",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to create or update a file for fix PRs",
+      "method": "PUT",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/browse/*",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to create a pull request for fix PRs",
+      "method": "POST",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to query for open pull requests by branch",
+      "method": "GET",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to check for a repo's default branch",
+      "method": "GET",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/branches/default",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "get a specific commit identified by the commit hash or name of a branch",
+      "method": "GET",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/commits/:sha",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to create a Code Insights report",
+      "method": "PUT",
+      "path": "/rest/insights/:apiVersion/projects/:project/repos/:repo/commits/:sha/reports/:report",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to remove a Code Insights report",
+      "method": "DELETE",
+      "path": "/rest/insights/:apiVersion/projects/:project/repos/:repo/commits/:sha/reports/:report",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to add Code Insights annotations to a report",
+      "method": "POST",
+      "path": "/rest/insights/:apiVersion/projects/:project/repos/:repo/commits/:sha/reports/:report/annotations",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "get list of API capabilities for Code Insights",
+      "method": "GET",
+      "path": "/rest/insights/:apiVersion/capabilities",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to remove Code Insights annotations for a report",
+      "method": "DELETE",
+      "path": "/rest/insights/:apiVersion/projects/:project/repos/:repo/commits/:sha/reports/:report/annotations",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to get current user. so we'll be able to fetch current user's repos, that are not part of any project. we're using atlassian's SDK api. Because atlassian's BB server rest api currently doesn't support such functionality",
+      "method": "GET",
+      "path": "/plugins/servlet/applinks/whoami",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to get the current user's project-like structure. So we'll be able to bind all user's private repos (that are not included in different project)",
+      "method": "GET",
+      "path": "/projects/:projectKey",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to check if the user has admin or higher permissions",
+      "method": "GET",
+      "path": "/admin/permissions/users",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to get all the users. it's called only for admin permissioned user. to retrieve all the repos they can access",
+      "method": "GET",
+      "path": "/users",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to redirect requests to snyk git client",
+      "method": "any",
+      "path": "/snykgit/*",
+      "origin": "${GIT_CLIENT_URL}"
+    },
+    {
+      "//": "needed to load code snippets",
+        "method": "GET",
+        "path": "/projects/:project/repos/:repo/browse*/:file",
+        "origin": "https://${BITBUCKET_API}",
+        "auth": {
+          "scheme": "basic",
+          "username": "${BITBUCKET_USERNAME}",
+          "password": "${BITBUCKET_PASSWORD}"
+        }
+  }
+  ]
+}

--- a/client-templates/github-com/accept-snippets.json.sample
+++ b/client-templates/github-com/accept-snippets.json.sample
@@ -1,0 +1,2006 @@
+{
+  "public": [
+    {
+      "//": "used for pushing up webhooks from github",
+      "method": "POST",
+      "path": "/webhook/github",
+      "valid": [
+        {
+          "//": "accept all pull request state changes (these don't have files in them)",
+          "path": "pull_request.state",
+          "value": "open"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "package.json"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "package.json"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "package-lock.json"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "package-lock.json"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "Gemfile.lock"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "Gemfile.lock"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "*req*.txt"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "*req*.txt"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "requirements%2F*.txt"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "requirements%2F*.txt"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "requirements/*.txt"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "requirements/*.txt"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "pom.xml"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "pom.xml"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "build.gradle"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "build.gradle"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "gradle.lockfile"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "gradle.lockfile"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "gradle.properties"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "gradle.properties"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "Packages.props"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "Packages.props"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "Directory.Build.props"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "Directory.Build.props"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "Directory.Build.targets"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "Directory.Build.targets"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "build.sbt"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "build.sbt"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "yarn.lock"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "yarn.lock"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": ".snyk"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": ".snyk"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "packages.config"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "packages.config"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "*.csproj"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "*.csproj"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "*.vbproj"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "*.vbproj"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "*.fsproj"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "*.fsproj"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "project.json"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "project.json"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "Gopkg.toml"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "Gopkg.toml"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "Gopkg.lock"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "Gopkg.lock"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "vendor.json"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "vendor.json"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "composer.lock"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "composer.lock"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "composer.json"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "composer.json"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "project.assets.json"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "project.assets.json"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "Podfile"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "Podfile"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "Podfile.lock"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "Podfile.lock"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "go.mod"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "go.mod"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "go.sum"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "go.sum"
+        }
+      ]
+    },
+    {
+      "//": "used for pushing up webhooks from github",
+      "method": "POST",
+      "path": "/webhook/github/:webhookId"
+    }
+  ],
+  "private": [
+    {
+      "//": "search for user's repos",
+      "method": "GET",
+      "path": "/search/repositories",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "list the user's info, and validate their credentials",
+      "method": "GET",
+      "path": "/user",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "list the user's orgs",
+      "method": "GET",
+      "path": "/user/orgs",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "list the logged in user's repos",
+      "method": "GET",
+      "path": "/user/repos",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "list a user's repos",
+      "method": "GET",
+      "path": "/users/:username/repos",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "list an orgs's repos",
+      "method": "GET",
+      "path": "/orgs/:username/repos",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "get a user's repo",
+      "method": "GET",
+      "path": "/repos/:user/:repo",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "rate limit check",
+      "method": "GET",
+      "path": "/rate_limit",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "allow meta lookup on the api version",
+      "method": "GET",
+      "path": "/",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "allow webhooks to be added, to allow commits to be checked by Snyk. Rules for what is sent to Snyk are controlled in the `public` accept filters",
+      "method": "POST",
+      "path": "/repos/:user/:repo/hooks",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "allow webhooks to be deleted, used to cleanup when a user deactivates or deletes a project",
+      "method": "DELETE",
+      "path": "/repos/:owner/:repo/hooks/:id",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to create commit status messages",
+      "method": "POST",
+      "path": "/repos/:user/:repo/statuses/:sha",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to list branches on a repo",
+      "method": "GET",
+      "path": "/repos/:user/:repo/branches",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to get branch info",
+      "method": "GET",
+      "path": "/repos/:user/:repo/branches/:branch",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to get status checks on a branch",
+      "method": "GET",
+      "path": "/repos/:user/:repo/branches/:branch/protection/required_status_checks/contexts",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to create status checks on a branch",
+      "method": "POST",
+      "path": "/repos/:user/:repo/branches/:branch/protection/required_status_checks/contexts",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to delete status checks on a branch",
+      "method": "DELETE",
+      "path": "/repos/:user/:repo/branches/:branch/protection/required_status_checks/contexts",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "check if repo is public",
+      "method": "GET",
+      "path": "/:user/:repo",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/package.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpackage.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/package.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fpackage.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/package-lock.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpackage-lock.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/package-lock.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fpackage-lock.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/Gemfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FGemfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/Gemfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2FGemfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/Gemfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FGemfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/Gemfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2FGemfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/pom.xml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpom.xml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/pom.xml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fpom.xml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/*req*.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2F*req*.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/*req*.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2F*req*.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/requirements/*.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Frequirements%2F*.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/requirements/*.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Frequirements%2F*.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/yarn.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fyarn.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/yarn.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fyarn.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/build.gradle",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fbuild.gradle",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/build.gradle",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fbuild.gradle",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/gradle.lockfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fgradle.lockfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/gradle.lockfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fgradle.lockfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/gradle.properties",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fgradle.properties",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/gradle.properties",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fgradle.properties",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/Packages.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FPackages.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/Packages.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2FPackages.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/Directory.Build.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FDirectory.Build.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/Directory.Build.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2FDirectory.Build.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/Directory.Build.targets",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FDirectory.Build.targets",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/Directory.Build.targets",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2FDirectory.Build.targets",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/build.sbt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fbuild.sbt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/build.sbt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fbuild.sbt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/packages.config",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpackages.config",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/packages.config",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fpackages.config",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/*.csproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2F*.csproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/*.csproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2F*.csproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/*.fsproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2F*.fsproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/*.fsproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2F*.fsproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/*.vbproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2F*.vbproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/*.vbproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2F*.vbproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/project.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fproject.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/project.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fproject.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/Gopkg.toml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FGopkg.toml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/Gopkg.toml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2FGopkg.toml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/Gopkg.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FGopkg.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/Gopkg.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2FGopkg.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/vendor.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fvendor.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/vendor.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fvendor.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/composer.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fcomposer.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/composer.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fcomposer.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/composer.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fcomposer.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/composer.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fcomposer.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/project.assets.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fproject.assets.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/project.assets.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fproject.assets.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/Podfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FPodfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/Podfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FPodfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/Podfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2FPodfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/Podfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2FPodfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/go.mod",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fgo.mod",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/go.mod",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fgo.mod",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/go.sum",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fgo.sum",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/go.sum",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fgo.sum",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to scan Dockerfile",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/Dockerfile*",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to scan Dockerfile",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FDockerfile*",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to scan Dockerfile",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/Dockerfile*",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to scan Dockerfile",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2FDockerfile*",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to check if there's any ignore rules or existing patches",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/.snyk",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to check if there's any ignore rules or existing patches",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2F.snyk",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/.snyk",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2F.snyk",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/package.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpackage.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/package.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fpackage.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/package-lock.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpackage-lock.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/package-lock.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fpackage-lock.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/Gemfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2FGemfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/Gemfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2FGemfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/Gemfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2FGemfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/Gemfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2FGemfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/pom.xml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpom.xml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/pom.xml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fpom.xml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/*req*.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2F*req*.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/*req*.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2F*req*.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/yarn.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fyarn.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/yarn.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fyarn.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/build.gradle",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fbuild.gradle",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/build.gradle",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fbuild.gradle",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/gradle.lockfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fgradle.lockfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/gradle.lockfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fgradle.lockfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/gradle.properties",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fgradle.properties",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/gradle.properties",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fgradle.properties",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/Packages.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2FPackages.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/Packages.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2FPackages.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/Directory.Build.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2FDirectory.Build.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/Directory.Build.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2FDirectory.Build.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/Directory.Build.targets",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2FDirectory.Build.targets",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/Directory.Build.targets",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2FDirectory.Build.targets",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/build.sbt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fbuild.sbt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/build.sbt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fbuild.sbt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/packages.config",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpackages.config",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/packages.config",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fpackages.config",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/*.csproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2F*.csproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/*.csproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2F*.csproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/*.fsproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2F*.fsproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/*.fsproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2F*.fsproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/*.vbproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2F*.vbproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/*.vbproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2F*.vbproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/project.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fproject.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/project.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fproject.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/Gopkg.toml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2FGopkg.toml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/Gopkg.toml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2FGopkg.toml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/Gopkg.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2FGopkg.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/Gopkg.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2FGopkg.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/vendor.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fvendor.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/vendor.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fvendor.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/composer.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fcomposer.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/composer.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fcomposer.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/composer.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fcomposer.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/composer.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fcomposer.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/project.assets.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fproject.assets.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/project.assets.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fproject.assets.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/Podfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2FPodfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/Podfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2FPodfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/Podfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2FPodfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/Podfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2FPodfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/go.mod",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fgo.mod",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/go.mod",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fgo.mod",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/go.sum",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fgo.sum",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/go.sum",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fgo.sum",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update Dockerfile",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/Dockerfile*",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update Dockerfile",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2FDockerfile*",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update Dockerfile",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/Dockerfile*",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update Dockerfile",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2FDockerfile*",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to write or update ignore rules or existing patches",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/.snyk",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to write or update ignore rules or existing patches",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2F.snyk",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+
+    {
+      "//": "get details of the repo",
+      "method": "GET",
+      "path": "/repos/:name/:repo",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "get the details of the commit to determine its SHA",
+      "method": "GET",
+      "path": "/repos/:name/:repo/commits/:ref",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}",
+      "valid": [
+        {
+          "header": "accept",
+          "values": ["application/vnd.github.v4.sha"]
+        }
+      ]
+    },
+    {
+      "//": "get a list of all the refs to match find whether an existing PR is open",
+      "method": "GET",
+      "path": "/repos/:name/:repo/git/refs",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "get the head commit of an individual ref",
+      "method": "GET",
+      "path": "/repos/:name/:repo/git/refs/heads/:ref",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "get the details of an individual ref",
+      "method": "GET",
+      "path": "/repos/:name/:repo/git/refs/:ref",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "search for open snyk pull requests",
+      "method": "GET",
+      "path": "/repos/:name/:repo/pulls",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "get pull request data for getting merge sha and tracking PR processing state",
+      "method": "GET",
+      "path": "/repos/:name/:repo/pulls/:pull_number",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "create branches for new commits",
+      "method": "POST",
+      "path": "/repos/:name/:repo/git/refs",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "create the pull request",
+      "method": "POST",
+      "path": "/repos/:name/:repo/pulls",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "add pull request assignees",
+      "method": "POST",
+      "path": "/repos/:name/:repo/issues/:pull_number/assignees",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "update ref",
+      "method": "PATCH",
+      "path": "/repos/:name/:repo/git/refs/:sha",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "update ref head",
+      "method": "PATCH",
+      "path": "/repos/:name/:repo/git/refs/heads/:ref",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "get list of all files in a repo",
+      "method": "GET",
+      "path": "/repos/:name/:repo/git/trees/:ref",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to get repo's contributors list",
+      "method": "GET",
+      "path": "/repos/:owner/:repo/commits",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to redirect requests to snyk git client",
+      "method": "any",
+      "path": "/snykgit/*",
+      "origin": "${GIT_CLIENT_URL}"
+    },
+    {
+      "//": "query graphql",
+      "method": "POST",
+      "path": "/graphql",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_GRAPHQL}",
+      "valid": [
+        {
+          "//": "query for all the file names 2 levels deep in the repo. used for auto project detection",
+          "path": "query",
+          "regex": "{\\s*repositoryOwner\\(login:\\s*\"([a-zA-Z0-9-_.]+)\"\\)\\s*{\\s*repository\\(name:\\s*\"([a-zA-Z0-9-_.]+)\"\\)\\s*{\\s*object\\(expression:\\s*\"([a-zA-Z0-9-_./:]+)\"\\)\\s*{\\s*\\.\\.\\.\\s*on\\s+Tree\\s+{\\s*entries\\s*{\\s*name\\s+type\\s+object\\s*{\\s*\\.\\.\\.\\s*on\\s+Tree\\s+{\\s*entries\\s*{\\s*name\\s+type\\s+object\\s*{\\s*\\.\\.\\.\\s*on\\s+Tree\\s*{\\s*entries\\s*{\\s*name\\s+type\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}"
+        },
+        {
+          "//": "query to find open snyk pull requests, allowing auto dependency upgrade pull requests to open no more than a limited amount of pull requests",
+          "path": "query",
+          "regex": "{\\s*search\\(\\s*query: \"repo:[a-zA-Z0-9-_.]+\\/[a-zA-Z0-9-_.]+ is:pr state:[a-zA-Z]+ head:snyk-\\s*(is:[a-zA-Z]+)?\", type: ISSUE, last: [0-9]+\\s*\\)\\s*{\\s*edges {\\s*node {\\s*\\.\\.\\. on PullRequest {\\s*url\\s*title\\s*createdAt\\s*headRefName\\s*state\\s*mergeable\\s*body\\s*repository\\s*{\\s*name\\s*}\\s*}\\s*}\\s*}\\s*}\\s*rateLimit\\s*{\\s*limit\\s*cost\\s*remaining\\s*resetAt\\s*}\\s*}\\s*"
+        },
+        {
+          "//": "query to get file SHA",
+          "path": "query",
+          "regex": "{\\s*repository\\(\\s*owner:\\s*\"[a-zA-Z0-9-_.]+\",\\s*name:\\s*\"[a-zA-Z0-9-_.]+\"\\)\\s*{\\s*object\\(\\s*expression:\\s*\"[a-zA-Z0-9-_./]+:[a-zA-Z0-9-_./]+\"\\)\\s*{\\s*\\.\\.\\.\\s*on\\s*Blob\\s*{\\s*oid\\,\\s*}\\s*}\\s*}\\s*}\\s*"
+        }
+      ]
+    },
+    {
+      "//": "needed to load code snippets",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    }
+  ]
+}

--- a/client-templates/github-enterprise/accept-snippets.json.sample
+++ b/client-templates/github-enterprise/accept-snippets.json.sample
@@ -1,0 +1,1334 @@
+{
+  "public": [
+    {
+      "//": "used for pushing up webhooks from github",
+      "method": "POST",
+      "path": "/webhook/github",
+      "valid": [
+        {
+          "//": "accept all pull request state changes (these don't have files in them)",
+          "path": "pull_request.state",
+          "value": "open"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "package.json"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "package.json"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "package-lock.json"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "package-lock.json"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "Gemfile.lock"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "Gemfile.lock"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "*req*.txt"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "*req*.txt"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "requirements%2F*.txt"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "requirements%2F*.txt"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "requirements/*.txt"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "requirements/*.txt"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "pom.xml"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "pom.xml"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "build.gradle"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "build.gradle"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "gradle.lockfile"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "gradle.lockfile"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "gradle.properties"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "gradle.properties"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "Directory.Build.targets"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "Directory.Build.targets"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "Packages.props"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "Packages.props"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "Directory.Build.props"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "Directory.Build.props"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "build.sbt"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "build.sbt"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "yarn.lock"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "yarn.lock"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": ".snyk"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": ".snyk"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "packages.config"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "packages.config"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "*.csproj"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "*.csproj"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "*.vbproj"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "*.vbproj"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "*.fsproj"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "*.fsproj"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "project.json"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "project.json"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "Gopkg.toml"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "Gopkg.toml"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "Gopkg.lock"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "Gopkg.lock"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "vendor.json"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "vendor.json"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "composer.lock"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "composer.lock"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "composer.json"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "composer.json"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "project.assets.json"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "project.assets.json"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "Podfile"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "Podfile"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "Podfile.lock"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "Podfile.lock"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "go.mod"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "go.mod"
+        },
+        {
+          "path": "commits.*.added.*",
+          "value": "go.sum"
+        },
+        {
+          "path": "commits.*.modified.*",
+          "value": "go.sum"
+        }
+      ]
+    },
+    {
+      "//": "used for pushing up webhooks from github",
+      "method": "POST",
+      "path": "/webhook/github/:webhookId"
+    }
+  ],
+  "private": [
+    {
+      "//": "search for user's repos",
+      "method": "GET",
+      "path": "/search/repositories",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "list the user's info, and validate their credentials",
+      "method": "GET",
+      "path": "/user",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "list the user's orgs",
+      "method": "GET",
+      "path": "/user/orgs",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "list the logged in user's repos",
+      "method": "GET",
+      "path": "/user/repos",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "list a user's repos",
+      "method": "GET",
+      "path": "/users/:username/repos",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "list an orgs's repos",
+      "method": "GET",
+      "path": "/orgs/:username/repos",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "get a user's repo",
+      "method": "GET",
+      "path": "/repos/:user/:repo",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "rate limit check",
+      "method": "GET",
+      "path": "/rate_limit",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "allow meta lookup on the api version",
+      "method": "GET",
+      "path": "/",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "allow webhooks to be added, to allow commits to be checked by Snyk. Rules for what is sent to Snyk are controlled in the `public` accept filters",
+      "method": "POST",
+      "path": "/repos/:user/:repo/hooks",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "allow webhooks to be deleted, used to cleanup when a user deactivates or deletes a project",
+      "method": "DELETE",
+      "path": "/repos/:owner/:repo/hooks/:id",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to create commit status messages",
+      "method": "POST",
+      "path": "/repos/:user/:repo/statuses/:sha",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to list branches on a repo",
+      "method": "GET",
+      "path": "/repos/:user/:repo/branches",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to get branch info",
+      "method": "GET",
+      "path": "/repos/:user/:repo/branches/:branch",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to get status checks on a branch",
+      "method": "GET",
+      "path": "/repos/:user/:repo/branches/:branch/protection/required_status_checks/contexts",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to create status checks on a branch",
+      "method": "POST",
+      "path": "/repos/:user/:repo/branches/:branch/protection/required_status_checks/contexts",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to delete status checks on a branch",
+      "method": "DELETE",
+      "path": "/repos/:user/:repo/branches/:branch/protection/required_status_checks/contexts",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "check if repo is public",
+      "method": "GET",
+      "path": "/:user/:repo",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/package.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpackage.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/package-lock.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpackage-lock.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/Gemfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FGemfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/Gemfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FGemfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/pom.xml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpom.xml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/*req*.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2F*req*.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/requirements/*.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Frequirements%2F*.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/yarn.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fyarn.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/build.gradle",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fbuild.gradle",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/gradle.lockfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fgradle.lockfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/gradle.properties",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fgradle.properties",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/Packages.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FPackages.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/Directory.Build.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FDirectory.Build.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/Directory.Build.targets",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FDirectory.Build.targets",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/build.sbt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fbuild.sbt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/packages.config",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpackages.config",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/*.csproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2F*.csproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/*.fsproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2F*.fsproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/*.vbproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2F*.vbproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/project.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fproject.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/Gopkg.toml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FGopkg.toml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/Gopkg.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FGopkg.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/vendor.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fvendor.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/composer.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fcomposer.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/composer.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fcomposer.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/project.assets.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fproject.assets.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/Podfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FPodfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/Podfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FPodfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/go.mod",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fgo.mod",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/go.mod",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fgo.mod",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/go.sum",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2Fgo.sum",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/go.sum",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2Fgo.sum",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to scan Dockerfile",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/Dockerfile*",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to scan Dockerfile",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2FDockerfile*",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to scan Dockerfile",
+      "method": "GET",
+      "path": "/:name/:repo/:path*/Dockerfile*",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to scan Dockerfile",
+      "method": "GET",
+      "path": "/:name/:repo/:path*%2FDockerfile*",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/package.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpackage.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/package-lock.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpackage-lock.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/Gemfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2FGemfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/Gemfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2FGemfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/pom.xml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpom.xml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/*req*.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2F*req*.txt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/yarn.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fyarn.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/build.gradle",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fbuild.gradle",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/gradle.lockfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fgradle.lockfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/gradle.properties",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fgradle.properties",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/Packages.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2FPackages.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/Directory.Build.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2FDirectory.Build.props",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/Directory.Build.targets",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2FDirectory.Build.targets",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/build.sbt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fbuild.sbt",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/packages.config",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fpackages.config",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/*.csproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2F*.csproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/*.fsproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2F*.fsproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/*.vbproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2F*.vbproj",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/project.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fproject.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/Gopkg.toml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2FGopkg.toml",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/Gopkg.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2FGopkg.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/vendor.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fvendor.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/composer.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fcomposer.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/composer.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fcomposer.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/project.assets.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fproject.assets.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/Podfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2FPodfile",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/Podfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2FPodfile.lock",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/go.mod",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fgo.mod",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/go.mod",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fgo.mod",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/go.sum",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2Fgo.sum",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/go.sum",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update manifest or lock",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2Fgo.sum",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to write or update ignore rules or existing patches",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/.snyk",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to write or update ignore rules or existing patches",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2F.snyk",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update Dockerfile",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*/Dockerfile*",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update Dockerfile",
+      "method": "PUT",
+      "path": "/repos/:name/:repo/contents/:path*%2FDockerfile*",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to update Dockerfile",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*/Dockerfile*",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to update Dockerfile",
+      "method": "PUT",
+      "path": "/:name/:repo/:path*%2FDockerfile*",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
+    },
+    {
+      "//": "used to check if there's any ignore rules or existing patches",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/.snyk",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to check if there's any ignore rules or existing patches",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*%2F.snyk",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "get details of the repo",
+      "method": "GET",
+      "path": "/repos/:name/:repo",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "get the details of the commit to determine its SHA",
+      "method": "GET",
+      "path": "/repos/:name/:repo/commits/:ref",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}",
+      "valid": [
+        {
+          "header": "accept",
+          "values": [
+            "application/vnd.github.v4.sha"
+          ]
+        }
+      ]
+    },
+    {
+      "//": "get a list of all the refs to match find whether an existing PR is open",
+      "method": "GET",
+      "path": "/repos/:name/:repo/git/refs",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "get the head commit of an individual ref",
+      "method": "GET",
+      "path": "/repos/:name/:repo/git/refs/heads/:ref",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "get the details of an individual ref",
+      "method": "GET",
+      "path": "/repos/:name/:repo/git/refs/:ref",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "search for open snyk pull requests",
+      "method": "GET",
+      "path": "/repos/:name/:repo/pulls",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "get pull request data for getting merge sha and tracking PR processing state",
+      "method": "GET",
+      "path": "/repos/:name/:repo/pulls/:pull_number",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "add commit data for new PR",
+      "method": "POST",
+      "path": "/repos/:name/:repo/git/refs",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "create the pull request",
+      "method": "POST",
+      "path": "/repos/:name/:repo/pulls",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "add pull request assignees",
+      "method": "POST",
+      "path": "/repos/:name/:repo/issues/:pull_number/assignees",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "update ref",
+      "method": "PATCH",
+      "path": "/repos/:name/:repo/git/refs/:sha",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "update ref head",
+      "method": "PATCH",
+      "path": "/repos/:name/:repo/git/refs/heads/:ref",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "get list of all files in a repo",
+      "method": "GET",
+      "path": "/repos/:name/:repo/git/trees/:ref",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to get repo's contributors list",
+      "method": "GET",
+      "path": "/repos/:owner/:repo/commits",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to redirect requests to snyk git client",
+      "method": "any",
+      "path": "/snykgit/*",
+      "origin": "${GIT_CLIENT_URL}"
+    },
+    {
+      "//": "query graphql",
+      "method": "POST",
+      "path": "/graphql",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_GRAPHQL}",
+      "valid": [
+        {
+          "//": "query for all the file names 2 levels deep in the repo. used for auto project detection",
+          "path": "query",
+          "regex": "{\\s*repositoryOwner\\(login:\\s*\"([a-zA-Z0-9-_.]+)\"\\)\\s*{\\s*repository\\(name:\\s*\"([a-zA-Z0-9-_.]+)\"\\)\\s*{\\s*object\\(expression:\\s*\"([a-zA-Z0-9-_./:]+)\"\\)\\s*{\\s*\\.\\.\\.\\s*on\\s+Tree\\s+{\\s*entries\\s*{\\s*name\\s+type\\s+object\\s*{\\s*\\.\\.\\.\\s*on\\s+Tree\\s+{\\s*entries\\s*{\\s*name\\s+type\\s+object\\s*{\\s*\\.\\.\\.\\s*on\\s+Tree\\s*{\\s*entries\\s*{\\s*name\\s+type\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}\\s*}"
+        },
+        {
+          "//": "query to find open snyk pull requests, allowing auto dependency upgrade pull requests to open no more than a limited amount of pull requests",
+          "path": "query",
+          "regex": "{\\s*search\\(\\s*query: \"repo:[a-zA-Z0-9-_.]+\\/[a-zA-Z0-9-_.]+ is:pr state:[a-zA-Z]+ head:snyk-\\s*(is:[a-zA-Z]+)?\", type: ISSUE, last: [0-9]+\\s*\\)\\s*{\\s*edges {\\s*node {\\s*\\.\\.\\. on PullRequest {\\s*url\\s*title\\s*createdAt\\s*headRefName\\s*state\\s*mergeable\\s*body\\s*repository\\s*{\\s*name\\s*}\\s*}\\s*}\\s*}\\s*}\\s*rateLimit\\s*{\\s*limit\\s*cost\\s*remaining\\s*resetAt\\s*}\\s*}\\s*"
+        },
+        {
+          "//": "query to get file SHA",
+          "path": "query",
+          "regex": "{\\s*repository\\(\\s*owner:\\s*\"[a-zA-Z0-9-_.]+\",\\s*name:\\s*\"[a-zA-Z0-9-_.]+\"\\)\\s*{\\s*object\\(\\s*expression:\\s*\"[a-zA-Z0-9-_./]+:[a-zA-Z0-9-_./]+\"\\)\\s*{\\s*\\.\\.\\.\\s*on\\s*Blob\\s*{\\s*oid\\,\\s*}\\s*}\\s*}\\s*}\\s*"
+        }
+      ]
+    },
+    {
+      "//": "needed to load code snippets",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    }
+  ]
+}

--- a/client-templates/gitlab/accept-snippets.json.sample
+++ b/client-templates/gitlab/accept-snippets.json.sample
@@ -1,0 +1,1471 @@
+{
+  "public": [
+    {
+      "//": "used for pushing up webhooks from gitlab",
+      "method": "POST",
+      "path": "/webhook/gitlab/:webhookId"
+    }
+  ],
+  "private": [
+    {
+      "//": "identify user",
+      "method": "GET",
+      "path": "/api/v4/user",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "list the user's projects",
+      "method": "GET",
+      "path": "/api/v4/projects",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "list the user's projects",
+      "method": "GET",
+      "path": "/api/v3/projects",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "list the user's visible projects",
+      "method": "GET",
+      "path": "/api/v3/projects/visible",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "get a user's project",
+      "method": "GET",
+      "path": "/api/v3/projects/:project",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "get a user's project",
+      "method": "GET",
+      "path": "/api/v4/projects/:project",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to search all manifest files",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/tree",
+      "origin": "https://${GITLAB}"
+    },
+
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/package.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fpackage.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/package-lock.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fpackage-lock.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/Gemfile.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2FGemfile.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/Gemfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2FGemfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/pom.xml",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fpom.xml",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/*req*.txt",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2F*req*.txt",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/requirements/*.txt",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Frequirements%2F*.txt",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/yarn.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fyarn.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/build.gradle",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fbuild.gradle",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/gradle.lockfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fgradle.lockfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/gradle.properties",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fgradle.properties",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/Directory.Build.targets",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2FDirectory.Build.targets",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/Directory.Build.props",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2FDirectory.Build.props",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/Packages.props",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2FPackages.props",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/build.sbt",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fbuild.sbt",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/packages.config",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fpackages.config",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/*.csproj",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2F*.csproj",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/*.vbproj",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2F*.vbproj",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/*.fsproj",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2F*.fsproj",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/project.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fproject.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/Gopkg.toml",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2FGopkg.toml",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/Gopkg.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2FGopkg.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/vendor.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fvendor.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/composer.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fcomposer.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/composer.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fcomposer.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/project.assets.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fproject.assets.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/Podfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2FPodfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/Podfile.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2FPodfile.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/go.mod",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fgo.mod",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/go.sum",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2Fgo.sum",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to scan Dockerfile",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/*Dockerfile*",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to scan Dockerfile",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2F*Dockerfile*",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to check if there's any ignore rules or existing patches",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*/.snyk",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to check if there's any ignore rules or existing patches",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files*%2F.snyk",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to determine the full dependency tree for v3 protocol",
+      "method": "GET",
+      "path": "/api/v3/projects/:project/repository/files",
+      "origin": "https://${GITLAB}",
+      "valid": [
+        {
+          "queryParam": "file_path",
+          "values": [
+            "**/package.json",
+            "**%2Fpackage.json",
+            "**/yarn.lock",
+            "**%2Fyarn.lock",
+            "**/package-lock.json",
+            "**%2Fpackage-lock.json",
+            "**/Gemfile",
+            "**%2FGemfile",
+            "**/Gemfile.lock",
+            "**%2FGemfile.lock",
+            "**/pom.xml",
+            "**%2Fpom.xml",
+            "**/*req*.txt",
+            "**%2F*req*.txt",
+            "**/requirements/*.txt",
+            "**%2Frequirements%2F*.txt",
+            "**/build.gradle",
+            "**%2Fbuild.gradle",
+            "**/gradle.lockfile",
+            "**%2Fgradle.lockfile",
+            "**/build.sbt",
+            "**%2Fbuild.sbt",
+            "**/.snyk",
+            "**%2F.snyk",
+            "**/packages.config",
+            "**%2Fpackages.config",
+            "**/*.csproj",
+            "**%2F*.csproj",
+            "**/*.vbproj",
+            "**%2F*.vbproj",
+            "**/*.fsproj",
+            "**%2F*.fsproj",
+            "**/project.json",
+            "**%2Fproject.json",
+            "**/Gopkg.toml",
+            "**%2FGopkg.toml",
+            "**/Gopkg.lock",
+            "**%2FGopkg.lock",
+            "**/vendor.json",
+            "**%2Fvendor.json",
+            "**/composer.lock",
+            "**%2Fcomposer.lock",
+            "**/composer.json",
+            "**%2Fcomposer.json",
+            "**/project.assets.json",
+            "**%2Fproject.assets.json",
+            "**/Podfile",
+            "**%2FPodfile",
+            "**/Podfile.lock",
+            "**%2FPodfile.lock",
+            "**/go.mod",
+            "**%2Fgo.mod",
+            "**/go.sum",
+            "**%2Fgo.sum"
+          ]
+        }
+      ]
+    },
+
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/package.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2Fpackage.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/package-lock.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2Fpackage-lock.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/Gemfile.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2FGemfile.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/Gemfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2FGemfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/pom.xml",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2Fpom.xml",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/*req*.txt",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2F*req*.txt",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/yarn.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2Fyarn.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/build.gradle",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2Fbuild.gradle",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/gradle.lockfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2Fgradle.lockfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/gradle.properties",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2Fgradle.properties",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/Directory.Build.targets",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2FDirectory.Build.targets",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/Directory.Build.props",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2FDirectory.Build.props",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/Packages.props",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2FPackages.props",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/build.sbt",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2Fbuild.sbt",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/packages.config",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2Fpackages.config",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/*.csproj",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2F*.csproj",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/*.vbproj",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2F*.vbproj",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/*.fsproj",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2F*.fsproj",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/project.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2Fproject.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/Gopkg.toml",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2FGopkg.toml",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/Gopkg.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2FGopkg.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/vendor.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2Fvendor.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/composer.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2Fcomposer.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/composer.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2Fcomposer.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/project.assets.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2Fproject.assets.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/Podfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2FPodfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/Podfile.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2FPodfile.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/go.mod",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2Fgo.mod",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/go.sum",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2Fgo.sum",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create Dockerfile",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/*Dockerfile*",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create Dockerfile",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2F*Dockerfile*",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create ignore rules or patches",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*/.snyk",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create ignore rules or patches",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/files*%2F.snyk",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create manifest file for v3 protocol",
+      "method": "POST",
+      "path": "/api/v3/projects/:project/repository/files",
+      "origin": "https://${GITLAB}",
+      "valid": [
+        {
+          "queryParam": "file_path",
+          "values": [
+            "**/package.json",
+            "**%2Fpackage.json",
+            "**/yarn.lock",
+            "**%2Fyarn.lock",
+            "**/package-lock.json",
+            "**%2Fpackage-lock.json",
+            "**/Gemfile",
+            "**%2FGemfile",
+            "**/Gemfile.lock",
+            "**%2FGemfile.lock",
+            "**/pom.xml",
+            "**%2Fpom.xml",
+            "**/*req*.txt",
+            "**%2F*req*.txt",
+            "**/build.gradle",
+            "**%2Fbuild.gradle",
+            "**/gradle.lockfile",
+            "**%2Fgradle.lockfile",
+            "**/build.sbt",
+            "**%2Fbuild.sbt",
+            "**/.snyk",
+            "**%2F.snyk",
+            "**/packages.config",
+            "**%2Fpackages.config",
+            "**/*.csproj",
+            "**%2F*.csproj",
+            "**/*.vbproj",
+            "**%2F*.vbproj",
+            "**/*.fsproj",
+            "**%2F*.fsproj",
+            "**/project.json",
+            "**%2Fproject.json",
+            "**/Gopkg.toml",
+            "**%2FGopkg.toml",
+            "**/Gopkg.lock",
+            "**%2FGopkg.lock",
+            "**/vendor.json",
+            "**%2Fvendor.json",
+            "**/composer.lock",
+            "**%2Fcomposer.lock",
+            "**/composer.json",
+            "**%2Fcomposer.json",
+            "**/project.assets.json",
+            "**%2Fproject.assets.json",
+            "**/Podfile",
+            "**%2FPodfile",
+            "**/Podfile.lock",
+            "**%2FPodfile.lock",
+            "**/go.mod",
+            "**%2Fgo.mod",
+            "**/go.sum",
+            "**%2Fgo.sum"
+          ]
+        }
+      ]
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/package.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2Fpackage.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/package-lock.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2Fpackage-lock.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/Gemfile.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2FGemfile.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/Gemfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2FGemfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/pom.xml",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2Fpom.xml",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/*req*.txt",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2F*req*.txt",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/yarn.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2Fyarn.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/build.gradle",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2Fbuild.gradle",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/gradle.lockfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2Fgradle.lockfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/gradle.properties",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2Fgradle.properties",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/Directory.Build.targets",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2FDirectory.Build.targets",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/Directory.Build.props",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2FDirectory.Build.props",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/Packages.props",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2FPackages.props",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/build.sbt",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2Fbuild.sbt",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/packages.config",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2Fpackages.config",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/*.csproj",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2F*.csproj",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/*.vbproj",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2F*.vbproj",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/*.fsproj",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2F*.fsproj",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/project.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2Fproject.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/Gopkg.toml",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2FGopkg.toml",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/Gopkg.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2FGopkg.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/vendor.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2Fvendor.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/composer.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2Fcomposer.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/composer.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2Fcomposer.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/project.assets.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2Fproject.assets.json",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/Podfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2FPodfile",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/Podfile.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2FPodfile.lock",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/go.mod",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2Fgo.mod",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/go.sum",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2Fgo.sum",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update Dockerfile",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/*Dockerfile*",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update Dockerfile",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2F*Dockerfile*",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update ignore rules or existing patches",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*/.snyk",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update ignore rules or existing patches",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/repository/files*%2F.snyk",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to update manifest file for v3 protocol",
+      "method": "PUT",
+      "path": "/api/v3/projects/:project/repository/files",
+      "origin": "https://${GITLAB}",
+      "valid": [
+        {
+          "queryParam": "file_path",
+          "values": [
+            "**/package.json",
+            "**%2Fpackage.json",
+            "**/yarn.lock",
+            "**%2Fyarn.lock",
+            "**/package-lock.json",
+            "**%2Fpackage-lock.json",
+            "**/Gemfile",
+            "**%2FGemfile",
+            "**/Gemfile.lock",
+            "**%2FGemfile.lock",
+            "**/pom.xml",
+            "**%2Fpom.xml",
+            "**/*req*.txt",
+            "**%2F*req*.txt",
+            "**/build.gradle",
+            "**%2Fbuild.gradle",
+            "**/gradle.lockfile",
+            "**%2Fgradle.lockfile",
+            "**/build.sbt",
+            "**%2Fbuild.sbt",
+            "**/.snyk",
+            "**%2F.snyk",
+            "**/packages.config",
+            "**%2Fpackages.config",
+            "**/*.csproj",
+            "**%2F*.csproj",
+            "**/*.vbproj",
+            "**%2F*.vbproj",
+            "**/*.fsproj",
+            "**%2F*.fsproj",
+            "**/project.json",
+            "**%2Fproject.json",
+            "**/Gopkg.toml",
+            "**%2FGopkg.toml",
+            "**/Gopkg.lock",
+            "**%2FGopkg.lock",
+            "**/vendor.json",
+            "**%2Fvendor.json",
+            "**/composer.lock",
+            "**%2Fcomposer.lock",
+            "**/composer.json",
+            "**%2Fcomposer.json",
+            "**/project.assets.json",
+            "**%2Fproject.assets.json",
+            "**/Podfile",
+            "**%2FPodfile",
+            "**/Podfile.lock",
+            "**%2FPodfile.lock",
+            "**/go.mod",
+            "**%2Fgo.mod",
+            "**/go.sum",
+            "**%2Fgo.sum"
+          ]
+        }
+      ]
+    },
+
+    {
+      "//": "allow webhooks to be added, to allow commits to be checked by Snyk. Rules for what is sent to Snyk are controlled in the `public` accept filters",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/hooks",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "allow webhooks to be deleted, used to cleanup when a user deactivates or deletes a project",
+      "method": "DELETE",
+      "path": "/api/v4/projects/:project/hooks/:id",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create commit status messages",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/statuses/:sha",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create branch for fix merge request",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/branches",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to create merge request for fix merge request",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/merge_requests",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to fetch fix merge request information",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/merge_requests",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "list the user's groups",
+      "method": "GET",
+      "path": "/api/v4/groups",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "list of projects in a group",
+      "method": "GET",
+      "path": "/api/v4/groups/:id/projects",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "get current user. so we'll be able to fetch it's projects",
+      "method": "GET",
+      "path": "/api/v4/user",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "get user's projects",
+      "method": "GET",
+      "path": "/api/v4/users/:user/projects",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "get all users. so we'll be able to fetch projects that admin can access",
+      "method": "GET",
+      "path": "/api/v4/users",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to get repo's contributors list",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/commits",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "get a specific commit identified by the commit hash or name of a branch or tag.",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/commits/:sha",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to redirect requests to snyk git client",
+      "method": "any",
+      "path": "/snykgit/*",
+      "origin": "${GIT_CLIENT_URL}"
+    },
+    {
+      "//": "needed to load code snippets",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/files/:path",
+      "origin": "https://${GITLAB}"
+    }
+  ]
+}


### PR DESCRIPTION
- [] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This is a PR that aims to facilitate enabling code-snippet in brokered flow and to enhance customers UX (as raised [here](https://snyk.slack.com/archives/C01T8J66QMS/p1634333215069800)) by creating an `accept-snippets.json` file that customers can opt-in for by passing `ACCEPT=accept-snippets.json` as shown [here](https://docs.snyk.io/features/integrations/snyk-broker/how-to-install-and-configure-your-snyk-broker-client)
 
#### The downside 
With this, we will have more `accept` files to maintain, but this feature's value surpasses the negative ones IMO.
We could think of a proper solution for the future, like a cascading config mechanism similar to what we have in Registry.
