### PR TITLE
fix: pin semantic release prior to v20 to keep node16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
           at: ~/broker
       - run:
           name: Release to GitHub
-          command: npx semantic-release
+          command: npx semantic-release@19.0.5
 
 workflows:
   version: 2


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Pins semantic release prior to v20 to avoid upgrading to node18 at the moment.

#### Any background context you want to provide?
[Semantic Release Release notes](https://github.com/semantic-release/semantic-release/releases/tag/v20.0.0)
