### PR TITLE
fix: Server was encountering an error when streaming was requested from Client

### DIFF
--- a/lib/relay.js
+++ b/lib/relay.js
@@ -262,6 +262,47 @@ function forwardHttpRequest(filterRules) {
   };
 }
 
+function legacyStreaming(logContext, rqst, config, io, streamingID) {
+  let prevPartialChunk;
+  let isResponseJson;
+  logger.warn(
+    logContext,
+    'server did not advertise received-post-streams capability - falling back to legacy streaming',
+  );
+  // Fall back to older streaming method if somehow connected to older server version
+  rqst
+    .on('response', (response) => {
+      const status = (response && response.statusCode) || 500;
+      logResponse(logContext, status, response, config);
+      isResponseJson = isJson(response.headers);
+      io.send('chunk', streamingID, '', false, {
+        status,
+        headers: response.headers,
+      });
+    })
+    .on('data', (chunk) => {
+      if (config.RES_BODY_URL_SUB && isResponseJson) {
+        const { newChunk, partial } = replaceUrlPartialChunk(
+          Buffer.from(chunk).toString(),
+          prevPartialChunk,
+          config,
+        );
+        prevPartialChunk = partial;
+        chunk = newChunk;
+      }
+      io.send('chunk', streamingID, chunk, false);
+    })
+    .on('end', () => {
+      io.send('chunk', streamingID, '', true);
+    })
+    .on('error', (error) => {
+      logError(logContext, error);
+      io.send('chunk', streamingID, error.message, true, {
+        status: 500,
+      });
+    });
+}
+
 // 1. Request coming in over websocket conn (logged)
 // 2. Filter for rule match (log and block if no match)
 // 3. Relay over HTTP conn (logged)
