### PR TITLE
fix: correct triggering mechanism for iac and code rule injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ docker run --restart=always \
        snyk/broker:github-com
 ```
 
-You can otherwise edit your `accept.json`, add the relevant IaC specific rules and load the customized accept file into the container. Note that if a custom accept file is used (using ACCEPT environment variable), the ACCEPT_IAC mechanism is then disabled.
+You can otherwise edit your `accept.json`, add the relevant IaC specific rules and load the customized accept file into the container. Note that if a custom accept file (from a separate folder) is used (using ACCEPT environment variable), the ACCEPT_IAC mechanism cannot be used.
 
 For example, if you are using GitHub and you would like to give the Broker access to your Terraform files, you should add the following rules to your `accept.json`:
 
@@ -527,6 +527,7 @@ docker run --restart=always \
            -e ACCEPT_CODE=true
        snyk/broker:github-com
 ```
+Note that if a custom accept file (from a separate folder) is used (using ACCEPT environment variable), the ACCEPT_CODE mechanism cannot be used.
 
 #### Changing the Auth Method
 

--- a/lib/filter-rules-loading.js
+++ b/lib/filter-rules-loading.js
@@ -130,7 +130,7 @@ module.exports = (acceptFilename = '', folderLocation = '') => {
 
   // If user brings an accept json, skip the IAC|CODE rules injection logic
   // If going through the effort of loading a separate file, add your rules there
-  if (!process.env.ACCEPT) {
+  if (process.env.ACCEPT == 'accept.json') {
     filters = injectRulesAtRuntime(filters);
   } else {
     logger.info(
@@ -138,6 +138,5 @@ module.exports = (acceptFilename = '', folderLocation = '') => {
       'Custom accept json, skipping filter rule injection',
     );
   }
-
   return filters;
 };

--- a/test/unit/runtime-rules-hotloading.test.ts
+++ b/test/unit/runtime-rules-hotloading.test.ts
@@ -13,12 +13,14 @@ describe('filter Rules Loading', () => {
   test.each(scmRulesToTest)(
     'Loads normal accept file - Testing %s',
     (folder) => {
+      process.env.ACCEPT='accept.json'
       const loadedRules = loadFilterRules(
         'accept.json.sample',
         path.join(__dirname, '../..', `client-templates/${folder}`),
       );
 
       expect(loadedRules).toMatchSnapshot();
+      delete process.env.ACCEPT
     },
   );
 
@@ -26,6 +28,7 @@ describe('filter Rules Loading', () => {
     'Skip injection if no or invalid IAC extensions - Testing %s',
     (folder) => {
       process.env.ACCEPT_IAC = 'rf';
+      process.env.ACCEPT='accept.json'
       const loadedRules = loadFilterRules(
         'accept.json.sample',
         path.join(__dirname, '../..', `client-templates/${folder}`),
@@ -33,6 +36,7 @@ describe('filter Rules Loading', () => {
 
       expect(loadedRules).toMatchSnapshot();
       delete process.env.ACCEPT_IAC;
+      delete process.env.ACCEPT
     },
   );
 
@@ -40,6 +44,7 @@ describe('filter Rules Loading', () => {
     'Injection of valid IAC extensions - Testing %s',
     (folder) => {
       process.env.ACCEPT_IAC = 'tf,yaml, json,yml,tpl';
+      process.env.ACCEPT='accept.json'
       const loadedRules = loadFilterRules(
         'accept.json.sample',
         path.join(__dirname, '../..', `client-templates/${folder}`),
@@ -47,6 +52,7 @@ describe('filter Rules Loading', () => {
 
       expect(loadedRules).toMatchSnapshot();
       delete process.env.ACCEPT_IAC;
+      delete process.env.ACCEPT
     },
   );
 
@@ -54,6 +60,7 @@ describe('filter Rules Loading', () => {
     'Injection of valid IAC extensions - Testing %s',
     (folder) => {
       process.env.ACCEPT_IAC = 'tf,json';
+      process.env.ACCEPT='accept.json'
       const loadedRules = loadFilterRules(
         'accept.json.sample',
         path.join(__dirname, '../..', `client-templates/${folder}`),
@@ -61,6 +68,7 @@ describe('filter Rules Loading', () => {
 
       expect(loadedRules).toMatchSnapshot();
       delete process.env.ACCEPT_IAC;
+      delete process.env.ACCEPT
     },
   );
 
@@ -68,6 +76,7 @@ describe('filter Rules Loading', () => {
     'Injection of valid CODE rules - Testing %s',
     (folder) => {
       process.env.ACCEPT_CODE = 'true';
+      process.env.ACCEPT='accept.json'
       const loadedRules = loadFilterRules(
         'accept.json.sample',
         path.join(__dirname, '../..', `client-templates/${folder}`),
@@ -75,6 +84,7 @@ describe('filter Rules Loading', () => {
 
       expect(loadedRules).toMatchSnapshot();
       delete process.env.ACCEPT_CODE;
+      delete process.env.ACCEPT
     },
   );
 
@@ -83,6 +93,7 @@ describe('filter Rules Loading', () => {
     (folder) => {
       process.env.ACCEPT_CODE = 'true';
       process.env.ACCEPT_IAC = 'yaml';
+      process.env.ACCEPT='accept.json'
       const loadedRules = loadFilterRules(
         'accept.json.sample',
         path.join(__dirname, '../..', `client-templates/${folder}`),
@@ -91,6 +102,7 @@ describe('filter Rules Loading', () => {
       expect(loadedRules).toMatchSnapshot();
       delete process.env.ACCEPT_CODE;
       delete process.env.ACCEPT_IAC;
+      delete process.env.ACCEPT
     },
   );
 });


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Fixes the trigger mechanism for ACCEPT_IAC and ACCEPT_CODE rule injection to actually run.
ACCEPT env var is used all the time, so custom accept files are loaded if not pointing to the default accept.json. Using this value as baseline to detect custom accept json file loading, and skipping rule injection in this case only.

