### PR TITLE
feat: remove content-encoding header from client requests

### DIFF
--- a/lib/relay.js
+++ b/lib/relay.js
@@ -327,6 +327,7 @@ function responseHandler(filterRules, config, io) {
           'content-length',
           'host',
           'accept-encoding',
+          'content-encoding'
         ].map((_) => delete headers[_]);
 
         if (brokerToken) {


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

- Removes the header `content-encoding` from requests coming over the websocket connection

#### Any background context you want to provide?

- When testing git cloning through the broker we found that git clone requests can add a 'content-encoding : gzip' header. As far as we know the broker does not support compressed payloads. As a result this causes requests to /git-upload-pack to be corrupted resulting in a clone error `fatal: error reading section header 'shallow-info'`. Removing the content-encoding header fixes this.