@@ -287,40 +328,55 @@ function forwardWebSocketRequest(filterRules, config, io) {
 
       const realEmit = emit;
       emit = (responseData) => {
-        if (responseData instanceof request.Request) {
-          logger.trace(
-            logContext,
-            'posting streaming response back to Broker Server',
-          );
-          pipeStream(
-            responseData,
-            logContext,
-            config,
-            brokerToken,
-            streamingID,
-          );
-        } else if (streamingID) {
-          // Only for responses generated internally in the Broker Client/Server
-          const body = responseData.body;
-          delete responseData.body;
-          logger.trace(
-            { ...logContext, responseData, body },
-            "posting internal response back to Broker Server as it's expecting streaming response",
-          );
-          const buffer = initStream(
-            config,
-            brokerToken,
-            streamingID,
-            JSON.stringify(responseData),
-          );
-          buffer.write(JSON.stringify(body));
-          buffer.end();
+        // This only works client -> server, it's not possible to post data server -> client
+        if (io?.capabilities?.includes('receive-post-streams')) {
+          if (responseData instanceof request.Request) {
+            logger.trace(
+              logContext,
+              'posting streaming response back to Broker Server',
+            );
+            pipeStream(
+              responseData,
+              logContext,
+              config,
+              brokerToken,
+              streamingID,
+            );
+          } else {
+            // Only for responses generated internally in the Broker Client/Server
+            const body = responseData.body;
+            delete responseData.body;
+            logger.trace(
+              {...logContext, responseData, body},
+              "posting internal response back to Broker Server as it's expecting streaming response",
+            );
+            const buffer = initStream(
+              config,
+              brokerToken,
+              streamingID,
+              JSON.stringify(responseData),
+            );
+            buffer.write(JSON.stringify(body));
+            buffer.end();
+          }
         } else {
-          logger.trace(
-            { ...logContext, responseData },
-            'sending fixed response over WebSocket connection',
-          );
-          realEmit(responseData);
+          if (streamingID) {
+            if (responseData instanceof request.Request) {
+              legacyStreaming(logContext, responseData, config, io, streamingID);
+            } else {
+              io.send('chunk', streamingID, '', false, {
+                status: responseData.status,
+                headers: responseData.headers,
+              });
+              io.send('chunk', streamingID, JSON.stringify(responseData.body), true);
+            }
+          } else {
+            logger.trace(
+              {...logContext, responseData},
+              'sending fixed response over WebSocket connection',
+            );
+            realEmit(responseData);
+          }
         }
       };
 
@@ -456,52 +512,8 @@ function forwardWebSocketRequest(filterRules, config, io) {
         if (streamingID) {
           logger.debug(logContext, 'serving stream request');
 
-          let prevPartialChunk;
-          let isResponseJson;
-
           try {
-            const rqst = request(req);
-            // This only works client -> server, it's not possible to post data server -> client
-            if (io.capabilities?.includes('receive-post-streams')) {
-              emit(rqst);
-            } else {
-              logger.warn(
-                logContext,
-                'server did not advertise receive-post-streams capability - falling back to legacy streaming',
-              );
-              // Fall back to older streaming method if somehow connected to older server version
-              rqst
-                .on('response', (response) => {
-                  const status = (response && response.statusCode) || 500;
-                  logResponse(logContext, status, response, config);
-                  isResponseJson = isJson(response.headers);
-                  io.send('chunk', streamingID, '', false, {
-                    status,
-                    headers: response.headers,
-                  });
-                })
-                .on('data', (chunk) => {
-                  if (config.RES_BODY_URL_SUB && isResponseJson) {
-                    const { newChunk, partial } = replaceUrlPartialChunk(
-                      Buffer.from(chunk).toString(),
-                      prevPartialChunk,
-                      config,
-                    );
-                    prevPartialChunk = partial;
-                    chunk = newChunk;
-                  }
-                  io.send('chunk', streamingID, chunk, false);
-                })
-                .on('end', () => {
-                  io.send('chunk', streamingID, '', true);
-                })
-                .on('error', (error) => {
-                  logError(logContext, error);
-                  io.send('chunk', streamingID, error.message, true, {
-                    status: 500,
-                  });
-                });
-            }
+            emit(request(req));
           } catch (e) {
             logger.error(
               { ...logContext, error: e },

--- a/test/fixtures/client/filters.json
+++ b/test/fixtures/client/filters.json
@@ -199,6 +199,17 @@
           "values": ["valid.accept.header"]
         }
       ]
+    },
+    {
+      "method": "any",
+      "path": "/server-side-blocked",
+      "origin": "${GIT_CLIENT_URL}"
+    },
+    {
+      "method": "any",
+      "path": "/server-side-blocked-streaming",
+      "origin": "${GIT_CLIENT_URL}",
+      "stream": true
     }
   ]
 }

--- a/test/functional/client-server.test.js
+++ b/test/functional/client-server.test.js
@@ -36,7 +36,7 @@ test('proxy requests originating from behind the broker client', (t) => {
   const clientPort = port();
   const client = app.main({ port: clientPort });
 
-  t.plan(15);
+  t.plan(17);
 
   client.io.once('identify', (serverData) => {
     t.test('server identifies self to client', (t) => {
@@ -148,6 +148,24 @@ test('proxy requests originating from behind the broker client', (t) => {
       // the filtering happens in the broker client
       t.test('block request for valid url with missing query param', (t) => {
         const url = `http://localhost:${clientPort}/echo-query/filtered`;
+        request({ url, method: 'get' }, (err, res) => {
+          t.equal(res.statusCode, 401, '401 statusCode');
+          t.end();
+        });
+      });
+
+      // the filtering happens in the broker server
+      t.test('block request for valid URL which is not allowed on server', (t) => {
+        const url = `http://localhost:${clientPort}/server-side-blocked`;
+        request({ url, method: 'get' }, (err, res) => {
+          t.equal(res.statusCode, 401, '401 statusCode');
+          t.end();
+        });
+      });
+
+      // the filtering happens in the broker server - this indicates a very badly misconfigured client
+      t.test('block request for valid URL which is not allowed on server with streaming response', (t) => {
+        const url = `http://localhost:${clientPort}/server-side-blocked-streaming`;
         request({ url, method: 'get' }, (err, res) => {
           t.equal(res.statusCode, 401, '401 statusCode');
           t.end();


### PR DESCRIPTION
Streaming requests received from the Client were not being handled correctly (the server was attempting to POST the response to the client), which was causing the Server to crash. In general, this seems like a configuration error on the Client side, but it is happening in production so needed to be fixed.

This has been fixed and responses will be correctly sent to the Client.

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules
