### PR TITLE
feat: add setup for Nexus repositories

### DIFF
--- a/client-templates/nexus/.env.sample
+++ b/client-templates/nexus/.env.sample
@@ -1,0 +1,29 @@
+# your unique broker identifier
+BROKER_TOKEN=<broker-token>
+
+# The Base URL for your Nexus Repository Manager
+# If not using basic auth this will only be "https://<your.nexus.hostname>/repository"
+BASE_NEXUS_URL=https://<username>:<password>@<your.nexus.hostname>
+
+# The URL to your Nexus Repository Manager
+NEXUS_URL=$BASE_NEXUS_URL/repository
+
+# The URL of the Snyk broker server
+BROKER_SERVER_URL=https://broker.snyk.io
+
+# the fine detail accept rules that allow Snyk to make API requests to your
+# Nexus instance
+ACCEPT=accept.json
+
+# The path for the broker's internal healthcheck URL. Must start with a '/'.
+BROKER_HEALTHCHECK_PATH=/healthcheck
+
+# Provide RES_BODY_URL_SUB with the URL of the Nexus without credentials and http protocol
+# This URL substitution is required for NPM integration
+# RES_BODY_URL_SUB=http://<your.nexus.hostname>/repository
+
+# Nexus validation url, checked by broker client systemcheck endpoint
+# readonly users must have 'nx-metrics-all' privilege enabled to access
+# https://support.sonatype.com/hc/en-us/articles/226254487-System-Status-and-Metrics-REST-API
+BROKER_CLIENT_VALIDATION_URL=$BASE_NEXUS_URL/service/rest/v1/status/check
+BROKER_CLIENT_VALIDATION_JSON_DISABLED=true

--- a/client-templates/nexus/accept.json.sample
+++ b/client-templates/nexus/accept.json.sample
@@ -1,0 +1,16 @@
+{
+  "public": [
+    {
+      "method": "any",
+      "path": "/*",
+      "stream": true
+    }
+  ],
+  "private": [
+    {
+      "method": "any",
+      "path": "/*",
+      "origin": "${NEXUS_URL}"
+    }
+  ]
+}

--- a/dockerfiles/nexus/Dockerfile
+++ b/dockerfiles/nexus/Dockerfile
@@ -1,0 +1,61 @@
+FROM snyk/ubuntu as base
+
+MAINTAINER Snyk Ltd
+
+USER root
+
+RUN apt update && apt install -y make python gcc
+
+RUN apt-get update && apt-get install -y ca-certificates
+
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+RUN npm install --global snyk-broker
+
+
+
+FROM snyk/ubuntu
+
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+COPY --from=base /home/node/.npm-global /home/node/.npm-global
+
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Don't run as root
+WORKDIR /home/node
+USER node
+
+# Generate default accept filter
+RUN broker init nexus
+
+######################################
+# Custom Broker Client configuration #
+# Redefine in derived Dockerfile,    #
+# or provide as runtime args `-e`    #
+######################################
+
+# Your unique Broker identifier
+# ENV BROKER_TOKEN <broker-token>
+
+# The URL to your Nexus Repository Manager
+# NOTA BENE: without `/` character in the end of URL
+# ENV NEXUS_URL=<username>:<password>@<your.nexus.hostname>/repository
+
+# Provide RES_BODY_URL_SUB with the URL of the nexus without credentials and http protocol
+# This URL substitution is required for NPM integration
+# RES_BODY_URL_SUB=http://<your.nexus.hostname>/repository
+
+# The port used by the broker client to accept internal connections
+# Default value is 7341
+# ENV PORT 7341
+
+# The URL of your broker client (including scheme and port)
+# This will be used as the webhook payload URL coming in from Jira
+# ENV BROKER_CLIENT_URL http://<broker.client.hostname>:$PORT
+
+EXPOSE $PORT
+
+CMD ["broker", "--verbose"]

--- a/lib/log.js
+++ b/lib/log.js
@@ -102,6 +102,10 @@ function sanitise(raw) {
     raw = sanitiseConfigVariable(raw, 'GIT_CLIENT_URL');
   }
 
+  if (config.NEXUS_URL) {
+    raw = sanitiseConfigVariable(raw, 'NEXUS_URL');
+  }
+
   return raw;
 }
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
- add Dockerfile and client-templates files for Nexus private repos

