### PR TITLE
fix: add version query param correctly to the dispatcher requests

### DIFF
--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -76,8 +76,9 @@ class DispatcherClient {
 
   #makeRequest(logContext, url, method, requestBody, cb) {
     // version *must* be provided
-    url = new URL(url);
-    url.searchParams.set('version', this.#version);
+    const urlWithVersion = new URL(url);
+    urlWithVersion.searchParams.append('version', this.#version);
+    url = urlWithVersion.toString();
     let body = '';
     let statusCode = -1;
     let headers = {};


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR fixes the issue with incorrect appending `version` query param for dispatcher API calls, e.g.
```
/internal/brokerservers/1/connections/2?brokerClientId=<uuid>?version=2022-12-02~experimental
/internal/brokerservers/1/connections/2?brokerClientId=<uuid>&version=2022-12-02~experimental
```

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
