### PR TITLE
Drop Ubuntu version to 20.04

### DIFF
--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -2,7 +2,7 @@
 # The following image is reachable through the snyk/ubuntu:latest image in DockerHub.
 # Note that there's no need to build it; All broker client Dockerfiles use the snyk/ubuntu:latest.
 
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node \


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Ubuntu 22.04 has some issues with older versions of the Docker Engine in Kubernetes. It's not clear whether this is a bug in Ubuntu / the Ubuntu docker image, or if it's a bug in the Docker Engine. Either way, in order to retain support for older versions it is necessary to drop the Ubuntu version back down.

Symptoms of this include segfaults or hard-crashes with C/C++ stack traces, such as:

```
node[1]: ../src/node_platform.cc:61:std::unique_ptr<long unsigned int> node::WorkerThreadsTaskRunner::DelayedTaskScheduler::Start(): Assertion `(0) == (uv_thread_create(t.get(), start_thread, this))' failed.
 1: 0xb02930 node::Abort() [node]
 2: 0xb029ae [node]
 3: 0xb6fb4e [node]
 4: 0xb6fc16 node::NodePlatform::NodePlatform(int, v8::TracingController*) [node]
 5: 0xac7d3d node::InitializeOncePerProcess(int, char**, node::InitializationSettingsFlags, node::ProcessFlags::Flags) [node]
 6: 0xac8919 node::Start(int, char**) [node]
 7: 0x7f49ed2c6d90 [/lib/x86_64-linux-gnu/libc.so.6]
 8: 0x7f49ed2c6e40 __libc_start_main [/lib/x86_64-linux-gnu/libc.so.6]
 9: 0xa3d03c [node]
```
