### PR TITLE
[ATLAS-67] feat: add default reviewers endpoint to BBS

### DIFF
--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -980,6 +980,28 @@
       "method": "any",
       "path": "/snykgit/*",
       "origin": "${GIT_CLIENT_URL}"
+    },
+    {
+      "//": "used to fetch a given repo from API",
+      "method": "GET",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to get default reviewers for a pull request",
+      "method": "GET",
+      "path": "/rest/default-reviewers/1.0/projects/:projectKey/repos/:repo/reviewers",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
     }
   ]
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This would allow us to create PRs with default reviewers assigned for Bitbucket Server. When you raise a PR via API, you need to do this manually.

#### Where should the reviewer start?

The next section.

#### How should this be manually tested?

1. Run a `bitbucket-server` Broker image locally, and point it at either dev or local Broker Server. Use the new `accept.json` rules introduced in this PR.
2. Set up Bitbucket Server/Data Center integration with Broker, and point it at the local Broker set up in the previous step.
3. Create or update a repository with existing vulnerabilities in your Bitbucket Server/Data Center, and set a default reviewer for that repository. _NB! The default reviewer must be a user other than the one whose credentials are used to raise the PR._
4. Raise a fix PR on a repository imported from Bitbucket Server, and check if the PR has reviewer(s) assigned. The assigned reviewer(s) should be the same that you have set up on your repository/project.

#### Any background context you want to provide?

It's a part of [ATLAS-67](https://snyksec.atlassian.net/browse/ATLAS-67).

#### Screenshots
See videos from https://github.com/snyk/bitbucket-server-agent/pull/431

#### Additional questions
- There is [this](https://github.com/snyk/broker/blob/master/client-templates/bitbucket-server/accept.json.sample#L44-L52) rule that should have not have blocked the request to get a repo. How come that adding it manually with `BITBUCKET` instead of `BITBUCKET_API` works? It is blocking them ATM; you can see the logs [here](https://app.logz.io/#/goto/180b4e98c7e91b9b2d02c9cfe5e8e655?switchToAccountId=2322).