### PR TITLE
feat: add logic for scm tokens rotation from pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,36 @@ One of the reason for failing of open Fix/Upgrade PRs or PR/recurring tests migh
 ```
 **Note** To ensure the maximum possible security, we do not enable this rule by default, as usage of this endpoint means that the Snyk platform can theoretically access all files in this repository, as the path does not include specific allowed file names.
 
+## Rate Limiting
+If needed, you might need to balance the load across numerous Personal Access Tokens (PAT)/Accounts.
+**The level and breadth of access offered by those PATs must be the same.**
+It will randomly rotate a token from the pool of tokens you provide for each calls the broker makes to your SCM.
+
+## How to balance load between several Personal Access Tokens
+1. Follow the instructions for the corresponding SCM.
+2. For the token environment variable, enter the name of an env var of your choice with the `_POOL` suffix instead of the token value.
+For example:
+`-e GITHUB_TOKEN=GITHUB_TOKEN_POOL`
+3. Add your extra environment variable with the all tokens to use separated by commas
+For example:
+`-e GITHUB_TOKEN_POOL=123,456,789`
+
+Example for GHE:
+
+```
+docker run --restart=always \
+           -p 8000:8000 \
+           -e BROKER_TOKEN=secret-broker-token \
+           -e GITHUB_TOKEN=GITHUB_TOKEN_POOL \
+           -e GITHUB_TOKEN_POOL=123,456,789 \
+           -e GITHUB=your.ghe.domain.com \
+           -e GITHUB_API=your.ghe.domain.com/api/v3 \
+           -e GITHUB_GRAPHQL=your.ghe.domain.com/api \
+           -e PORT=8000 \
+           -e BROKER_CLIENT_URL=http://my.broker.client:8000 \
+       snyk/broker:github-enterprise
+```
+
 ## Misc
 
 * [License: Apache License, Version 2.0](https://github.com/snyk/broker/blob/master/LICENSE)

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -348,6 +348,18 @@ function responseHandler(filterRules, config, io) {
           },
         };
 
+        if (headers.authorization?.includes('_POOL')) {
+          const tokenSet =
+            process.env[
+              headers.authorization.replace('Bearer ', '').replace('token ', '')
+            ].split(',');
+          const tokenInUse = tokenSet.random();
+          headers.authorization = headers.authorization.replace(
+            /[a-zA-Z\_]+_POOL/g,
+            tokenInUse,
+          );
+        }
+
         // check if this is a streaming request for binary data
         if (streamingID) {
           logger.debug(logContext, 'serving stream request');
@@ -433,3 +445,7 @@ function logError(logContext, error) {
     'error while sending websocket request over HTTP connection',
   );
 }
+
+Array.prototype.random = function () {
+  return this[Math.floor(Math.random() * this.length)];
+};

--- a/test/unit/relay-response-headers.test.ts
+++ b/test/unit/relay-response-headers.test.ts
@@ -3,6 +3,10 @@ import * as request from 'request';
 import { mocked } from 'ts-jest/utils';
 import { response as relay } from '../../lib/relay';
 
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
 describe('header relay', () => {
   it('swaps header values found in BROKER_VAR_SUB', (done) => {
     expect.hasAssertions();
@@ -51,6 +55,55 @@ describe('header relay', () => {
         );
         expect(arg.headers!.replaceme).toEqual(`replace ${config.VALUE}`);
         expect(arg.headers!.donttouch).toEqual('not to be changed ${VALUE}');
+        done();
+      },
+    );
+  });
+  it('swaps token values found in SECRET_TOKEN_POOL', (done) => {
+    expect.hasAssertions();
+    const requestMock = mocked(request);
+
+    requestMock.mockImplementationOnce((_options, fn) => {
+      fn!(null, { statusCode: 200 } as any, {});
+      return {} as any;
+    });
+
+    const brokerToken = 'test-broker';
+
+    const config = {
+      SECRET_TOKEN: 'SECRET_TOKEN_POOL',
+
+      VALUE: 'some-special-value',
+    };
+    process.env.SECRET_TOKEN_POOL = '123,456';
+    const route = relay(
+      [
+        {
+          method: 'any',
+          url: '/*',
+        },
+      ],
+      config,
+    )(brokerToken);
+
+    const headers = {
+      authorization: `Bearer ${config.SECRET_TOKEN}`,
+    };
+
+    route(
+      {
+        url: '/',
+        method: 'GET',
+        headers: headers,
+      },
+      () => {
+        expect(requestMock).toHaveBeenCalledTimes(1);
+        const arg = requestMock.mock.calls[0][0];
+        expect(
+          arg.headers!['authorization'] == `Bearer 123` ||
+            arg.headers!['authorization'] == `Bearer 456`,
+        ).toBeTruthy();
+        delete process.env.SECRET_TOKEN_POOL;
         done();
       },
     );


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Implements a mechanism to randomly select a value from a pool of tokens as a palliative measure for rate limiting issues some large situations may create, so the load gets "spread" across several Personal Access Tokens.

#### Where should the reviewer start?

README addition

#### How should this be manually tested?

Follow the instructions listed in the README and give this a shot.