### PR TITLE
fix: prolong prototype pollution predefine vulnerability snyk ignore

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -9,5 +9,5 @@ ignore:
   'SNYK-JS-PREDEFINE-1054935':
     - primus > fusing > predefine:
         reason: Fixed in https://github.com/snyk/broker/pull/336
-        expires: '2022-07-06T09:47:29.283Z'
+        expires: '2023-07-06T09:47:29.283Z'
 patch: {}


### PR DESCRIPTION
#### What does this PR do?
This PR prolongs the predefine prototype pollution ignore as nothing has changed on [fusing](https://github.com/bigpipe/fusing ) since last year and no change is anticipated in the foreseeable future.


#### Any background context you want to provide?
[#337](https://github.com/snyk/broker/pull/337)
