### PR TITLE
feat: add ability to create a credential array

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,3 +4,4 @@ indent_style = space
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -499,16 +499,16 @@ More details can be found here:
 
 ### Credential Pooling
 Under some circumstances it can be desirable to create a "pool" of credentials, e.g., to work around rate-limiting issues.
-This can be achieved by creating an environment variable ending in `_ARRAY`, separate each credential with a comma, and
+This can be achieved by creating an environment variable ending in `_POOL`, separate each credential with a comma, and
 the Broker Client will then, when doing variable replacement, look to see if the variable in use has a variant with an
-`_ARRAY` suffix, and use the next item in that array if so. For example, if you have set the environment variable
+`_POOL` suffix, and use the next item in that array if so. For example, if you have set the environment variable
 `GITHUB_TOKEN`, but want to provide multiple tokens, you would do this:
 
 ```shell
-GITHUB_TOKEN_ARRAY=token1, token2, token3
+GITHUB_TOKEN_POOL=token1, token2, token3
 ```
 
-And then the Broker Server would, any time it needed `GITHUB_TOKEN`, instead take an item from the `GITHUB_TOKEN_ARRAY`.
+And then the Broker Server would, any time it needed `GITHUB_TOKEN`, instead take an item from the `GITHUB_TOKEN_POOL`.
 
 Credentials will be taken in a round-robin fashion, so the first, the second, the third, etc, etc, until it reaches the end
 and then takes the first one again.
@@ -517,7 +517,7 @@ Calling the `/systemcheck` endpoint will validate all credentials, in order, and
 is the first credential and so on. For example, if you were running the GitHub Client and had this:
 
 ```shell
-GITHUB_TOKEN_ARRAY=good_token, bad_token
+GITHUB_TOKEN_POOL=good_token, bad_token
 ```
 
 The `/systemcheck` endpoint would return the following, where the first object is for `good_token` and the second for
@@ -558,25 +558,25 @@ cases you will need to create multiple accounts with one credential per account.
 #### Credentials Matrix
 Generating a Matrix of credentials is not supported.
 
-A "Matrix" in this case is defined as taking two (or more) `_ARRAY`s of length `x` and `y`, and producing one final array
+A "Matrix" in this case is defined as taking two (or more) `_POOL`s of length `x` and `y`, and producing one final array
 of length `x * y`. For example, given an input like:
 
 ```shell
-USERNAME_ARRAY=u1, u2, u3
-PASSWORD_ARRAY=p1, p2, p3
-CREDENTIALS_ARRAY=$USERNAME:$PASSWORD
+USERNAME_POOL=u1, u2, u3
+PASSWORD_POOL=p1, p2, p3
+CREDENTIALS_POOL=$USERNAME:$PASSWORD
 ```
 
 Matrix support would generate this internally:
 
 ```shell
-CREDENTIALS_ARRAY=u1:p1,u1:p2,u1:p3,u2:p1,u2:p2,u2:p3,u3:p1,u3:p2,u3:p3
+CREDENTIALS_POOL=u1:p1,u1:p2,u1:p3,u2:p1,u2:p2,u2:p3,u3:p1,u3:p2,u3:p3
 ```
 
 Instead, the Broker Client would generate this internally, using only the first array it finds:
 
 ```shell
-CREDENTIALS_ARRAY=u1:$PASSWORD,u2:$PASSWORD,u3:$PASSWORD
+CREDENTIALS_POOL=u1:$PASSWORD,u2:$PASSWORD,u3:$PASSWORD
 ```
 
 ### Custom approved-listing filter

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ The Broker client exposes an endpoint at `/systemcheck`, which can be used to va
 * `BROKER_CLIENT_VALIDATION_METHOD` - [optional] the HTTP method of the request (default is `GET`).
 * `BROKER_CLIENT_VALIDATION_TIMEOUT_MS` - [optional] the request timeout in milliseconds (default is 5000 ms).
 
