### PR TITLE
fix: store clientId to send it on close

### DIFF
--- a/lib/server/socket.js
+++ b/lib/server/socket.js
@@ -41,6 +41,7 @@ module.exports = ({ server, filters, config }) => {
   io.on('connection', function (socket) {
     logger.info('new client connection');
     let token = null;
+    let clientId = null;
 
     socket.send('identify', { capabilities: ['receive-post-streams'] });
 
@@ -66,7 +67,7 @@ module.exports = ({ server, filters, config }) => {
           connections.delete(token);
         }
         decrementSocketConnectionGauge();
-        dispatcher.clientDisconnected(token, io?.metadata?.clientId);
+        dispatcher.clientDisconnected(token, clientId);
       }
     };
 
@@ -109,8 +110,9 @@ module.exports = ({ server, filters, config }) => {
 
       socket.on('chunk', streamingResponse(token));
       socket.on('request', response(token));
-
-      dispatcher.clientConnected(token, clientData.metadata.clientId);
+      
+      clientId = clientData.metadata.clientId
+      dispatcher.clientConnected(token, clientId);
       incrementSocketConnectionGauge();
     });
 


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Store clientId upon new connection to have it available to send to dispatcher upon connection close.