### PR TITLE
feat: do not expand variables that contain passwords

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -13,6 +13,15 @@ function camelify(res) {
   }, {});
 }
 
+function isEnvVarContainingPassword(envVarName) {
+  const enVarsContainingPasswords = [
+    'PASSWORD',
+    'BROKER_CLIENT_VALIDATION_AUTHORIZATION_HEADER',
+    'BROKER_CLIENT_VALIDATION_BASIC_AUTH',
+  ];
+  return enVarsContainingPasswords.some((v) => envVarName.includes(v));
+}
+
 function expandValue(obj, value) {
   return value.replace(/([\\]?\$.+?\b)/g, (all, key) => {
     if (key[0] === '$') {
@@ -28,9 +37,11 @@ function expand(obj) {
   const keys = Object.keys(obj);
 
   for (const key of keys) {
-    const value = expandValue(obj, obj[key]);
-    if (value !== obj[key]) {
-      obj[key] = value;
+    if (!isEnvVarContainingPassword(key)) {
+      const value = expandValue(obj, obj[key]);
+      if (value !== obj[key]) {
+        obj[key] = value;
+      }
     }
   }
 

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -1,13 +1,29 @@
 describe('config', () => {
-  it('contain application config', () => {
+  it('parses application config', () => {
     const foo = (process.env.FOO = 'bar');
     const token = (process.env.BROKER_TOKEN = '1234');
-    process.env.FOO_BAR = '$FOO/bar';
+    const passwordWithSpecialChars = (process.env.BITBUCKET_PASSWORD =
+      "!\"#%&'()*+,-./:;$<=>?@[\\]^_`{|}~'");
+    const brokerClientValidationAuthHeader =
+      (process.env.BROKER_CLIENT_VALIDATION_AUTHORIZATION_HEADER =
+        "username:!\"#%&'()*+,-./:;$<=>?@[\\]^_`{|}~'");
+    const brokerClientValidationBasicAuth =
+      (process.env.BROKER_CLIENT_VALIDATION_BASIC_AUTH =
+        "username:!\"#%&'()*+,-./:;$<=>?@[\\]^_`{|}~'");
+
+    process.env.EXPANDABLE_ENV_VAR = '$FOO/bar';
 
     const config = require('../../lib/config');
 
     expect(config.foo).toEqual(foo);
     expect(config.brokerToken).toEqual(token);
-    expect(config.fooBar).toEqual('bar/bar');
+    expect(config.expandableEnvVar).toEqual('bar/bar');
+    expect(config.bitbucketPassword).toEqual(passwordWithSpecialChars);
+    expect(config.brokerClientValidationAuthorizationHeader).toEqual(
+      brokerClientValidationAuthHeader,
+    );
+    expect(config.brokerClientValidationBasicAuth).toEqual(
+      brokerClientValidationBasicAuth,
+    );
   });
 });


### PR DESCRIPTION
Avoid expanding variables that contain passwords since passwords may contain `$` symbols 

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
