### PR TITLE
feat: Add support for dot paths query filter

### DIFF
--- a/client-templates/azure-repos/accept.json.sample
+++ b/client-templates/azure-repos/accept.json.sample
@@ -140,8 +140,8 @@
             "**%2Fgo.mod",
             "**/go.sum",
             "**%2Fgo.sum",
-            "**/Dockerfile",
-            "**%2FDockerfile"
+            "**/*Dockerfile*",
+            "**%2F*Dockerfile*"
           ]
         },
         {

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -157,7 +157,9 @@ module.exports = (ruleSource) => {
           // validate against the querystring
           isValid = queryFilters.every(({ queryParam, values }) => {
             return values.some((value) =>
-              minimatch(parsedQuerystring[queryParam] || '', value),
+              minimatch(parsedQuerystring[queryParam] || '', value, {
+                dot: true,
+              }),
             );
           });
         }

--- a/test/fixtures/relay.json
+++ b/test/fixtures/relay.json
@@ -47,6 +47,16 @@
     ]
   },
   {
+    "method": "GET",
+    "path": "/filtered-on-query-with-dot",
+    "valid": [
+      {
+        "queryParam": "filePath",
+        "values": ["**/*Dockerfile"]
+      }
+    ]
+  },
+  {
     "method": "POST",
     "path": "/filtered-on-query-and-body",
     "valid": [

--- a/test/unit/filters.test.ts
+++ b/test/unit/filters.test.ts
@@ -343,6 +343,54 @@ describe('filters', () => {
       );
     });
 
+    it('permits requests with path that is a dot file', (done) => {
+      filter(
+        {
+          url: '/filtered-on-query-with-dot?filePath=.Dockerfile',
+          method: 'GET',
+        },
+        (error, res) => {
+          expect(error).toBeNull();
+          expect(res.url).toEqual(
+            '/filtered-on-query-with-dot?filePath=.Dockerfile',
+          );
+          done();
+        },
+      );
+    });
+
+    it('permits requests with path that contains a dot file', (done) => {
+      filter(
+        {
+          url: '/filtered-on-query-with-dot?filePath=folder/.Dockerfile',
+          method: 'GET',
+        },
+        (error, res) => {
+          expect(error).toBeNull();
+          expect(res.url).toEqual(
+            '/filtered-on-query-with-dot?filePath=folder/.Dockerfile',
+          );
+          done();
+        },
+      );
+    });
+
+    it('permits requests with path that contains a dot directory', (done) => {
+      filter(
+        {
+          url: '/filtered-on-query-with-dot?filePath=.hidden-folder/Dockerfile',
+          method: 'GET',
+        },
+        (error, res) => {
+          expect(error).toBeNull();
+          expect(res.url).toEqual(
+            '/filtered-on-query-with-dot?filePath=.hidden-folder/Dockerfile',
+          );
+          done();
+        },
+      );
+    });
+
     it('blocks requests to files that are not allowed by the rules', (done) => {
       filter(
         {


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This change adds support for dot paths in the query filter, which allows importing hidden files and folders when the file path is specified in the query string. This is need in order to support importing hidden dockerfiles in azure repos, as well as opening a fixPR for these hidden files.

#### Any background context you want to provide?

This fix is done as part of adding support for fix PRs of hidden files and folders.
