### PR TITLE
fix: change query param name for broker client id according openapi spec

### DIFF
--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -51,7 +51,7 @@ class DispatcherClient {
       { maskedToken, clientId, requestType: 'client-connected' },
       `${this.#url}/internal/brokerservers/${this.#id}/connections/${hash(
         token,
-      )}${clientId ? `?brokerClientId=${clientId}` : ''}`,
+      )}${clientId ? `?broker_client_id=${clientId}` : ''}`,
       'post',
       {
         data: {
@@ -69,7 +69,7 @@ class DispatcherClient {
       { maskedToken, clientId, requestType: 'client-disconnected' },
       `${this.#url}/internal/brokerservers/${this.#id}/connections/${hash(
         token,
-      )}${clientId ? `?brokerClientId=${clientId}` : ''}`,
+      )}${clientId ? `?broker_client_id=${clientId}` : ''}`,
       'delete',
     );
   }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
The queryparam name for brokerClientId is `broker_client_id` according OpenAPI specification. This PR fixes it.


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
