### PR TITLE
fix: env var substitution

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -16,8 +16,8 @@ function camelify(res) {
 function expandValue(obj, value) {
   return value.replace(/([\\]?\$.+?\b)/g, (all, key) => {
     if (key[0] === '$') {
-      key = key.slice(1);
-      return obj[key] || '';
+      const keys = key.slice(1);
+      return obj[keys] || key;
     }
 
     return key;

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -3,11 +3,13 @@ describe('config', () => {
     const foo = (process.env.FOO = 'bar');
     const token = (process.env.BROKER_TOKEN = '1234');
     process.env.FOO_BAR = '$FOO/bar';
+    const complex_token = (process.env.COMPLEX_TOKEN='1234$$%#@!$!$@$$$')
 
     const config = require('../../lib/config');
 
     expect(config.foo).toEqual(foo);
     expect(config.brokerToken).toEqual(token);
     expect(config.fooBar).toEqual('bar/bar');
+    expect(config.complex_token).toEqual(complex_token);
   });
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Addresses current environment variable substitution logic breaking passwords or any field that contains a $ character

#### Where should the reviewer start?
lib/config.js lines 19/20
tests/unit/config.tests.js lines 6/13

#### How should this be manually tested?
enforce BITBUCKET_PASSWORD="abc$123" to be retained in config object after evaluate method

#### Any background context you want to provide?
Very important to ensure users don't need to unnecessarily change their passwords and reduce security.

#### Screenshots


#### Additional questions
