### PR TITLE
fix: correct websocket config types

### DIFF
--- a/lib/client/socket.js
+++ b/lib/client/socket.js
@@ -42,8 +42,8 @@ module.exports = ({ url, token, filters, config, identifyingMetadata }) => {
       retries: 30,
       max: 20 * 60 * 1000,
     },
-    pingTimeout: config.socketPingTimeout ?? 45000,
-    timeout: config.socketConnectTimeout ?? 10000
+    pingTimeout: parseInt(config.socketPingTimeout) ?? 45000,
+    timeout: parseInt(config.socketConnectTimeout) ?? 10000,
   });
 
   io.on('reconnect scheduled', (opts) => {

--- a/lib/server/socket.js
+++ b/lib/server/socket.js
@@ -12,11 +12,11 @@ module.exports = ({ server, filters, config }) => {
   const ioConfig = {
     transformer: 'engine.io',
     parser: 'EJSON',
-    maxLength: config.socketMaxResponseLength ?? '20971520', // support up to 20MB in response bodies
+    maxLength: parseInt(config.socketMaxResponseLength) ?? 20971520, // support up to 20MB in response bodies
     transport: { allowEIO3: true },
-    pingInterval: config.socketPingInterval ?? 30000,
-    compression: config.socketUseCompression ?? false
-  }
+    pingInterval: parseInt(config.socketPingInterval) ?? 30000,
+    compression: Boolean(config.socketUseCompression) ?? false,
+  };
   const io = new Primus(server, ioConfig);
   io.plugin('emitter', Emitter);
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
- Ensures that websocket configuration parameters are of the expected type - previously these were set as `string`, which the underlying `primus` library may not correctly respect.

#### Where should the reviewer start?
- Compare the types expected by `Primus` (https://github.com/primus/primus#getting-started) against the types specified in both `lib/client/socket.js` and `/lib/client/server.js`.

#### How should this be manually tested?
I've tested this by:
- Executing the project locally without any env vars to observe type of default configuration (logging the `io.options` object)
- Specifying environment variables (`SOCKET_MAX_RESPONSE_LENGTH="200000"`) and ensuring the value is updated in the `io.options` object, and that the type is correct (here, `Int`).

#### Any background context you want to provide?
-

#### Screenshots
-

#### Additional questions
