### PR TITLE
fix: set permissions for OpenShift

### DIFF
--- a/dockerfiles/artifactory/Dockerfile
+++ b/dockerfiles/artifactory/Dockerfile
@@ -28,6 +28,10 @@ USER node
 
 # Generate default accept filter
 RUN broker init artifactory
+# Support for OpenShift - have to run after init to get accept.json and .env
+USER root
+RUN chgrp -R 0 /home/node && chmod -R g=u,o= /home/node && chown -R node /home/node
+USER node
 
 ######################################
 # Custom Broker Client configuration #

--- a/dockerfiles/azure-repos/Dockerfile
+++ b/dockerfiles/azure-repos/Dockerfile
@@ -28,6 +28,10 @@ USER node
 
 # Generate default accept filter
 RUN broker init azure-repos
+# Support for OpenShift - have to run after init to get accept.json and .env
+USER root
+RUN chgrp -R 0 /home/node && chmod -R g=u,o= /home/node && chown -R node /home/node
+USER node
 
 ######################################
 # Custom Broker Client configuration #

--- a/dockerfiles/bitbucket-server/Dockerfile
+++ b/dockerfiles/bitbucket-server/Dockerfile
@@ -28,6 +28,10 @@ USER node
 
 # Generate default accept filter
 RUN broker init bitbucket-server
+# Support for OpenShift - have to run after init to get accept.json and .env
+USER root
+RUN chgrp -R 0 /home/node && chmod -R g=u,o= /home/node && chown -R node /home/node
+USER node
 
 ######################################
 # Custom Broker Client configuration #

--- a/dockerfiles/container-registry-agent/Dockerfile
+++ b/dockerfiles/container-registry-agent/Dockerfile
@@ -31,6 +31,10 @@ COPY --chown=node:node ./bin/container-registry-agent/docker-entrypoint.sh ./doc
 
 # Generate default accept filter
 RUN broker init container-registry-agent
+# Support for OpenShift - have to run after init to get accept.json and .env
+USER root
+RUN chgrp -R 0 /home/node && chmod -R g=u,o= /home/node && chown -R node /home/node
+USER node
 
 ######################################
 # Custom Broker Client configuration #

--- a/dockerfiles/github-com/Dockerfile
+++ b/dockerfiles/github-com/Dockerfile
@@ -28,6 +28,10 @@ USER node
 
 # Generate default accept filter
 RUN broker init github-com
+# Support for OpenShift - have to run after init to get accept.json and .env
+USER root
+RUN chgrp -R 0 /home/node && chmod -R g=u,o= /home/node && chown -R node /home/node
+USER node
 
 ######################################
 # Custom Broker Client configuration #

--- a/dockerfiles/github-enterprise/Dockerfile
+++ b/dockerfiles/github-enterprise/Dockerfile
@@ -28,6 +28,10 @@ USER node
 
 # Generate default accept filter
 RUN broker init github-enterprise
+# Support for OpenShift - have to run after init to get accept.json and .env
+USER root
+RUN chgrp -R 0 /home/node && chmod -R g=u,o= /home/node && chown -R node /home/node
+USER node
 
 ######################################
 # Custom Broker Client configuration #

--- a/dockerfiles/gitlab/Dockerfile
+++ b/dockerfiles/gitlab/Dockerfile
@@ -28,6 +28,10 @@ USER node
 
 # Generate default accept filter
 RUN broker init gitlab
+# Support for OpenShift - have to run after init to get accept.json and .env
+USER root
+RUN chgrp -R 0 /home/node && chmod -R g=u,o= /home/node && chown -R node /home/node
+USER node
 
 ######################################
 # Custom Broker Client configuration #

--- a/dockerfiles/jira/Dockerfile
+++ b/dockerfiles/jira/Dockerfile
@@ -28,6 +28,10 @@ USER node
 
 # Generate default accept filter
 RUN broker init jira
+# Support for OpenShift - have to run after init to get accept.json and .env
+USER root
+RUN chgrp -R 0 /home/node && chmod -R g=u,o= /home/node && chown -R node /home/node
+USER node
 
 ######################################
 # Custom Broker Client configuration #

--- a/dockerfiles/nexus/Dockerfile
+++ b/dockerfiles/nexus/Dockerfile
@@ -28,6 +28,10 @@ USER node
 
 # Generate default accept filter
 RUN broker init nexus
+# Support for OpenShift - have to run after init to get accept.json and .env
+USER root
+RUN chgrp -R 0 /home/node && chmod -R g=u,o= /home/node && chown -R node /home/node
+USER node
 
 ######################################
 # Custom Broker Client configuration #

--- a/dockerfiles/nexus2/Dockerfile
+++ b/dockerfiles/nexus2/Dockerfile
@@ -28,6 +28,10 @@ USER node
 
 # Generate default accept filter
 RUN broker init nexus2
+# Support for OpenShift - have to run after init to get accept.json and .env
+USER root
+RUN chgrp -R 0 /home/node && chmod -R g=u,o= /home/node && chown -R node /home/node
+USER node
 
 ######################################
 # Custom Broker Client configuration #

--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -8,9 +8,6 @@ RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node \
   && apt update && apt upgrade -y && apt install gpg curl xz-utils -y
 
-USER root
-RUN chgrp -R 0 /home/node && chmod -R g=u /home/node
-
 ENV NODE_VERSION 16.17.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \


### PR DESCRIPTION
#### What does this PR do?
OpenShift has very specific needs for permissions - all files should be part of the "root" group, and should have the same permissions as the primary user.

This needs to be done per-dockerfile so that can adjust permissions for all files, including those generated during the build.

Also remove global permissions from all files and folders while we're doing this.

- [✅] Ready for review
- [✅] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules


#### Where should the reviewer start?


#### How should this be manually tested?
Deploy any of the Broker Client docker images to OpenShift

#### Any background context you want to provide?
[OpenShift Docs](https://docs.openshift.com/container-platform/4.9/openshift_images/create-images.html#images-create-guide-openshift_create-images) indicating this is the correct approach

#### Screenshots


#### Additional questions
