### PR TITLE
 feat: Add 'bearer' auth scheme #397 

### DIFF
--- a/lib/auth-header.js
+++ b/lib/auth-header.js
@@ -17,6 +17,11 @@ module.exports = ({ scheme, token, username, password }) => {
   if (scheme === 'token') {
     return `Token ${replace(token, config)}`;
   }
+
+  if (scheme === 'bearer') {
+    return `Bearer ${replace(token, config)}`;
+  }
+
   if (scheme === 'basic') {
     const basicAuth = token
       ? getEncodedTokenBasedBasicAuth(token, config)


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Enables the possibility for broker client to use bearer tokens for auth.

Resolves: https://github.com/snyk/broker/issues/396

this is a copy of https://github.com/snyk/broker/pull/397