### PR TITLE
fix: enhance accept rule for GH code snippets

### DIFF
--- a/lib/filter-rules-loading.js
+++ b/lib/filter-rules-loading.js
@@ -144,7 +144,7 @@ function injectRulesAtRuntime(filters) {
         break;
       case 'GITHUB':
         templateGET.path = '*/info/refs*';
-        templateGETForSnippets.path = '/repos/:name/:repo/contents/:path';
+        templateGETForSnippets.path = '/repos/:name/:repo/contents/:path*';
         templatePOST.path = '*/git-upload-pack';
         break;
       case 'GITLAB':

--- a/lib/filter-rules-loading.js
+++ b/lib/filter-rules-loading.js
@@ -43,7 +43,7 @@ function injectRulesAtRuntime(filters) {
       let template = nestedCopy(
         filters.private.filter(
           (entry) =>
-            entry.method == 'GET' &&
+            entry.method === 'GET' &&
             entry.path.includes('requirements') &&
             IAC_SCM_ORIGINS.filter((origin) =>
               entry.origin.includes(`{${origin}}`),
@@ -75,7 +75,7 @@ function injectRulesAtRuntime(filters) {
       // Copying and modifying in place in array, not doing NestedCopy here
       let templateToModify = filters.private.filter(
         (entry) =>
-          entry.method == 'GET' &&
+          entry.method === 'GET' &&
           entry.valid &&
           entry.valid[0].values.includes('**/requirements/*.txt'),
       );
@@ -100,7 +100,7 @@ function injectRulesAtRuntime(filters) {
     let templateGET = nestedCopy(
       filters.private.filter(
         (entry) =>
-          entry.method == 'GET' &&
+          entry.method === 'GET' &&
           CODE_SCM_ORIGINS.filter((origin) =>
             entry.origin.includes(`{${origin}}`),
           ).length > 0,
@@ -127,7 +127,7 @@ function injectRulesAtRuntime(filters) {
     let templateGETForSnippets = nestedCopy(
       filters.private.filter(
         (entry) =>
-          entry.method == 'GET' &&
+          entry.method === 'GET' &&
           SNIPPETS_CODE_SCM_ORIGINS.filter((origin) =>
             entry.origin.includes(`{${origin}}`),
           ).length > 0,
@@ -186,7 +186,7 @@ module.exports = (acceptFilename = '', folderLocation = '') => {
 
   // If user brings an accept json, skip the IAC|CODE rules injection logic
   // If going through the effort of loading a separate file, add your rules there
-  if (process.env.ACCEPT == 'accept.json') {
+  if (process.env.ACCEPT === 'accept.json') {
     filters = injectRulesAtRuntime(filters);
   } else {
     logger.info(

--- a/test/fixtures/accept/github.json
+++ b/test/fixtures/accept/github.json
@@ -26,6 +26,12 @@
           "values": ["application/vnd.github.v4.sha"]
         }
       ]
+    },
+    {
+      "//": "needed to load code snippets",
+      "method": "GET",
+      "path": "/repos/:name/:repo/contents/:path*",
+      "origin": "https://pat:${GITHUB_TOKEN}@${GITHUB_API}"
     }
   ]
 }

--- a/test/unit/__snapshots__/runtime-rules-hotloading.test.ts.snap
+++ b/test/unit/__snapshots__/runtime-rules-hotloading.test.ts.snap
@@ -3187,7 +3187,7 @@ Object {
       "//": "needed to load code snippets",
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
-      "path": "/repos/:name/:repo/contents/:path",
+      "path": "/repos/:name/:repo/contents/:path*",
     },
   ],
   "public": Array [
@@ -4536,7 +4536,7 @@ Object {
       "//": "needed to load code snippets",
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
-      "path": "/repos/:name/:repo/contents/:path",
+      "path": "/repos/:name/:repo/contents/:path*",
     },
   ],
   "public": Array [
@@ -9517,7 +9517,7 @@ Object {
       "//": "needed to load code snippets",
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
-      "path": "/repos/:name/:repo/contents/:path",
+      "path": "/repos/:name/:repo/contents/:path*",
     },
   ],
   "public": Array [
@@ -10878,7 +10878,7 @@ Object {
       "//": "needed to load code snippets",
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
-      "path": "/repos/:name/:repo/contents/:path",
+      "path": "/repos/:name/:repo/contents/:path*",
     },
   ],
   "public": Array [

--- a/test/unit/filters.test.ts
+++ b/test/unit/filters.test.ts
@@ -7,9 +7,7 @@ const jsonBuffer = (body) => Buffer.from(JSON.stringify(body));
 
 function loadFixture(name: string) {
   const fixturePath = path.join(__dirname, '..', 'fixtures', name);
-  const fixture = readFileSync(fixturePath, { encoding: 'utf-8' });
-
-  return fixture;
+  return readFileSync(fixturePath, { encoding: 'utf-8' });
 }
 
 describe('filters', () => {
@@ -33,15 +31,15 @@ describe('filters', () => {
         );
       });
 
-      it('should block when manifest appears after fragment identifier', () => {
+      it('should remove any fragments identifier', () => {
         filter(
           {
             url: '/repos/angular/angular/contents/test-main.js#/package.json',
             method: 'GET',
           },
           (error, res) => {
-            expect(error.message).toEqual('blocked');
-            expect(res).toBeUndefined();
+            expect(error).toBeNull();
+            expect(res.url).not.toContain('#');
           },
         );
       });
@@ -688,6 +686,38 @@ describe('filters', () => {
           expect(error.message).toEqual('blocked');
           expect(res).toBeUndefined();
           done();
+        },
+      );
+    });
+
+    it('should allow the get file in the root directory for code snippets', async () => {
+      const url =
+        '/repos/owner/repo-name/contents/main.js?ref=e5d896304278f15be39e5b13ab7f0f2add9f8e3e';
+
+      filter(
+        {
+          url,
+          method: 'GET',
+        },
+        (error, res) => {
+          expect(error).toBeNull();
+          expect(res.url).toMatch(url);
+        },
+      );
+    });
+
+    it('should allow the get file in the nested directory for code snippets', async () => {
+      const url =
+        '/repos/owner/repo-name/contents/nested-folder/main.js?ref=e5d896304278f15be39e5b13ab7f0f2add9f8e3e';
+
+      filter(
+        {
+          url,
+          method: 'GET',
+        },
+        (error, res) => {
+          expect(error).toBeNull();
+          expect(res.url).toMatch(url);
         },
       );
     });


### PR DESCRIPTION
This PR fixes issue with blocking request for code snippets in GitHub.

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR fixes the issue with preview of code snippets and allow to list files in the root of repository and in the nested folders.

The current rule for GitHub code snippets doesn't contain `*` so the regex will work for files in the root only.

`/repos/:name/:repo/contents/:path` -> `/repos/:name/:repo/contents/:path*`

#### Where should the reviewer start?

#### Screenshots


#### Additional questions
