### PR TITLE
chore: add accept json rules for jira server version 9 api endpoints

### DIFF
--- a/client-templates/jira/accept.json.sample
+++ b/client-templates/jira/accept.json.sample
@@ -67,6 +67,28 @@
       }
     },
     {
+      "//": "used to get createmeta for a jira project & issueType version 9 and above",
+      "method": "GET",
+      "path": "/rest/api/2/issue/createmeta/:project/issuetypes/:issue",
+      "origin": "https://${JIRA_HOSTNAME}",
+      "auth": {
+         "scheme": "basic",
+         "username": "${JIRA_USERNAME}",
+         "password": "${JIRA_PASSWORD}"
+      }
+    },
+    {
+      "//": "used to get issue type information for version 9 or above",
+      "method": "GET",
+      "path": "/rest/api/2/issuetype/:issuetype",
+      "origin": "https://${JIRA_HOSTNAME}",
+      "auth": {
+         "scheme": "basic",
+         "username": "${JIRA_USERNAME}",
+         "password": "${JIRA_PASSWORD}"
+      }
+    },
+    {
       "//": "used to get jira issue",
       "method": "GET",
       "path": "/rest/api/2/issue/:issue",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### Any background context you want to provide?

Jira server version 9 deprecates calling `create-meta` with query parameters [https://confluence.atlassian.com/jiracore/createmeta-rest-endpoint-to-be-removed-975040986.html](). 

As such, we had to update our Jira integration to call the new endpoints as mentioned [here](https://developer.atlassian.com/server/jira/platform/jira-rest-api-examples/#creating-an-issue-examples).

For this to work with the broker, this PR updates the `accept.json` example.
