### PR TITLE
Log size of original request as well, and log errors as warnings

### DIFF
--- a/lib/relay.js
+++ b/lib/relay.js
@@ -177,7 +177,8 @@ function requestHandler(filterRules) {
             }
           } else {
             logContext.ioErrorType = ioResponse.errorType;
-            logger.info(logContext, logMsg);
+            logContext.ioOriginalBodySize = ioResponse.originalBodySize;
+            logger.warn(logContext, logMsg);
           }
 
           const httpResponse = res
@@ -402,7 +403,7 @@ function responseHandler(filterRules, config, io) {
           }
 
           // all headers converted to lower-case
-          const contentLength = response.headers && response.headers['content-length'];
+          const contentLength = responseBody.length;
           // Note that the other side of the request will also check the length and will also reject it if it's too large
           // Set to 20MB even though the server is 21MB because the server looks at the total data travelling through the websocket,
           // not just the size of the body, so allow 1MB for miscellaneous data (e.g., headers, Primus overhead)
@@ -413,8 +414,9 @@ function responseHandler(filterRules, config, io) {
               errorMessage
             });
             return emit({
-              status: 500,
+              status: 502,
               errorType: 'BODY_TOO_LARGE',
+              originalBodySize: contentLength,
               body: {
                 message: errorMessage
               }

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -402,7 +402,6 @@ function responseHandler(filterRules, config, io) {
             });
           }
 
-          // all headers converted to lower-case
           const contentLength = responseBody.length;
           // Note that the other side of the request will also check the length and will also reject it if it's too large
           // Set to 20MB even though the server is 21MB because the server looks at the total data travelling through the websocket,

--- a/test/functional/server-client.test.js
+++ b/test/functional/server-client.test.js
@@ -450,7 +450,7 @@ test('proxy requests originating from behind the broker server', (t) => {
       t.test('reject responses that are too large', (t) => {
         const url = `http://localhost:${serverPort}/broker/${token}/huge-file`;
         request({ url, method: 'get' }, (err, res) => {
-          t.equal(res.statusCode, 500, '500 statusCode');
+          t.equal(res.statusCode, 502, '502 statusCode');
           t.equal(res.body, '{"message":"body size of 20971532 is greater than max allowed of 20971520 bytes"}', 'error returned');
           t.end();
         });


### PR DESCRIPTION
Should really log errors as errors, but some "errors" aren't really errors. e.g., a 404 probably shouldn't be logged at all as they're very common, while a 502 from the Client should be logged at error level.

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