#### Where should the reviewer start?
- compare with Artifactory structure

#### How should this be manually tested?
1 - BASIC CHECK - build the docker image to check it produces it correctly as a basic check, e.g. `docker build -t broker-nexus-client`

2 - BASIC CHECK - run `./dist/cli/index.js init nexus` (or `npm link` at the root to link the bin to the global bin dir so you can run   `broker init nexus` instead) -> check there are no errors and the Nexus `.env` and `accept.json` available in the root dir with the repo locally.

3 - FULL CHECK (run a container for Nexus broker client, Snyk broker server and a separate container to make requests to the broker server)
- Build the broker server image and run in a container. This requires just changing last line of `Dockerfile` to `CMD ["broker", "server", "--verbose"]` and running `docker build -t broker-server`. Then run using `docker run -d broker-server`. Undo changes to the `Dockerfile` afterwards.
- Since I had trouble getting the containers to communicate with running broker server locally or in a container using `host.docker.internal` etc., I resorted to using the Docker default bridge IP of the broker server created above, which I passed as an environment variable in the next step. I found the IP by doing `docker inspect <broker-server_container_id> | grep IPAddress` -> e.g. `172.17.0.2`
- Build the Nexus broker client image and run in a container. Since we do `RUN npm install --global snyk-broker` on line 15, this will not have the latest Nexus client templates. Therefore, I added `COPY ../../client-templates/nexus/ /home/node/.npm-global/lib/node_modules/snyk-broker/dist/client-templates/nexus/` to below line 25, so that the image would have the latest Nexus client template. Then ran `docker build -t broker-nexus-client -f ./dockerfiles/nexus/Dockerfile .` from the root (since my `COPY` command requires directory traversal, you need to build the image from the root in this case, so Docker build has full context). I then ran this image using `docker run -d -e BROKER_TOKEN=<UUID-token> -e BASE_NEXUS_URL=https://<pre-prod-nexus-user>:<pre-prod-nexus-password>@nexus.dev.snyk.io -e BROKER_SERVER_URL=http://172.17.0.2:7341 broker-nexus-client`. Then exec into this to check the `.env` and `accept.json` are there as required using `docker exec -it <broker-nexus-client> bash`.
- Run docker logs for both the client and the server in different terminals and we should see the websocket connection created, using `docker logs -f <container-id>`. In the client logs you should see `successfully established a websocket connection to the broker server` and the in the server logs you should see `new client connection` and `new client connection identified` indicating a successful outcome.
- Run a separate container using any image you like, so we can make requests to the broker server endpoints to check. I just used `snyk/ubuntu` and ran `docker run -dit snyk/ubuntu`. Then exec on to the container as root user and install `curl` in my case (you can use what you like or another image), using `docker exec --user=root -it <this-container-id> bash` and do `apt-get install curl`. Broker / client server logs will provide some additional info if needed when running the following commands. Firstly you can check that the broker server recognizes the token using `curl http://172.17.0.2:7341/connection-status/<broker-client-UUID-token>` => check the broker server logs, you should see `{"ok":false}` for incorrect token and `{"ok":true,"clients":[{"version":"4.118.1","filters":{"public":[{"method":"any","path":"/*","stream":true}],"private":[{"method":"any","path":"/*","origin":"${NEXUS_URL}"}]}}]` for the correct token. Next, I added a test POM to https://nexus.dev.snyk.io/repository/maven-releases/com/mycompany/app/my-app/1/my-app-1.pom. So we can check if the proxying to this POM file occurs via the broker connection correctly -> run `curl http://172.17.0.2:7341/broker/a8937793-eca5-420c-a366-eef864c029f6/maven-releases/com/mycompany/app/my-app/1/my-app-1.pom` and you should see the correct POM.xml output.

#### Any background context you want to provide?
- Being done as part of Nexus integration work by Tardis - [TARDIS-364](https://snyksec.atlassian.net/browse/TARDIS-364)
- Will be used to build a pre-prod-broker-client for Nexus - https://github.com/snyk/pre-prod-broker-clients 
- Will be used and tested with `pre-prod-nexus` server in the pre-prod MT cluster
- We need to update the README to include Nexus once the integration is ready for public consumption
