### PR TITLE
fix: update code snippet filter path to work again on gh

### DIFF
--- a/lib/filter-rules-loading.js
+++ b/lib/filter-rules-loading.js
@@ -144,7 +144,7 @@ function injectRulesAtRuntime(filters) {
         break;
       case 'GITHUB':
         templateGET.path = '*/info/refs*';
-        templateGETForSnippets.path = '/repos/:name/:repo/contents/:path';
+        templateGETForSnippets.path = '/repos/:name/:repo/contents/:path*';
         templatePOST.path = '*/git-upload-pack';
         break;
       case 'GITLAB':

--- a/test/fixtures/accept/github-with-snippets.json
+++ b/test/fixtures/accept/github-with-snippets.json
@@ -1,0 +1,37 @@
+{
+  "//": "Cut down example accept.json for GitHub to test filter logic",
+  "public": [],
+  "private":
+  [
+    {
+      "//": "used to determine the full dependency tree",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/package.json",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "used to whitelist a folder",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*/docs/*",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "get the details of the commit to determine its SHA",
+      "method": "GET",
+      "path": "/repos/:name/:repo/commits/:ref",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}",
+      "valid": [
+        {
+          "header": "accept",
+          "values": ["application/vnd.github.v4.sha"]
+        }
+      ]
+    },
+    {
+      "//": "needed to load code snippets",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    }
+  ]
+}

--- a/test/unit/__snapshots__/runtime-rules-hotloading.test.ts.snap
+++ b/test/unit/__snapshots__/runtime-rules-hotloading.test.ts.snap
@@ -3187,7 +3187,7 @@ Object {
       "//": "needed to load code snippets",
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
-      "path": "/repos/:name/:repo/contents/:path",
+      "path": "/repos/:name/:repo/contents/:path*",
     },
   ],
   "public": Array [
@@ -4536,7 +4536,7 @@ Object {
       "//": "needed to load code snippets",
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
-      "path": "/repos/:name/:repo/contents/:path",
+      "path": "/repos/:name/:repo/contents/:path*",
     },
   ],
   "public": Array [
@@ -9517,7 +9517,7 @@ Object {
       "//": "needed to load code snippets",
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
-      "path": "/repos/:name/:repo/contents/:path",
+      "path": "/repos/:name/:repo/contents/:path*",
     },
   ],
   "public": Array [
@@ -10878,7 +10878,7 @@ Object {
       "//": "needed to load code snippets",
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
-      "path": "/repos/:name/:repo/contents/:path",
+      "path": "/repos/:name/:repo/contents/:path*",
     },
   ],
   "public": Array [

--- a/test/unit/filters.test.ts
+++ b/test/unit/filters.test.ts
@@ -653,7 +653,9 @@ describe('filters', () => {
   });
 
   describe('for GitHub', () => {
-    const rules = JSON.parse(loadFixture(path.join('accept', 'github.json')));
+    const rules = JSON.parse(
+      loadFixture(path.join('accept', 'github-with-snippets.json')),
+    );
     const filter = Filters(rules.private);
 
     it('should allow the sha media type header when requesting a branch SHA to prevent patch information being returned', (done) => {
@@ -687,6 +689,22 @@ describe('filters', () => {
         (error, res) => {
           expect(error.message).toEqual('blocked');
           expect(res).toBeUndefined();
+          done();
+        },
+      );
+    });
+
+    it('should allow code snippets', (done) => {
+      const url =
+        '/repos/aarlaud-playground/python-flask-sample-app/contents/minitwit/minitwit.py?ref=ba1cd682e5a2ffaebcada391d13f423b9279b247';
+      filter(
+        {
+          url,
+          method: 'GET',
+        },
+        (error, res) => {
+          expect(error).toBeNull();
+          expect(res.url).toMatch(url);
           done();
         },
       );


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adjust the snippet path rules for gh to work again.