### PR TITLE
Add environment variable to strip all X-Forwarded-* headers

### DIFF
--- a/lib/relay.js
+++ b/lib/relay.js
@@ -491,6 +491,18 @@ function forwardWebSocketRequest(filterRules, config, io) {
           'content-encoding',
         ].map((_) => delete headers[_]);
 
+        if (config.removeXForwardedHeaders === 'true') {
+          for (let key in headers) {
+            if (key.startsWith('x-forwarded-')) {
+              delete headers[key];
+            }
+          }
+
+          if (headers['forwarded']) {
+            delete headers['forwarded'];
+          }
+        }
+
         if (brokerToken && io?.socketType === 'server') {
           Object.assign(headers, { 'X-Broker-Token': brokerToken });
         }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "tmp-promise": "^3.0.2",
     "ts-jest": "^26.1.3",
     "tsc-watch": "^4.2.3",
-    "typescript": "^3.8.3"
+    "typescript": "^4.9.3"
   },
   "dependencies": {
     "@types/minimist": "^1.2.0",

--- a/test/functional/server-client.test.js
+++ b/test/functional/server-client.test.js
@@ -243,6 +243,7 @@ test('proxy requests originating from behind the broker server', (t) => {
             'x-forwarded-proto': 'https',
             'x-forwarded-for': '127.0.0.1',
             'x-forwarded-port': '8080',
+            'X-Forwarded-Port': '8080',
             'x-forwarded-host': 'banana',
             'forwarded': 'by=broker;for=127.0.0.1;host=banana;port=8080;proto=https',
           } }, (err, res) => {
@@ -251,27 +252,32 @@ test('proxy requests originating from behind the broker server', (t) => {
             t.equal(
               responseBody['x-forwarded-proto'],
               undefined,
-              'x-forwarded-proto header included',
+              'x-forwarded-proto header not included',
             );
             t.equal(
               responseBody['x-forwarded-for'],
               undefined,
-              'x-forwarded-for header included',
+              'x-forwarded-for header not included',
             );
             t.equal(
               responseBody['x-forwarded-port'],
               undefined,
-              'x-forwarded-port header included',
+              'x-forwarded-port header not included',
+            );
+            t.equal(
+              responseBody['X-Forwarded-Port'],
+              undefined,
+              'X-Forwarded-Port header not included',
             );
             t.equal(
               responseBody['x-forwarded-host'],
               undefined,
-              'x-forwarded-host header included',
+              'x-forwarded-host header not included',
             );
             t.equal(
               responseBody['forwarded'],
               undefined,
-              'forwarded header included',
+              'forwarded header not included',
             );
             t.end();
           });

--- a/test/unit/relay-response-body.test.ts
+++ b/test/unit/relay-response-body.test.ts
@@ -39,6 +39,7 @@ describe('body relay', () => {
       {
         url: '/',
         method: 'POST',
+        // @ts-ignore
         body: Buffer.from(JSON.stringify(body)),
         headers: {},
       },


### PR DESCRIPTION
As some backend systems (e.g., Nexus) use these headers in unexpected ways, it is safer for us to strip out any header starting with X-Forwarded-, along with the Forwarded header.

Configurable via the REMOVE_X_FORWARDED_HEADERS, so it can be turned off if there are any unexpected issues.

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules
