### PR TITLE
fix: remove callback that was causing memory leak

### DIFF
--- a/lib/client/socket.js
+++ b/lib/client/socket.js
@@ -105,6 +105,5 @@ module.exports = ({ url, token, filters, config, identifyingMetadata }) => {
     throw error;
   }
 
-
   return createWebSocket(token, url, config, filters, identifyingMetadata);
 };

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -56,6 +56,11 @@ class StreamResponseHandler {
       isStreaming: true,
     });
   };
+
+  destroy = (error) => {
+    this.streamBuffer.destroy(error);
+    streams.del(this.streamingID);
+  };
 }
 
 module.exports = {
@@ -164,23 +169,13 @@ function forwardHttpRequest(filterRules) {
         });
         streamBuffer.pipe(res);
 
-        res.locals.io.send(
-          'request',
-          {
-            url: req.url,
-            method: req.method,
-            body: req.body,
-            headers: req.headers,
-            streamingID,
-          },
-          () => {
-            // Streaming requests should not be handled using the emit function
-            // but rather by sending 'chunk' messages
-            const msg = 'Broker client does not support streaming requests';
-            logger.error(logContext, msg);
-            return res.status(501).send({ message: msg });
-          },
-        );
+        res.locals.io.send('request', {
+          url: req.url,
+          method: req.method,
+          body: req.body,
+          headers: req.headers,
+          streamingID,
+        });
 
         return;
       }

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -188,7 +188,7 @@ module.exports = ({ config = {}, port = null, filters = {} }) => {
           { ...logContext, error: err },
           'received error handling POST from client',
         );
-        streamHandler.finished();
+        streamHandler.destroy(err);
         res.status(500).json({ err });
       });
   });

--- a/lib/stream-posts.js
+++ b/lib/stream-posts.js
@@ -9,7 +9,9 @@ module.exports = {
 
 function initStream(config, brokerToken, streamingID, ioData) {
   const buffer = new stream.PassThrough({ highWaterMark: 1048576 });
-  buffer.on('error', (e) => logger.error({error: e}, 'received error sending data to buffer'));
+  buffer.on('error', (e) =>
+    logger.error({ error: e }, 'received error sending data to buffer'),
+  );
   buffer.pipe(
     request({
       url: `${config.brokerServerUrl}/response-data/${brokerToken}/${streamingID}`,
@@ -20,7 +22,7 @@ function initStream(config, brokerToken, streamingID, ioData) {
       },
     })
       .on('error', (e) => {
-        logger.error({error: e}, 'received error sending data via POST');
+        logger.error({ error: e }, 'received error sending data via POST');
       })
       .on('response', (r) => {
         if (r.statusCode !== 200) {
@@ -56,18 +58,25 @@ function pipeStream(rqst, logContext, config, brokerToken, streamingID) {
   rqst
     .on('error', (e) => {
       logError(logContext, e);
+      const body = JSON.stringify({ message: e.message });
       const buffer = initStream(
         config,
         brokerToken,
         streamingID,
-        JSON.stringify({ status: 500 }),
+        JSON.stringify({
+          status: 500,
+          headers: {
+            'Content-Length': `${body.length}`,
+            'Content-Type': 'application/json',
+          },
+        }),
       );
-      buffer.write(e.message);
+      buffer.write(body);
       buffer.end();
     })
     .on('response', (response) => {
       logger.debug('Response received - setting up stream to Server');
-      const status = (response?.statusCode) || 500;
+      const status = response?.statusCode || 500;
       logResponse(logContext, status, response, config);
       isResponseJson = isJson(response.headers);
       const ioData = JSON.stringify({


### PR DESCRIPTION
Removed a callback that would handle the case where a response was emitted to a streaming request, which isn't supported. Unfortunately, this resulted in a substantial memory leak because the callback was never removed. This only affected the Broker Server, and then only if a large number of streaming requests were received.

Also added better handling for errors - e.g., destroying the stream to trigger proper error processing, and adding content-length/content-type for errors POST'd to the Server.

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules