### PR TITLE
feat: observe broker response size

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -1,8 +1,31 @@
-const { Gauge } = require('prom-client');
+const { Gauge, Histogram, Counter } = require('prom-client');
 
 const socketConnectionGauge = new Gauge({
   name: 'broker_socket_connection_total',
   help: 'Number of active socket connections',
+});
+
+const responseSizeHistogram = new Histogram({
+  name: 'broker_response_size_bytes',
+  help: 'The size of broker server responses in bytes',
+  labelNames: ['isStreaming'],
+  buckets: [
+    1024, // 1kb
+    5120, // 5kb
+    10_240, // 10kb
+    25_600, // 25kb
+    51_200, // 50kb
+    102_400, // 100kb
+    512_000, // 500kb
+    1_048_576, // 1mb
+    10_485_760, // 10mb
+    20_971_520, // 20mb 'maxLength' in socket.js
+  ],
+});
+
+const unableToSizeResponseCounter = new Counter({
+  name: 'broker_unable_to_size_response_count',
+  help: 'A count of the number of times broker server was unable to size a response',
 });
 
 function incrementSocketConnectionGauge() {
@@ -13,7 +36,17 @@ function decrementSocketConnectionGauge() {
   socketConnectionGauge.dec(1);
 }
 
+function observeResponseSize({ bytes, isStreaming }) {
+  responseSizeHistogram.observe({ isStreaming }, bytes);
+}
+
+function incrementUnableToSizeResponse() {
+  unableToSizeResponseCounter.inc(1);
+}
+
 module.exports = {
   incrementSocketConnectionGauge,
   decrementSocketConnectionGauge,
+  observeResponseSize,
+  incrementUnableToSizeResponse,
 };

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -11,6 +11,7 @@ const version = require('./version');
 const { maskToken } = require('./token');
 const stream = require('stream');
 const NodeCache = require('node-cache');
+const metrics = require('./metrics');
 
 module.exports = {
   request: requestHandler,
@@ -25,7 +26,11 @@ const streams = new NodeCache({
 });
 
 function streamResponseHandler(token) {
+  let streamSizeMap = {};
   return (streamingID, chunk, finished, ioResponse) => {
+    if (!streamSizeMap[streamingID]) {
+      streamSizeMap[streamingID] = 0;
+    }
     const streamFromId = streams.get(streamingID);
 
     if (streamFromId) {
@@ -36,11 +41,17 @@ function streamResponseHandler(token) {
           response.status(ioResponse.status).set(ioResponse.headers);
         }
         if (chunk) {
+          streamSizeMap[streamingID] += chunk.length;
           streamBuffer.write(chunk);
         }
         if (finished) {
           streamBuffer.end();
           streams.del(streamingID);
+          metrics.observeResponseSize({
+            bytes: streamSizeMap[streamingID],
+            isStreaming: true,
+          });
+          delete streamSizeMap[streamingID];
         }
       } else {
         logger.warn({ streamingID, token }, 'discarding binary chunk');
@@ -145,6 +156,26 @@ function requestHandler(filterRules) {
           const logMsg = 'sending response back to HTTP connection';
           if (ioResponse.status <= 200) {
             logger.debug(logContext, logMsg);
+            let responseBodyString = '';
+            if (typeof ioResponse.body === 'string') {
+              responseBodyString = ioResponse.body;
+            } else if (typeof ioResponse.body === 'object') {
+              responseBodyString = JSON.stringify(ioResponse.body);
+            }
+            if (responseBodyString) {
+              const responseBodyBytes = Buffer.byteLength(
+                responseBodyString,
+                'utf-8',
+              );
+              metrics.observeResponseSize({
+                bytes: responseBodyBytes,
+                isStreaming: false,
+              });
+            } else {
+              // fallback metric to let us know if we're recording all response sizes
+              // we expect to remove this should it report 0
+              metrics.incrementUnableToSizeResponse();
+            }
           } else {
             logger.info(logContext, logMsg);
           }

--- a/test/fixtures/client/filters.json
+++ b/test/fixtures/client/filters.json
@@ -79,6 +79,12 @@
     },
 
     {
+      "path": "/test-blob-param/*",
+      "method": "GET",
+      "origin": "http://localhost:${originPort}"
+    },
+
+    {
       "path": "/repos/:repo/:owner/contents/folder*/package.json",
       "method": "GET",
       "origin": "http://localhost:${originPort}"

--- a/test/fixtures/server/filters.json
+++ b/test/fixtures/server/filters.json
@@ -37,6 +37,12 @@
     },
 
     {
+      "path": "/test-blob-param/*",
+      "method": "GET",
+      "origin": "http://localhost:${originPort}"
+    },
+
+    {
       "//": "Block on headers",
       "path": "/echo-param-protected/:param",
       "method": "GET",
@@ -52,6 +58,11 @@
   "public": [
     {
       "path": "/test-blob/*",
+      "method": "GET",
+      "stream": true
+    },
+    {
+      "path": "/test-blob-param/*",
       "method": "GET",
       "stream": true
     },

--- a/test/functional/metrics.test.ts
+++ b/test/functional/metrics.test.ts
@@ -1,0 +1,86 @@
+// awkward require from '../utils' on '../../lib/config'
+// means we have to assign a port and set env here *before* importing
+const originPort = 9877;
+process.env.ORIGIN_PORT = `${originPort}`;
+
+import * as path from 'path';
+import * as app from '../../lib';
+import * as metrics from '../../lib/metrics';
+import { createTestServer, requestAsync, port } from '../utils';
+
+const fixtures = path.resolve(__dirname, '..', 'fixtures');
+const serverAccept = path.join(fixtures, 'server', 'filters.json');
+const clientAccept = path.join(fixtures, 'client', 'filters.json');
+
+describe('metrics', () => {
+  let client;
+  let server;
+  let serverPort;
+  let utilServer;
+  let brokerToken;
+
+  beforeAll((done) => {
+    const { testServer } = createTestServer(originPort);
+    utilServer = testServer;
+    serverPort = port();
+    server = app.main({
+      port: serverPort,
+      client: undefined,
+      config: {
+        accept: serverAccept,
+      },
+    });
+    client = app.main({
+      port: port(),
+      client: 'artifactory',
+      config: {
+        accept: clientAccept,
+        brokerServerUrl: `http://localhost:${serverPort}`,
+        brokerToken: '98f04768-50d3-46fa-817a-9ee6631e9970',
+        artifactoryUrl: `http://localhost:${originPort}`,
+      },
+    });
+
+    // wait for server <> client connection
+    server.io.on('connection', (socket) => {
+      socket.on('identify', ({ token }) => {
+        brokerToken = token;
+        done();
+      });
+    });
+  });
+
+  afterAll(() => {
+    utilServer.close();
+    client.close();
+    server.close();
+  });
+
+  afterEach(() => jest.resetAllMocks());
+
+  it('observes response size when not streaming', async () => {
+    const metricsSpy = jest.spyOn(metrics, 'observeResponseSize');
+    const response = 'testing123';
+    await requestAsync({
+      url: `http://localhost:${serverPort}/broker/${brokerToken}/echo-param/${response}`,
+      method: 'get',
+    });
+    expect(metricsSpy).toHaveBeenCalledWith({
+      bytes: Buffer.byteLength(response),
+      isStreaming: false,
+    });
+  });
+
+  it('observes response size when streaming', async () => {
+    const metricsSpy = jest.spyOn(metrics, 'observeResponseSize');
+    const expectedBytes = 256_000; // 250kb
+    await requestAsync({
+      url: `http://localhost:${serverPort}/broker/${brokerToken}/test-blob-param/${expectedBytes}`,
+      method: 'get',
+    });
+    expect(metricsSpy).toHaveBeenCalledWith({
+      bytes: expectedBytes,
+      isStreaming: true,
+    });
+  });
+});


### PR DESCRIPTION

- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Introduces two new metrics:

* `broker_response_size_bytes`
* `broker_unable_to_size_response_count`

`broker_unable_to_size_response_count` can be removed if we see that all responses are being observed (this metric is empty).

`broker_response_size_bytes` starts at 1kb and goes upto the maximum length 20mb and is labeled with `isStreaming` (boolean).
