### PR TITLE
fix: add server_id param to socket url

### DIFF
--- a/lib/client/socket.js
+++ b/lib/client/socket.js
@@ -14,6 +14,10 @@ function createWebSocket(token, url, config, filters, identifyingMetadata) {
     pathname: `/primus/${token}`,
   });
 
+  const urlWithServerId = new URL(url);
+  urlWithServerId.searchParams.append('server_id', serverId);
+  url = urlWithServerId.toString();
+
   // Will exponentially back-off from 0.5 seconds to a maximum of 20 minutes
   // Retry for a total period of around 4.5 hours
   const io = new Socket(url, {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR fixes the issue with missing `server_id` to Socket url.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
