### PR TITLE
fix: disable xff by default for nexus broker clients [HYB-83]

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,10 @@ ENV BROKER_CLIENT_VALIDATION_URL     https://<your.nexus.hostname>/service/rest/
 ENV RES_BODY_URL_SUB                 https://<your.nexus.hostname>/repository
 ```
 
+> Note: By default for Nexus 3, the X-Forwarded-For headers are stripped off by the broker client so Nexus returns the npm tarball uri to the nexus registry instead of the broker server.
+Include the environment variable `REMOVE_X_FORWARDED_HEADERS=false` to disable this behavior.
+
+
 ### Jira
 
 To use the Broker client with a Jira deployment, run `docker pull snyk/broker:jira` tag. The following environment variables are mandatory to configure the Broker client:

--- a/client-templates/nexus/.env.sample
+++ b/client-templates/nexus/.env.sample
@@ -31,3 +31,6 @@ BROKER_HEALTHCHECK_PATH=/healthcheck
 BROKER_CLIENT_VALIDATION_URL=$BASE_NEXUS_URL/service/rest/v1/status/check
 
 BROKER_CLIENT_VALIDATION_JSON_DISABLED=true
+
+# Disable X-Forwarded-For headers so Nexus doesn't return npm tarball uri pointing to the broker server
+REMOVE_X_FORWARDED_HEADERS=true


### PR DESCRIPTION
- [x] Ready for review

#### What does this PR do?

Disables the XFF headers for nexus broker clients by default to avoid nexus returning invalid npm tarball uris.
