### PR TITLE
fix: adjust Nexus env.sample and accept.json

### DIFF
--- a/client-templates/nexus/.env.sample
+++ b/client-templates/nexus/.env.sample
@@ -3,7 +3,10 @@ BROKER_TOKEN=<broker-token>
 
 # The Base URL for your Nexus Repository Manager
 # If not using basic auth this will only be "https://<your.nexus.hostname>"
-NEXUS_URL=https://<username>:<password>@<your.nexus.hostname>
+BASE_NEXUS_URL=https://<username>:<password>@<your.nexus.hostname>
+
+# The URL to your Nexus Repository Manager
+NEXUS_URL=$BASE_NEXUS_URL/repository
 
 # The URL of the Snyk broker server
 BROKER_SERVER_URL=https://broker.snyk.io
@@ -22,5 +25,5 @@ BROKER_HEALTHCHECK_PATH=/healthcheck
 # Nexus validation url, checked by broker client systemcheck endpoint
 # readonly users must have 'nx-metrics-all' privilege enabled to access
 # https://support.sonatype.com/hc/en-us/articles/226254487-System-Status-and-Metrics-REST-API
-BROKER_CLIENT_VALIDATION_URL=$NEXUS_URL/service/rest/v1/status/check
+BROKER_CLIENT_VALIDATION_URL=$BASE_NEXUS_URL/service/rest/v1/status/check
 BROKER_CLIENT_VALIDATION_JSON_DISABLED=true

--- a/client-templates/nexus/accept.json.sample
+++ b/client-templates/nexus/accept.json.sample
@@ -8,6 +8,11 @@
   ],
   "private": [
     {
+      "method": "GET",
+      "path": "/service/rest/v1/status/check",
+      "origin": "${BASE_NEXUS_URL}"
+    },
+    {
       "method": "any",
       "path": "/*",
       "origin": "${NEXUS_URL}"


### PR DESCRIPTION
Reinstate the BASE_NEXUS_URL and adjust the accept.json to work for '/repository' and '/service/rest/v1/status/check'

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
- Reinstates the `BASE_NEXUS_URL` env var and makes an adjustment in the `accept.json` to account for `/repository` and `/service/rest/v1/status/check`

#### How should this be manually tested?
- can follow steps in https://github.com/snyk/broker/pull/382  (I also have it on my machine so can show you)

#### Any background context you want to provide?
- reinstates things that were changed in https://github.com/snyk/broker/pull/388/files
- If we do go ahead with this, will need to make changes to pre-prod-broker-clients and reinstate `BASE_NEXUS_URL` in 1Password

![Screenshot 2022-03-22 at 13 10 06](https://user-images.githubusercontent.com/14161129/159490072-874c4a5f-0b9b-4222-8d0b-657caa839d32.png)

![Screenshot 2022-03-22 at 13 12 36](https://user-images.githubusercontent.com/14161129/159490102-f0d0f099-0150-4386-ad0b-4abb04cfc505.png)

![Screenshot 2022-03-22 at 13 13 26](https://user-images.githubusercontent.com/14161129/159490122-fdd08195-6449-4223-b2c2-60516db4d1e9.png)

