### PR TITLE
fix: run broker client on openshift

### DIFF
--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -8,6 +8,9 @@ RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node \
   && apt update && apt upgrade -y && apt install gpg curl xz-utils -y
 
+USER root
+RUN chgrp -R 0 /home/node && chmod -R g=u /home/node
+
 ENV NODE_VERSION 16.15.1
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \


### PR DESCRIPTION
#### What does this PR do?

Updates the ubuntu base image to fix the permissions problem with openShift running by using a random user.


