### PR TITLE
fix: rename BASE_NEXUS_URL to NEXUS_URL

### DIFF
--- a/client-templates/nexus/.env.sample
+++ b/client-templates/nexus/.env.sample
@@ -1,12 +1,9 @@
 # your unique broker identifier
 BROKER_TOKEN=<broker-token>
 
-# The Base URL for your Nexus Repository Manager
-# If not using basic auth this will only be "https://<your.nexus.hostname>/repository"
-BASE_NEXUS_URL=https://<username>:<password>@<your.nexus.hostname>
-
-# The URL to your Nexus Repository Manager
-NEXUS_URL=$BASE_NEXUS_URL/repository
+# The URL for your Nexus Repository Manager
+# If not using basic auth this will only be "https://<your.nexus.hostname>"
+NEXUS_URL=https://<username>:<password>@<your.nexus.hostname>
 
 # The URL of the Snyk broker server
 BROKER_SERVER_URL=https://broker.snyk.io
@@ -25,5 +22,5 @@ BROKER_HEALTHCHECK_PATH=/healthcheck
 # Nexus validation url, checked by broker client systemcheck endpoint
 # readonly users must have 'nx-metrics-all' privilege enabled to access
 # https://support.sonatype.com/hc/en-us/articles/226254487-System-Status-and-Metrics-REST-API
-BROKER_CLIENT_VALIDATION_URL=$BASE_NEXUS_URL/service/rest/v1/status/check
+BROKER_CLIENT_VALIDATION_URL=$NEXUS_URL/service/rest/v1/status/check
 BROKER_CLIENT_VALIDATION_JSON_DISABLED=true


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
- Remove `BASE_NEXUS_URL` reference and switch to `NEXUS_URL` instead

#### How should this be manually tested?
- No real need to test as we are working on it now, but steps added in https://github.com/snyk/broker/pull/382 can be followed if needed

#### Any background context you want to provide?
 - Being done as part of Nexus integration work by Tardis - [TARDIS-364](https://snyksec.atlassian.net/browse/TARDIS-364)
 - Will be used to redeploy a pre-prod-broker-client for Nexus - https://github.com/snyk/pre-prod-broker-clients
 - Will be used and tested with pre-prod-nexus server in the pre-prod MT cluster