-This endpoint responds with status code `200 OK` when the internal request is successful, and returns `{ ok: true }` in the response body. If the internal request fails, this endpoint responds with status code `500 Internal Server Error` and `{ ok: false }` in the response body.
+This endpoint responds with status code `200 OK` when the internal request is successful, and returns `[{ ok: true, ... }]` in the response body (one object in the array per credential, see [Credential Pooling](#credential-pooling)). If the internal request fails, this endpoint responds with status code `500 Internal Server Error` and `[{ ok: false }, ...]` in the response body.
 
 To change the location of the systemcheck endpoint, you can specify an alternative path via an environment variable:
 
@@ -502,7 +502,7 @@ Under some circumstances it can be desirable to create a "pool" of credentials, 
 This can be achieved by creating an environment variable ending in `_ARRAY`, separate each credential with a comma, and
 the Broker Client will then, when doing variable replacement, look to see if the variable in use has a variant with an
 `_ARRAY` suffix, and use the next item in that array if so. For example, if you have set the environment variable
-`GITHUB_TOKEN`, but want to provide multiple tokens, you would just do this:
+`GITHUB_TOKEN`, but want to provide multiple tokens, you would do this:
 
 ```shell
 GITHUB_TOKEN_ARRAY=token1, token2, token3
@@ -529,18 +529,23 @@ The `/systemcheck` endpoint would return the following, where the first object i
     "brokerClientValidationUrl": "https://api.github.com/user",
     "brokerClientValidationMethod": "GET",
     "brokerClientValidationTimeoutMs": 5000,
-    "ok": true
+    "brokerClientValidationUrlStatusCode": 200,
+    "ok": true,
+    "maskedCredentials": "goo***ken"
   },
   {
     "brokerClientValidationUrl": "https://api.github.com/user",
     "brokerClientValidationMethod": "GET",
     "brokerClientValidationTimeoutMs": 5000,
     "ok": false,
-    "error": "401 - {\"message\":\"Bad credentials\",\"documentation_url\":\"https://docs.github.com/rest\"}"
+    "error": "401 - {\"message\":\"Bad credentials\",\"documentation_url\":\"https://docs.github.com/rest\"}",
+    "maskedCredentials": "bad***ken"
   }
 ]
 ```
-The actual credentials are not included to avoid exposing sensitive data accidentally.
+
+The credentials are masked, though note that if your credentials contain 6 or fewer characters, they will be completely
+replaced with the mask.
 
 #### Limitations
 Credential validity is not checked before using a credential, nor are invalid credentials removed from the pool, so it is
@@ -549,6 +554,30 @@ at different times, and that the `/systemcheck` endpoint be called before use.
 
 Some providers, such as GitHub, do rate-limiting on a per-user basis, not a per-token or per-credential basis, and in those
 cases you will need to create multiple accounts with one credential per account.
+
+#### Credentials Matrix
+Generating a Matrix of credentials is not supported.
+
+A "Matrix" in this case is defined as taking two (or more) `_ARRAY`s of length `x` and `y`, and producing one final array
+of length `x * y`. For example, given an input like:
+
+```shell
+USERNAME_ARRAY=u1, u2, u3
+PASSWORD_ARRAY=p1, p2, p3
+CREDENTIALS_ARRAY=$USERNAME:$PASSWORD
+```
+
+Matrix support would generate this internally:
+
+```shell
+CREDENTIALS_ARRAY=u1:p1,u1:p2,u1:p3,u2:p1,u2:p2,u2:p3,u3:p1,u3:p2,u3:p3
+```
+
+Instead, the Broker Client would generate this internally, using only the first array it finds:
+
+```shell
+CREDENTIALS_ARRAY=u1:$PASSWORD,u2:$PASSWORD,u3:$PASSWORD
+```
 
 ### Custom approved-listing filter
 

--- a/README.md
+++ b/README.md
@@ -500,9 +500,9 @@ More details can be found here:
 ### Credential Pooling
 Under some circumstances it can be desirable to create a "pool" of credentials, e.g., to work around rate-limiting issues.
 This can be achieved by creating an environment variable ending in `_POOL`, separate each credential with a comma, and
-the Broker Client will then, when doing variable replacement, look to see if the variable in use has a variant with an
-`_POOL` suffix, and use the next item in that array if so. For example, if you have set the environment variable
-`GITHUB_TOKEN`, but want to provide multiple tokens, you would do this:
+the Broker Client will then, when doing variable replacement, look to see if the variable in use has a variant with a
+`_POOL` suffix, and use the next item in that pool if so. For example, if you have set the environment variable
+`GITHUB_TOKEN`, but want to provide multiple tokens, you would do this instead:
 
 ```shell
 GITHUB_TOKEN_POOL=token1, token2, token3
@@ -558,7 +558,7 @@ cases you will need to create multiple accounts with one credential per account.
 #### Credentials Matrix
 Generating a Matrix of credentials is not supported.
 
-A "Matrix" in this case is defined as taking two (or more) `_POOL`s of length `x` and `y`, and producing one final array
+A "Matrix" in this case is defined as taking two (or more) `_POOL`s of length `x` and `y`, and producing one final pool
 of length `x * y`. For example, given an input like:
 
 ```shell
@@ -573,7 +573,7 @@ Matrix support would generate this internally:
 CREDENTIALS_POOL=u1:p1,u1:p2,u1:p3,u2:p1,u2:p2,u2:p3,u3:p1,u3:p2,u3:p3
 ```
 
-Instead, the Broker Client would generate this internally, using only the first array it finds:
+Instead, the Broker Client would generate this internally, using only the first pool it finds:
 
 ```shell
 CREDENTIALS_POOL=u1:$PASSWORD,u2:$PASSWORD,u3:$PASSWORD

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -62,12 +62,12 @@ module.exports = ({port = null, config = {}, filters = {}}) => {
     }
     let auths = [];
     let rawCreds = [];
-    if (config.brokerClientValidationAuthorizationHeaderArray) {
-      auths = config.brokerClientValidationAuthorizationHeaderArray;
-      rawCreds = config.brokerClientValidationAuthorizationHeaderArray.map(credsFromHeader);
-    } else if (config.brokerClientValidationBasicAuthArray) {
-      auths = config.brokerClientValidationBasicAuthArray.map(s => `Basic ${Buffer.from(s).toString('base64')}`)
-      rawCreds = config.brokerClientValidationBasicAuthArray
+    if (config.brokerClientValidationAuthorizationHeaderPool) {
+      auths = config.brokerClientValidationAuthorizationHeaderPool;
+      rawCreds = config.brokerClientValidationAuthorizationHeaderPool.map(credsFromHeader);
+    } else if (config.brokerClientValidationBasicAuthPool) {
+      auths = config.brokerClientValidationBasicAuthPool.map(s => `Basic ${Buffer.from(s).toString('base64')}`)
+      rawCreds = config.brokerClientValidationBasicAuthPool
     } else if (config.brokerClientValidationAuthorizationHeader) {
       auths.push(config.brokerClientValidationAuthorizationHeader);
       rawCreds.push(config.brokerClientValidationAuthorizationHeader);

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -53,15 +53,28 @@ module.exports = ({port = null, config = {}, filters = {}}) => {
     const isJsonResponse = !config.brokerClientValidationJsonDisabled;
 
     // set auth header according to config
+    function credsFromHeader(s) {
+      if (s.indexOf(" ") >= 0) {
+        return s.substring(s.indexOf(" ") + 1);
+      } else {
+        return s;
+      }
+    }
     let auths = [];
+    let rawCreds = [];
     if (config.brokerClientValidationAuthorizationHeaderArray) {
       auths = config.brokerClientValidationAuthorizationHeaderArray;
+      rawCreds = config.brokerClientValidationAuthorizationHeaderArray.map(credsFromHeader);
     } else if (config.brokerClientValidationBasicAuthArray) {
       auths = config.brokerClientValidationBasicAuthArray.map(s => `Basic ${Buffer.from(s).toString('base64')}`)
+      rawCreds = config.brokerClientValidationBasicAuthArray
     } else if (config.brokerClientValidationAuthorizationHeader) {
       auths.push(config.brokerClientValidationAuthorizationHeader);
+      rawCreds.push(config.brokerClientValidationAuthorizationHeader);
+      rawCreds = rawCreds.map(credsFromHeader);
     } else if (config.brokerClientValidationBasicAuth) {
       auths.push(`Basic ${Buffer.from(config.brokerClientValidationBasicAuth).toString('base64')}`)
+      rawCreds.push(config.brokerClientValidationBasicAuth);
     }
 
     // make the internal validation request
@@ -71,7 +84,9 @@ module.exports = ({port = null, config = {}, filters = {}}) => {
       for (let i = 0; i < auths.length; i++) {
         logger.info(`Checking if credentials at index ${i} are valid`)
         const auth = auths[i];
+        const rawCred = rawCreds[i];
         let [data, err] = await checkCredentials(auth, config, brokerClientValidationMethod, brokerClientValidationTimeoutMs, isJsonResponse)
+        data.maskedCredentials = rawCred.length <= 6 ? '***' : `${rawCred.substring(0, 3)}***${rawCred.substring(rawCred.length - 3)}`
         rv.push(data)
         errorOccurred = err;
         logger.info("Credentials checked")
@@ -79,6 +94,7 @@ module.exports = ({port = null, config = {}, filters = {}}) => {
     } else {
       logger.info("No credentials specified - checking if target can be accessed without credentials")
       let [data, err] = await checkCredentials(null, config, brokerClientValidationMethod, brokerClientValidationTimeoutMs, isJsonResponse)
+      data.maskedCredentials = null;
       rv.push(data)
       errorOccurred = err;
     }

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -53,56 +53,34 @@ module.exports = ({port = null, config = {}, filters = {}}) => {
     const isJsonResponse = !config.brokerClientValidationJsonDisabled;
 
     // set auth header according to config
-    function credsFromHeader(s) {
-      if (s.indexOf(" ") >= 0) {
-        return s.substring(s.indexOf(" ") + 1);
-      } else {
-        return s;
-      }
-    }
-    let auths = [];
-    let rawCreds = [];
-    if (config.brokerClientValidationAuthorizationHeaderPool) {
-      auths = config.brokerClientValidationAuthorizationHeaderPool;
-      rawCreds = config.brokerClientValidationAuthorizationHeaderPool.map(credsFromHeader);
-    } else if (config.brokerClientValidationBasicAuthPool) {
-      auths = config.brokerClientValidationBasicAuthPool.map(s => `Basic ${Buffer.from(s).toString('base64')}`)
-      rawCreds = config.brokerClientValidationBasicAuthPool
-    } else if (config.brokerClientValidationAuthorizationHeader) {
-      auths.push(config.brokerClientValidationAuthorizationHeader);
-      rawCreds.push(config.brokerClientValidationAuthorizationHeader);
-      rawCreds = rawCreds.map(credsFromHeader);
-    } else if (config.brokerClientValidationBasicAuth) {
-      auths.push(`Basic ${Buffer.from(config.brokerClientValidationBasicAuth).toString('base64')}`)
-      rawCreds.push(config.brokerClientValidationBasicAuth);
-    }
+    let {auths, rawCreds} = loadCredentialsFromConfig(config);
 
     // make the internal validation request
-    const rv = [];
+    const validationResults = [];
     let errorOccurred = true;
     if (auths.length > 0) {
       for (let i = 0; i < auths.length; i++) {
         logger.info(`Checking if credentials at index ${i} are valid`)
         const auth = auths[i];
         const rawCred = rawCreds[i];
-        let [data, err] = await checkCredentials(auth, config, brokerClientValidationMethod, brokerClientValidationTimeoutMs, isJsonResponse)
+        let {data, errorOccurred: err} = await checkCredentials(auth, config, brokerClientValidationMethod, brokerClientValidationTimeoutMs, isJsonResponse)
         data.maskedCredentials = rawCred.length <= 6 ? '***' : `${rawCred.substring(0, 3)}***${rawCred.substring(rawCred.length - 3)}`
-        rv.push(data)
+        validationResults.push(data)
         errorOccurred = err;
         logger.info("Credentials checked")
       }
     } else {
       logger.info("No credentials specified - checking if target can be accessed without credentials")
-      let [data, err] = await checkCredentials(null, config, brokerClientValidationMethod, brokerClientValidationTimeoutMs, isJsonResponse)
+      let {data, errorOccurred: err} = await checkCredentials(null, config, brokerClientValidationMethod, brokerClientValidationTimeoutMs, isJsonResponse)
       data.maskedCredentials = null;
-      rv.push(data)
+      validationResults.push(data)
       errorOccurred = err;
     }
 
     if (errorOccurred) {
-      return res.status(500).json(rv);
+      return res.status(500).json(validationResults);
     } else {
-      return res.status(200).json(rv);
+      return res.status(200).json(validationResults);
     }
   });
 
@@ -130,6 +108,34 @@ module.exports = ({port = null, config = {}, filters = {}}) => {
     },
   };
 };
+
+function credsFromHeader(s) {
+  if (s.indexOf(" ") >= 0) {
+    return s.substring(s.indexOf(" ") + 1);
+  } else {
+    return s;
+  }
+}
+
+function loadCredentialsFromConfig(config) {
+  let auths = [];
+  let rawCreds = [];
+  if (config.brokerClientValidationAuthorizationHeaderPool) {
+    auths = config.brokerClientValidationAuthorizationHeaderPool;
+    rawCreds = config.brokerClientValidationAuthorizationHeaderPool.map(credsFromHeader);
+  } else if (config.brokerClientValidationBasicAuthPool) {
+    auths = config.brokerClientValidationBasicAuthPool.map(s => `Basic ${Buffer.from(s).toString('base64')}`)
+    rawCreds = config.brokerClientValidationBasicAuthPool
+  } else if (config.brokerClientValidationAuthorizationHeader) {
+    auths.push(config.brokerClientValidationAuthorizationHeader);
+    rawCreds.push(config.brokerClientValidationAuthorizationHeader);
+    rawCreds = rawCreds.map(credsFromHeader);
+  } else if (config.brokerClientValidationBasicAuth) {
+    auths.push(`Basic ${Buffer.from(config.brokerClientValidationBasicAuth).toString('base64')}`)
+    rawCreds.push(config.brokerClientValidationBasicAuth);
+  }
+  return {auths, rawCreds};
+}
 
 async function checkCredentials(auth, config, brokerClientValidationMethod, brokerClientValidationTimeoutMs, isJsonResponse) {
   const data = {
@@ -197,5 +203,5 @@ async function checkCredentials(auth, config, brokerClientValidationMethod, brok
     data.error = error.message;
   });
 
-  return [data, errorOccurred];
+  return {data, errorOccurred};
 }

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -1,12 +1,12 @@
 const primus = require('primus');
-const request = require('request');
+const rp = require('request-promise-native');
 const socket = require('./socket');
 const relay = require('../relay');
 const logger = require('../log');
 const version = require('../version');
 
-module.exports = ({ port = null, config = {}, filters = {} }) => {
-  logger.info({ version }, 'running in client mode');
+module.exports = ({port = null, config = {}, filters = {}}) => {
+  logger.info({version}, 'running in client mode');
 
   const identifyingMetadata = {
     version,
@@ -22,7 +22,7 @@ module.exports = ({ port = null, config = {}, filters = {} }) => {
   });
 
   // start the local webserver to listen for relay requests
-  const { app, server } = require('../webserver')(config, port);
+  const {app, server} = require('../webserver')(config, port);
 
   // IMPORTANT: defined before relay (`app.all('/*', ...`)
   app.get(config.brokerHealthcheckPath || '/healthcheck', (req, res) => {
@@ -41,7 +41,7 @@ module.exports = ({ port = null, config = {}, filters = {} }) => {
     return res.status(status).json(data);
   });
 
-  app.get(config.brokerSystemcheckPath || '/systemcheck', (req, res) => {
+  app.get(config.brokerSystemcheckPath || '/systemcheck', async (req, res) => {
     // Systemcheck is the broker client's ability to assert the network
     // reachability and some correctness of credentials for the service
     // being proxied by the broker client.
@@ -52,74 +52,42 @@ module.exports = ({ port = null, config = {}, filters = {} }) => {
       config.brokerClientValidationTimeoutMs || 5000;
     const isJsonResponse = !config.brokerClientValidationJsonDisabled;
 
-    const data = {
-      brokerClientValidationUrl: logger.sanitise(
-        config.brokerClientValidationUrl,
-      ),
-      brokerClientValidationMethod,
-      brokerClientValidationTimeoutMs,
-    };
-
-    const validationRequestHeaders = {
-      'user-agent': 'Snyk Broker client ' + version,
-    };
-
     // set auth header according to config
-    if (config.brokerClientValidationAuthorizationHeader) {
-      validationRequestHeaders.authorization =
-        config.brokerClientValidationAuthorizationHeader;
+    let auths = [];
+    if (config.brokerClientValidationAuthorizationHeaderArray) {
+      auths = config.brokerClientValidationAuthorizationHeaderArray;
+    } else if (config.brokerClientValidationBasicAuthArray) {
+      auths = config.brokerClientValidationBasicAuthArray.map(s => `Basic ${Buffer.from(s).toString('base64')}`)
+    } else if (config.brokerClientValidationAuthorizationHeader) {
+      auths.push(config.brokerClientValidationAuthorizationHeader);
     } else if (config.brokerClientValidationBasicAuth) {
-      validationRequestHeaders.authorization = `Basic ${Buffer.from(
-        config.brokerClientValidationBasicAuth,
-      ).toString('base64')}`;
+      auths.push(`Basic ${Buffer.from(config.brokerClientValidationBasicAuth).toString('base64')}`)
     }
 
     // make the internal validation request
-    request(
-      {
-        url: config.brokerClientValidationUrl,
-        headers: validationRequestHeaders,
-        method: brokerClientValidationMethod,
-        timeout: brokerClientValidationTimeoutMs,
-        json: isJsonResponse,
-        agentOptions: {
-          ca: config.caCert, // Optional CA cert
-        },
-      },
-      (error, response) => {
-        // test logic requires to surface internal data
-        // which is best not exposed in production
-        if (process.env.TAP) {
-          data.testError = error;
-          data.testResponse = response;
-        }
+    const rv = [];
+    let errorOccurred = true;
+    if (auths.length > 0) {
+      for (let i = 0; i < auths.length; i++) {
+        logger.info(`Checking if credentials at index ${i} are valid`)
+        const auth = auths[i];
+        let [data, err] = await checkCredentials(auth, config, brokerClientValidationMethod, brokerClientValidationTimeoutMs, isJsonResponse)
+        rv.push(data)
+        errorOccurred = err;
+        logger.info("Credentials checked")
+      }
+    } else {
+      logger.info("No credentials specified - checking if target can be accessed without credentials")
+      let [data, err] = await checkCredentials(null, config, brokerClientValidationMethod, brokerClientValidationTimeoutMs, isJsonResponse)
+      rv.push(data)
+      errorOccurred = err;
+    }
 
-        if (error) {
-          data.ok = false;
-          data.error = error.message;
-          return res.status(500).json(data);
-        }
-
-        const responseStatusCode = response && response.statusCode;
-        data.brokerClientValidationUrlStatusCode = responseStatusCode;
-
-        // check for 2xx status code
-        const goodStatusCode = /^2/.test(responseStatusCode);
-        if (!goodStatusCode) {
-          data.ok = false;
-          data.error =
-            responseStatusCode === 401 || responseStatusCode === 403
-              ? 'Failed due to invalid credentials'
-              : 'Status code is not 2xx';
-
-          logger.error(data, response && response.body, 'Systemcheck failed');
-          return res.status(500).json(data);
-        }
-
-        data.ok = true;
-        return res.status(200).json(data);
-      },
-    );
+    if (errorOccurred) {
+      return res.status(500).json(rv);
+    } else {
+      return res.status(200).json(rv);
+    }
   });
 
   // relay all other URL paths
@@ -146,3 +114,72 @@ module.exports = ({ port = null, config = {}, filters = {} }) => {
     },
   };
 };
+
+async function checkCredentials(auth, config, brokerClientValidationMethod, brokerClientValidationTimeoutMs, isJsonResponse) {
+  const data = {
+    brokerClientValidationUrl: logger.sanitise(
+      config.brokerClientValidationUrl,
+    ),
+    brokerClientValidationMethod,
+    brokerClientValidationTimeoutMs,
+  };
+
+  const validationRequestHeaders = {
+    'user-agent': 'Snyk Broker client ' + version,
+  };
+  if (auth) {
+    validationRequestHeaders.authorization = auth;
+  }
+
+  let errorOccurred = true;
+  // This was originally `request`, but `await` is a lot easier to understand than nested callback hell.
+  await rp(
+    {
+      url: config.brokerClientValidationUrl,
+      headers: validationRequestHeaders,
+      method: brokerClientValidationMethod,
+      timeout: brokerClientValidationTimeoutMs,
+      json: isJsonResponse,
+      resolveWithFullResponse: true,
+      agentOptions: {
+        ca: config.caCert, // Optional CA cert
+      },
+    },
+  ).then(response => {
+    // test logic requires to surface internal data
+    // which is best not exposed in production
+    if (process.env.TAP) {
+      data.testResponse = response;
+    }
+
+    const responseStatusCode = response && response.statusCode;
+    data.brokerClientValidationUrlStatusCode = responseStatusCode;
+
+    // check for 2xx status code
+    const goodStatusCode = /^2/.test(responseStatusCode);
+    if (!goodStatusCode) {
+      data.ok = false;
+      data.error =
+        responseStatusCode === 401 || responseStatusCode === 403
+          ? 'Failed due to invalid credentials'
+          : 'Status code is not 2xx';
+
+      logger.error(data, response && response.body, 'Systemcheck failed');
+      return;
+    }
+
+    errorOccurred = false;
+    data.ok = true;
+  }).catch(error => {
+    // test logic requires to surface internal data
+    // which is best not exposed in production
+    if (process.env.TAP) {
+      data.testError = error;
+    }
+
+    data.ok = false;
+    data.error = error.message;
+  });
+
+  return [data, errorOccurred];
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const camelcase = require('camelcase');
 
-const { loadConfig } = require('snyk-config');
+const {loadConfig} = require('snyk-config');
 const config = loadConfig(__dirname + '/..');
 
 function camelify(res) {
@@ -14,14 +14,51 @@ function camelify(res) {
 }
 
 function expandValue(obj, value) {
-  return value.replace(/([\\]?\$.+?\b)/g, (all, key) => {
-    if (key[0] === '$') {
-      const keyToReplace = key.slice(1);
-      return obj[keyToReplace] || key;
+  let arrayFound = undefined;
+  let keyWithArray = undefined;
+  const variableRegex = /(\\?\$.+?\b)/g;
+  const variableMatcher = value.match(variableRegex);
+  if (variableMatcher) {
+    for (const key of variableMatcher) {
+      if (key[0] === "$" && obj[(key.slice(1) + "_ARRAY")]) {
+        keyWithArray = key.slice(1);
+        arrayFound = (key.slice(1) + "_ARRAY");
+        break;
+      }
+    }
+  }
+
+  if (arrayFound) {
+    const values = [];
+    let array;
+    if (Array.isArray(obj[arrayFound])) {
+      array = obj[arrayFound];
+    } else {
+      array = obj[arrayFound].split(",").map(s => s.trim());
+      obj[arrayFound] = array;
     }
 
-    return key;
-  });
+    for (const o of array) {
+      values.push(value.replace(variableRegex, (all, key) => {
+        if (key[0] === '$') {
+          const keyToReplace = key.slice(1);
+          return keyToReplace === keyWithArray ? o : (obj[keyToReplace] || key);
+        }
+
+        return key;
+      }));
+    }
+    return values;
+  } else {
+    return value.replace(variableRegex, (all, key) => {
+      if (key[0] === '$') {
+        const keyToReplace = key.slice(1);
+        return obj[keyToReplace] || key;
+      }
+
+      return key;
+    });
+  }
 }
 
 function expand(obj) {
@@ -29,7 +66,10 @@ function expand(obj) {
 
   for (const key of keys) {
     const value = expandValue(obj, obj[key]);
-    if (value !== obj[key]) {
+    if (value && Array.isArray(value)) {
+      // This will get camel-cased later on
+      obj[(key + "_ARRAY")] = value;
+    } else if (value !== obj[key]) {
       obj[key] = value;
     }
   }
@@ -51,6 +91,12 @@ const res = Object.assign({}, camelify(config), camelify(process.env));
 
 if (res.caCert) {
   res.caCert = fs.readFileSync(path.resolve(process.cwd(), res.caCert));
+}
+
+for (const [key, value] of Object.entries(res)) {
+  if ((key.endsWith("Array") || key.endsWith("_ARRAY")) && !Array.isArray(value)) {
+    res[key] = value.split(",").map(s => s.trim());
+  }
 }
 
 module.exports = res;

--- a/lib/config.js
+++ b/lib/config.js
@@ -14,35 +14,35 @@ function camelify(res) {
 }
 
 function expandValue(obj, value) {
-  let arrayFound = undefined;
-  let keyWithArray = undefined;
+  let poolFound = undefined;
+  let keyWithPool = undefined;
   const variableRegex = /(\\?\$.+?\b)/g;
   const variableMatcher = value.match(variableRegex);
   if (variableMatcher) {
     for (const key of variableMatcher) {
-      if (key[0] === "$" && obj[(key.slice(1) + "_ARRAY")]) {
-        keyWithArray = key.slice(1);
-        arrayFound = (key.slice(1) + "_ARRAY");
+      if (key[0] === "$" && obj[(key.slice(1) + "_POOL")]) {
+        keyWithPool = key.slice(1);
+        poolFound = (key.slice(1) + "_POOL");
         break;
       }
     }
   }
 
-  if (arrayFound) {
+  if (poolFound) {
     const values = [];
-    let array;
-    if (Array.isArray(obj[arrayFound])) {
-      array = obj[arrayFound];
+    let pool;
+    if (Array.isArray(obj[poolFound])) {
+      pool = obj[poolFound];
     } else {
-      array = obj[arrayFound].split(",").map(s => s.trim());
-      obj[arrayFound] = array;
+      pool = obj[poolFound].split(",").map(s => s.trim());
+      obj[poolFound] = pool;
     }
 
-    for (const o of array) {
+    for (const o of pool) {
       values.push(value.replace(variableRegex, (all, key) => {
         if (key[0] === '$') {
           const keyToReplace = key.slice(1);
-          return keyToReplace === keyWithArray ? o : (obj[keyToReplace] || key);
+          return keyToReplace === keyWithPool ? o : (obj[keyToReplace] || key);
         }
 
         return key;
@@ -68,7 +68,7 @@ function expand(obj) {
     const value = expandValue(obj, obj[key]);
     if (value && Array.isArray(value)) {
       // This will get camel-cased later on
-      obj[(key + "_ARRAY")] = value;
+      obj[(key + "_POOL")] = value;
     } else if (value !== obj[key]) {
       obj[key] = value;
     }
@@ -94,7 +94,7 @@ if (res.caCert) {
 }
 
 for (const [key, value] of Object.entries(res)) {
-  if ((key.endsWith("Array") || key.endsWith("_ARRAY")) && !Array.isArray(value)) {
+  if ((key.endsWith("Pool") || key.endsWith("_POOL")) && !Array.isArray(value)) {
     res[key] = value.split(",").map(s => s.trim());
   }
 }

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -55,6 +55,7 @@ module.exports = (ruleSource) => {
   const tests = rules.map((entry) => {
     const keys = [];
     let { method, origin, path: entryPath, valid } = entry;
+    const baseOrigin = origin;
     const { stream } = entry;
     method = (method || 'get').toLowerCase();
     valid = valid || [];
@@ -73,8 +74,6 @@ module.exports = (ruleSource) => {
       fromConfig[key] = config[key] || '';
       return ':' + key;
     });
-
-    origin = replace(origin, config);
 
     if (entryPath[0] !== '/') {
       entryPath = '/' + entryPath;
@@ -175,6 +174,7 @@ module.exports = (ruleSource) => {
         }
       }
 
+      const origin = replace(baseOrigin, config);
       logger.debug(
         { path: entryPath, origin, url, querystring },
         'rule matched',

--- a/lib/replace-vars.js
+++ b/lib/replace-vars.js
@@ -8,12 +8,12 @@ function replace(input, source) {
       const key = match.slice(2, -1); // ditch the wrappers
       let keyName;
       let idxName;
-      if (source[(key + "_ARRAY")]) {
-          keyName = key + "_ARRAY";
-          idxName = key + "_ARRAY_IDX";
-      } else if (source[(key + "Array")]) {
-          keyName = key + "Array";
-          idxName = key + "ArrayIdx";
+      if (source[(key + "_POOL")]) {
+          keyName = key + "_POOL";
+          idxName = key + "_POOL_IDX";
+      } else if (source[(key + "Pool")]) {
+          keyName = key + "Pool";
+          idxName = key + "PoolIdx";
       }
 
       const array = source[keyName];

--- a/lib/replace-vars.js
+++ b/lib/replace-vars.js
@@ -5,8 +5,28 @@ module.exports = {
 
 function replace(input, source) {
   return (input || '').replace(/(\${.*?})/g, (_, match) => {
-    const key = match.slice(2, -1); // ditch the wrappers
-    return source[key] || '';
+      const key = match.slice(2, -1); // ditch the wrappers
+      let keyName;
+      let idxName;
+      if (source[(key + "_ARRAY")]) {
+          keyName = key + "_ARRAY";
+          idxName = key + "_ARRAY_IDX";
+      } else if (source[(key + "Array")]) {
+          keyName = key + "Array";
+          idxName = key + "ArrayIdx";
+      }
+
+      const array = source[keyName];
+      let idx;
+      if (array) {
+          idx = source[idxName] || 0;
+          if (idx >= array.length) {
+              idx = 0;
+          }
+          source[idxName] = idx + 1;
+      }
+
+      return array ? array[idx] : source[key] || '';
   });
 }
 

--- a/lib/replace-vars.js
+++ b/lib/replace-vars.js
@@ -6,27 +6,27 @@ module.exports = {
 function replace(input, source) {
   return (input || '').replace(/(\${.*?})/g, (_, match) => {
       const key = match.slice(2, -1); // ditch the wrappers
-      let keyName;
-      let idxName;
+      let poolName;
+      let poolIndex;
       if (source[(key + "_POOL")]) {
-          keyName = key + "_POOL";
-          idxName = key + "_POOL_IDX";
+          poolName = key + "_POOL";
+          poolIndex = key + "_POOL_IDX";
       } else if (source[(key + "Pool")]) {
-          keyName = key + "Pool";
-          idxName = key + "PoolIdx";
+          poolName = key + "Pool";
+          poolIndex = key + "PoolIdx";
       }
 
-      const array = source[keyName];
+      const pool = source[poolName];
       let idx;
-      if (array) {
-          idx = source[idxName] || 0;
-          if (idx >= array.length) {
+      if (pool) {
+          idx = source[poolIndex] || 0;
+          if (idx >= pool.length) {
               idx = 0;
           }
-          source[idxName] = idx + 1;
+          source[poolIndex] = idx + 1;
       }
 
-      return array ? array[idx] : source[key] || '';
+      return pool ? pool[idx] : source[key] || '';
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "prom-client": "^11.5.3",
     "qs": "^6.9.1",
     "request": "^2.88.1",
+    "request-promise-native": "^1.0.9",
     "snyk-config": "^4.0.0-rc.2",
     "then-fs": "^2.0.0",
     "tunnel": "0.0.6",

--- a/test/fixtures/client/filters.json
+++ b/test/fixtures/client/filters.json
@@ -43,6 +43,12 @@
     },
 
     {
+      "path": "/echo-headers/github-token-in-origin",
+      "method": "POST",
+      "origin": "http://${GITHUB_TOKEN}@localhost:${originPort}"
+    },
+
+    {
       "path": "/echo-headers/bitbucket",
       "method": "POST",
       "origin": "http://bitbucketUser:bitbucketPassword@localhost:${originPort}"

--- a/test/functional/server-client-pooled-credentials.test.js
+++ b/test/functional/server-client-pooled-credentials.test.js
@@ -52,7 +52,7 @@ test('proxy requests originating from behind the broker server with pooled crede
   server.io.on('connection', (socket) => {
     socket.on('identify', (clientData) => {
       const token = clientData.token;
-      t.plan(5);
+      t.plan(8);
 
       t.test('identification', (t) => {
         const filters = require(`${clientRootPath}/${ACCEPT}`);
@@ -119,6 +119,60 @@ test('proxy requests originating from behind the broker server with pooled crede
               encodedAuth,
               `${process.env.USERNAME}:${process.env.PASSWORD1}`,
               'auth header is set correctly [3]',
+            );
+            t.end();
+          });
+        },
+      );
+
+      t.test(
+        'successfully broker on endpoint that forwards requests with token auth in origin, using first credential',
+        (t) => {
+          const url = `http://localhost:${serverPort}/broker/${token}/echo-headers/github-token-in-origin`;
+          request({ url, method: 'post' }, (err, res) => {
+            t.equal(res.statusCode, 200, '200 statusCode [1]');
+
+            const auth = JSON.parse(res.body).authorization;
+            t.equal(
+              auth,
+              'token token1',
+              'auth header is set correctly [1]',
+            );
+            t.end();
+          });
+        },
+      );
+
+      t.test(
+        'successfully broker on endpoint that forwards requests with token auth in origin, using second credential',
+        (t) => {
+          const url = `http://localhost:${serverPort}/broker/${token}/echo-headers/github-token-in-origin`;
+          request({ url, method: 'post' }, (err, res) => {
+            t.equal(res.statusCode, 200, '200 statusCode [2]');
+
+            const auth = JSON.parse(res.body).authorization;
+            t.equal(
+              auth,
+              'token token2',
+              'auth header is set correctly [1]',
+            );
+            t.end();
+          });
+        },
+      );
+
+      t.test(
+        'successfully broker on endpoint that forwards requests with token auth in origin, using first credential again',
+        (t) => {
+          const url = `http://localhost:${serverPort}/broker/${token}/echo-headers/github-token-in-origin`;
+          request({ url, method: 'post' }, (err, res) => {
+            t.equal(res.statusCode, 200, '200 statusCode [3]');
+
+            const auth = JSON.parse(res.body).authorization;
+            t.equal(
+              auth,
+              'token token1',
+              'auth header is set correctly [1]',
             );
             t.end();
           });

--- a/test/functional/server-client-pooled-credentials.test.js
+++ b/test/functional/server-client-pooled-credentials.test.js
@@ -44,7 +44,8 @@ test('proxy requests originating from behind the broker server with pooled crede
   process.env.PASSWORD = 'not-used';
   process.env.PASSWORD1 = 'aB}#/:%40*1';
   process.env.PASSWORD2 = 'aB}#/:%40*2';
-  process.env.PASSWORD_ARRAY = '$PASSWORD1, $PASSWORD2';
+  process.env.PASSWORD_POOL = '$PASSWORD1, $PASSWORD2';
+  process.env.GITHUB_TOKEN_POOL = 'token1, token2';
   const client = app.main({ port: port() });
 
   // wait for the client to successfully connect to the server and identify itself

--- a/test/functional/server-client-pooled-credentials.test.js
+++ b/test/functional/server-client-pooled-credentials.test.js
@@ -1,0 +1,137 @@
+const test = require('tap-only');
+const path = require('path');
+const request = require('request');
+const app = require('../../lib');
+const version = require('../../lib/version');
+const root = __dirname;
+
+const { port, createTestServer } = require('../utils');
+
+test('proxy requests originating from behind the broker server with pooled credentials', (t) => {
+  /**
+   * 1. start broker in server mode
+   * 2. start broker in client mode and join (1)
+   * 3. run local http server that replicates "private server"
+   * 4. send requests to **server**
+   *
+   * Note: client is forwarding requests to echo-server defined in test/util.js
+   */
+
+  const { echoServerPort, testServer } = createTestServer();
+
+  t.teardown(() => {
+    testServer.close();
+  });
+
+  const ACCEPT = 'filters.json';
+  process.env.ACCEPT = ACCEPT;
+
+  process.chdir(path.resolve(root, '../fixtures/server'));
+  process.env.BROKER_TYPE = 'server';
+  const serverPort = port();
+  const server = app.main({ port: serverPort });
+
+  const clientRootPath = path.resolve(root, '../fixtures/client');
+  process.chdir(clientRootPath);
+  const BROKER_SERVER_URL = `http://localhost:${serverPort}`;
+  const BROKER_TOKEN = '98f04768-50d3-46fa-817a-9ee6631e9970';
+  process.env.BROKER_TYPE = 'client';
+  process.env.GITHUB = 'github.com';
+  process.env.BROKER_TOKEN = BROKER_TOKEN;
+  process.env.BROKER_SERVER_URL = BROKER_SERVER_URL;
+  process.env.ORIGIN_PORT = echoServerPort;
+  process.env.USERNAME = 'user@email.com';
+  process.env.PASSWORD = 'not-used';
+  process.env.PASSWORD1 = 'aB}#/:%40*1';
+  process.env.PASSWORD2 = 'aB}#/:%40*2';
+  process.env.PASSWORD_ARRAY = '$PASSWORD1, $PASSWORD2';
+  const client = app.main({ port: port() });
+
+  // wait for the client to successfully connect to the server and identify itself
+  server.io.on('connection', (socket) => {
+    socket.on('identify', (clientData) => {
+      const token = clientData.token;
+      t.plan(5);
+
+      t.test('identification', (t) => {
+        const filters = require(`${clientRootPath}/${ACCEPT}`);
+        t.equal(clientData.token, BROKER_TOKEN, 'correct token');
+        t.deepEqual(
+          clientData.metadata,
+          {
+            version,
+            filters,
+          },
+          'correct metadata',
+        );
+        t.end();
+      });
+
+      t.test(
+        'successfully broker on endpoint that forwards requests with basic auth, using first credential',
+        (t) => {
+          const url = `http://localhost:${serverPort}/broker/${token}/basic-auth`;
+          request({ url, method: 'get' }, (err, res) => {
+            t.equal(res.statusCode, 200, '200 statusCode [1]');
+
+            const auth = res.body.replace('Basic ', '');
+            const encodedAuth = Buffer.from(auth, 'base64').toString('utf-8');
+            t.equal(
+              encodedAuth,
+              `${process.env.USERNAME}:${process.env.PASSWORD1}`,
+              'auth header is set correctly [1]',
+            );
+            t.end();
+          });
+        },
+      );
+
+      t.test(
+        'successfully broker on endpoint that forwards requests with basic auth, using second credential',
+        (t) => {
+          const url = `http://localhost:${serverPort}/broker/${token}/basic-auth`;
+          request({ url, method: 'get' }, (err, res) => {
+            t.equal(res.statusCode, 200, '200 statusCode [2]');
+
+            const auth = res.body.replace('Basic ', '');
+            const encodedAuth = Buffer.from(auth, 'base64').toString('utf-8');
+            t.equal(
+              encodedAuth,
+              `${process.env.USERNAME}:${process.env.PASSWORD2}`,
+              'auth header is set correctly [2]',
+            );
+            t.end();
+          });
+        },
+      );
+
+      t.test(
+        'successfully broker on endpoint that forwards requests with basic auth, using first credential again',
+        (t) => {
+          const url = `http://localhost:${serverPort}/broker/${token}/basic-auth`;
+          request({ url, method: 'get' }, (err, res) => {
+            t.equal(res.statusCode, 200, '200 statusCode [3]');
+
+            const auth = res.body.replace('Basic ', '');
+            const encodedAuth = Buffer.from(auth, 'base64').toString('utf-8');
+            t.equal(
+              encodedAuth,
+              `${process.env.USERNAME}:${process.env.PASSWORD1}`,
+              'auth header is set correctly [3]',
+            );
+            t.end();
+          });
+        },
+      );
+
+      t.test('clean up', (t) => {
+        client.close();
+        setTimeout(() => {
+          server.close();
+          t.ok('sockets closed');
+          t.end();
+        }, 100);
+      });
+    });
+  });
+});

--- a/test/functional/systemcheck.test.js
+++ b/test/functional/systemcheck.test.js
@@ -316,7 +316,7 @@ test('broker client systemcheck endpoint', (t) => {
         brokerToken: '1234567890',
         brokerServerUrl: 'http://localhost:12345',
         brokerClientValidationUrl: 'https://httpbin.org/headers',
-        brokerClientValidationBasicAuthArray: ['username:password', 'username1:password1'],
+        brokerClientValidationBasicAuthPool: ['username:password', 'username1:password1'],
       },
     });
 

--- a/test/functional/systemcheck.test.js
+++ b/test/functional/systemcheck.test.js
@@ -399,7 +399,7 @@ test('broker client systemcheck endpoint', (t) => {
       t.equal(
         res.body[0].brokerClientValidationUrl,
         'https://snyk.io/no-such-url-ever',
-        'masked credentials present',
+        'validation url present',
       );
 
       client.close();

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -4,11 +4,11 @@ describe('config', () => {
     const token = (process.env.BROKER_TOKEN = '1234');
     const bitbucketTokens = ['1234', '5678'];
     const githubTokens = ['9012', '3456'];
-    process.env.BITBUCKET_PASSWORD_ARRAY = '1234, 5678'
-    process.env.GITHUB_TOKEN_ARRAY = '9012, 3456'
+    process.env.BITBUCKET_PASSWORD_POOL = '1234, 5678'
+    process.env.GITHUB_TOKEN_POOL = '9012, 3456'
     process.env.FOO_BAR = '$FOO/bar';
     process.env.GITHUB_USERNAME = 'git'
-    process.env.GITHUB_PASSWORD_ARRAY = '9012, 3456'
+    process.env.GITHUB_PASSWORD_POOL = '9012, 3456'
     process.env.GITHUB_AUTH = 'Basic $GITHUB_USERNAME:$GITHUB_PASSWORD';
     const complexToken = (process.env.COMPLEX_TOKEN = '1234$$%#@!$!$@$$$');
 
@@ -18,11 +18,11 @@ describe('config', () => {
     expect(config.brokerToken).toEqual(token);
     expect(config.fooBar).toEqual('bar/bar');
     expect(config.complexToken).toEqual(complexToken);
-    expect(config.bitbucketPasswordArray).toEqual(bitbucketTokens);
-    expect(config.BITBUCKET_PASSWORD_ARRAY).toEqual(bitbucketTokens);
-    expect(config.githubTokenArray).toEqual(githubTokens);
-    expect(config.GITHUB_TOKEN_ARRAY).toEqual(githubTokens);
-    expect(config.githubAuthArray).toEqual(['Basic git:9012', 'Basic git:3456']);
-    expect(config.GITHUB_AUTH_ARRAY).toEqual(['Basic git:9012', 'Basic git:3456']);
+    expect(config.bitbucketPasswordPool).toEqual(bitbucketTokens);
+    expect(config.BITBUCKET_PASSWORD_POOL).toEqual(bitbucketTokens);
+    expect(config.githubTokenPool).toEqual(githubTokens);
+    expect(config.GITHUB_TOKEN_POOL).toEqual(githubTokens);
+    expect(config.githubAuthPool).toEqual(['Basic git:9012', 'Basic git:3456']);
+    expect(config.GITHUB_AUTH_POOL).toEqual(['Basic git:9012', 'Basic git:3456']);
   });
 });

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -2,7 +2,14 @@ describe('config', () => {
   it('contain application config', () => {
     const foo = (process.env.FOO = 'bar');
     const token = (process.env.BROKER_TOKEN = '1234');
+    const bitbucketTokens = ['1234', '5678'];
+    const githubTokens = ['9012', '3456'];
+    process.env.BITBUCKET_PASSWORD_ARRAY = '1234, 5678'
+    process.env.GITHUB_TOKEN_ARRAY = '9012, 3456'
     process.env.FOO_BAR = '$FOO/bar';
+    process.env.GITHUB_USERNAME = 'git'
+    process.env.GITHUB_PASSWORD_ARRAY = '9012, 3456'
+    process.env.GITHUB_AUTH = 'Basic $GITHUB_USERNAME:$GITHUB_PASSWORD';
     const complexToken = (process.env.COMPLEX_TOKEN = '1234$$%#@!$!$@$$$');
 
     const config = require('../../lib/config');
@@ -11,5 +18,11 @@ describe('config', () => {
     expect(config.brokerToken).toEqual(token);
     expect(config.fooBar).toEqual('bar/bar');
     expect(config.complexToken).toEqual(complexToken);
+    expect(config.bitbucketPasswordArray).toEqual(bitbucketTokens);
+    expect(config.BITBUCKET_PASSWORD_ARRAY).toEqual(bitbucketTokens);
+    expect(config.githubTokenArray).toEqual(githubTokens);
+    expect(config.GITHUB_TOKEN_ARRAY).toEqual(githubTokens);
+    expect(config.githubAuthArray).toEqual(['Basic git:9012', 'Basic git:3456']);
+    expect(config.GITHUB_AUTH_ARRAY).toEqual(['Basic git:9012', 'Basic git:3456']);
   });
 });

--- a/test/unit/replace-vars.test.ts
+++ b/test/unit/replace-vars.test.ts
@@ -1,4 +1,4 @@
-import { replaceUrlPartialChunk } from '../../lib/replace-vars';
+import {replace, replaceUrlPartialChunk} from '../../lib/replace-vars';
 
 describe('replacePartialChunk', () => {
   const config = {
@@ -54,3 +54,40 @@ describe('replacePartialChunk', () => {
     });
   });
 });
+
+describe('replace - with arrays', () => {
+  const config = {
+    RES_BODY_URL_SUB: 'http://replac.ed',
+    BROKER_SERVER_URL: 'broker.com',
+    BROKER_TOKEN: 'a-tok-en',
+    BITBUCKET_PASSWORD_ARRAY: ['1', '2', '3'],
+    GITHUB_TOKEN_ARRAY: ['1'],
+    githubTokenArray: ['1'],
+  };
+
+  it('Uses an array if configured - upper case', () => {
+    const chunk = 'START ${GITHUB_TOKEN} END';
+    const expected = 'START 1 END';
+
+    expect(replace(chunk, config)).toEqual(expected);
+  });
+
+  it('Uses an array if configured - camel case', () => {
+    const chunk = 'START ${githubToken} END';
+    const expected = 'START 1 END';
+
+    expect(replace(chunk, config)).toEqual(expected);
+  });
+
+  it('Goes back to the start of the array if end reached', () => {
+    const chunk = 'START ${BITBUCKET_PASSWORD} END';
+
+    expect(replace(chunk, config)).toEqual('START 1 END');
+
+    expect(replace(chunk, config)).toEqual('START 2 END');
+
+    expect(replace(chunk, config)).toEqual('START 3 END');
+
+    expect(replace(chunk, config)).toEqual('START 1 END');
+  });
+})

--- a/test/unit/replace-vars.test.ts
+++ b/test/unit/replace-vars.test.ts
@@ -60,9 +60,9 @@ describe('replace - with arrays', () => {
     RES_BODY_URL_SUB: 'http://replac.ed',
     BROKER_SERVER_URL: 'broker.com',
     BROKER_TOKEN: 'a-tok-en',
-    BITBUCKET_PASSWORD_ARRAY: ['1', '2', '3'],
-    GITHUB_TOKEN_ARRAY: ['1'],
-    githubTokenArray: ['1'],
+    BITBUCKET_PASSWORD_POOL: ['1', '2', '3'],
+    GITHUB_TOKEN_POOL: ['1'],
+    githubTokenPool: ['1'],
   };
 
   it('Uses an array if configured - upper case', () => {


### PR DESCRIPTION
- [✅] Ready for review
- [✅] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Users can now specify a credential pool by adding "_POOL" to the
environment variable name, and providing a comma-separated list of
credentials as the value, which will get turned into an array
internally. For example, to provide multiple GitHub tokens, you would
do:

GITHUB_TOKEN_POOL=token1, token2, token3, ...

This will then create an array, and anywhere that GITHUB_TOKEN is
referenced (e.g., in accept.json) it will instead pick a token from that
list (picking the first then second then third then back to the
beginning, etc).

It will also create an array of any other variables that reference it,
like BROKER_CLIENT_VALIDATION_AUTHORIZATION_HEADER - it will create a
BROKER_CLIENT_VALIDATION_AUTHORIZATION_HEADER_POOL value, which is
used by the systemcheck endpoint.

This includes a breaking change to the /systemcheck endpoint as it now
returns a JSON array rather than an object - this is to accommodate
checking multiple credentials at once.

#### Where should the reviewer start?
Start in `config.js`, which has to parse the pools, then `replace-vars.js`, which handles the actual replacing. Then `index.js` for the `/systemcheck` endpoint and `filter.js` has some minor changes applied.


#### How should this be manually tested?
Start the Broker Client with an `_POOL` environment variable for whichever provider you're using. Verify the `/systemcheck` endpoint picks up both credentials. Verify multiple requests work. Add one good and one bad credential, and verify 50% of requests fail.

#### Any background context you want to provide?


#### Screenshots


#### Additional questions
