### PR TITLE
feat: set ping config through env

### DIFF
--- a/lib/client/socket.js
+++ b/lib/client/socket.js
@@ -42,7 +42,8 @@ module.exports = ({ url, token, filters, config, identifyingMetadata }) => {
       retries: 30,
       max: 20 * 60 * 1000,
     },
-    pingTimeout: parseInt(config.socketPingTimeout) || 45000,
+    ping: parseInt(config.socketPingInterval) || 25000,
+    pong: parseInt(config.socketPongTimeout) || 10000,
     timeout: parseInt(config.socketConnectTimeout) || 10000,
   });
 

--- a/lib/server/socket.js
+++ b/lib/server/socket.js
@@ -12,9 +12,12 @@ module.exports = ({ server, filters, config }) => {
   const ioConfig = {
     transformer: 'engine.io',
     parser: 'EJSON',
-    maxLength: parseInt(config.socketMaxResponseLength) || 22020096, // support up to 21MB in response bodies
-    transport: { allowEIO3: true },
-    pingInterval: parseInt(config.socketPingInterval) || 30000,
+    maxLength: parseInt(config.socketMaxResponseLength) || 20971520, // support up to 20MB in response bodies
+    transport: {
+      allowEIO3: true,
+      pingInterval: parseInt(config.socketPingInterval) || 25000,
+      pingTimeout: parseInt(config.socketPingTimeout) || 20000,
+    },
     compression: Boolean(config.socketUseCompression) || false,
   };
 

--- a/lib/server/socket.js
+++ b/lib/server/socket.js
@@ -12,7 +12,7 @@ module.exports = ({ server, filters, config }) => {
   const ioConfig = {
     transformer: 'engine.io',
     parser: 'EJSON',
-    maxLength: parseInt(config.socketMaxResponseLength) || 20971520, // support up to 20MB in response bodies
+    maxLength: parseInt(config.socketMaxResponseLength) || 22020096, // support up to 21MB in response bodies
     transport: {
       allowEIO3: true,
       pingInterval: parseInt(config.socketPingInterval) || 25000,


### PR DESCRIPTION
#### What does this PR do?

- Allows the configuration of ping intervals and timeouts for the server and client
- The client values are defaulted to the [primus defaults](https://github.com/primus/primus/tree/6.1.0#connecting-from-the-browser)
- The server values and defaults had to be set at the [engine.io level ](https://github.com/socketio/engine.io/blob/917d1d29e13f2e8f523c3738f6413f67b587aebe/lib/server.ts#L138)as the the [Primus timeout option](https://github.com/primus/primus/tree/6.1.0#getting-started) did not have an effect on the socket ping interval or timeout