### PR TITLE
fix: set the group to root on the node home folder

### DIFF
--- a/dockerfiles/bitbucket-server/Dockerfile
+++ b/dockerfiles/bitbucket-server/Dockerfile
@@ -22,6 +22,12 @@ COPY --from=base /home/node/.npm-global /home/node/.npm-global
 
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
+# On Openshift it's required that all files are owned by the root
+# group, and with all perms set. This is because the images run with a
+# randomly assigned user id, but part of the root group. See
+# https://docs.openshift.com/container-platform/4.9/openshift_images/create-images.html#images-create-guide-openshift_create-images
+RUN chgrp -R 0 /home/node && chmod -R g=u /home/node
+
 # Don't run as root
 WORKDIR /home/node
 USER node

--- a/dockerfiles/bitbucket-server/Dockerfile
+++ b/dockerfiles/bitbucket-server/Dockerfile
@@ -26,6 +26,7 @@ COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificat
 # group, and with all perms set. This is because the images run with a
 # randomly assigned user id, but part of the root group. See
 # https://docs.openshift.com/container-platform/4.9/openshift_images/create-images.html#images-create-guide-openshift_create-images
+USER root
 RUN chgrp -R 0 /home/node && chmod -R g=u /home/node
 
 # Don't run as root


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

On Openshift it's required that all files are owned by the root group,
and with all perms set. This is because the images run with a randomly
assigned user id, but part of the root group. See
https://docs.openshift.com/container-platform/4.9/openshift_images/create-images.html#images-create-guide-openshift_create-images

#### Where should the reviewer start?

Only one file was changed, but it's good to take a look at https://docs.openshift.com/container-platform/4.9/openshift_images/create-images.html#images-create-guide-openshift_create-images

#### How should this be manually tested?

Run latest broker Bitbucket image on Openshift
