### PR TITLE
fix: Accept dockerfile with prefix in github and ghe

### DIFF
--- a/client-templates/github-com/accept.json.sample
+++ b/client-templates/github-com/accept.json.sample
@@ -1098,25 +1098,25 @@
     {
       "//": "used to scan Dockerfile",
       "method": "GET",
-      "path": "/repos/:name/:repo/contents/:path*/Dockerfile*",
+      "path": "/repos/:name/:repo/contents/:path*/*Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
       "//": "used to scan Dockerfile",
       "method": "GET",
-      "path": "/repos/:name/:repo/contents/:path*%2FDockerfile*",
+      "path": "/repos/:name/:repo/contents/:path*%2F*Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
       "//": "used to scan Dockerfile",
       "method": "GET",
-      "path": "/:name/:repo/:path*/Dockerfile*",
+      "path": "/:name/:repo/:path*/*Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to scan Dockerfile",
       "method": "GET",
-      "path": "/:name/:repo/:path*%2FDockerfile*",
+      "path": "/:name/:repo/:path*%2F*Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
@@ -1843,25 +1843,25 @@
     {
       "//": "used to update Dockerfile",
       "method": "PUT",
-      "path": "/repos/:name/:repo/contents/:path*/Dockerfile*",
+      "path": "/repos/:name/:repo/contents/:path*/*Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
       "//": "used to update Dockerfile",
       "method": "PUT",
-      "path": "/repos/:name/:repo/contents/:path*%2FDockerfile*",
+      "path": "/repos/:name/:repo/contents/:path*%2F*Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
       "//": "used to update Dockerfile",
       "method": "PUT",
-      "path": "/:name/:repo/:path*/Dockerfile*",
+      "path": "/:name/:repo/:path*/*Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update Dockerfile",
       "method": "PUT",
-      "path": "/:name/:repo/:path*%2FDockerfile*",
+      "path": "/:name/:repo/:path*%2F*Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {

--- a/client-templates/github-enterprise/accept.json.sample
+++ b/client-templates/github-enterprise/accept.json.sample
@@ -762,25 +762,25 @@
     {
       "//": "used to scan Dockerfile",
       "method": "GET",
-      "path": "/repos/:name/:repo/contents/:path*/Dockerfile*",
+      "path": "/repos/:name/:repo/contents/:path*/*Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
       "//": "used to scan Dockerfile",
       "method": "GET",
-      "path": "/repos/:name/:repo/contents/:path*%2FDockerfile*",
+      "path": "/repos/:name/:repo/contents/:path*%2F*Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
       "//": "used to scan Dockerfile",
       "method": "GET",
-      "path": "/:name/:repo/:path*/Dockerfile*",
+      "path": "/:name/:repo/:path*/*Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to scan Dockerfile",
       "method": "GET",
-      "path": "/:name/:repo/:path*%2FDockerfile*",
+      "path": "/:name/:repo/:path*%2F*Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
@@ -1170,25 +1170,25 @@
     {
       "//": "used to update Dockerfile",
       "method": "PUT",
-      "path": "/repos/:name/:repo/contents/:path*/Dockerfile*",
+      "path": "/repos/:name/:repo/contents/:path*/*Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
       "//": "used to update Dockerfile",
       "method": "PUT",
-      "path": "/repos/:name/:repo/contents/:path*%2FDockerfile*",
+      "path": "/repos/:name/:repo/contents/:path*%2F*Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
       "//": "used to update Dockerfile",
       "method": "PUT",
-      "path": "/:name/:repo/:path*/Dockerfile*",
+      "path": "/:name/:repo/:path*/*Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {
       "//": "used to update Dockerfile",
       "method": "PUT",
-      "path": "/:name/:repo/:path*%2FDockerfile*",
+      "path": "/:name/:repo/:path*%2F*Dockerfile*",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_RAW}"
     },
     {


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Extend accept.json of github.com and github-enterprise to allow Dockerfiles with a prefix and hidden (dot) dockerfiles (as done for other SCMs).

#### How should this be manually tested?

Create a file names `.dockerfile` in github/ghe and import it through a brokered connection.

#### Any background context you want to provide?

This fix is done as part of adding support for fix PRs of hidden files and folders.

It is also related to the following PR created a few months ago: https://github.com/snyk/broker/pull/368
