### PR TITLE
fix: actually log resp body when streaming as well

### DIFF
--- a/lib/stream-posts.js
+++ b/lib/stream-posts.js
@@ -109,6 +109,7 @@ function pipeStream(
       buffer = initStream(config, brokerToken, streamingID, ioData, serverId);
     })
     .on('data', (chunk) => {
+      logResponse(logContext, 'undefined', {body: chunk.toString()}, config);
       logger.trace(`writing data of length ${chunk.length} to buffer`);
       if (config.RES_BODY_URL_SUB && isResponseJson) {
         const { newChunk, partial } = replaceUrlPartialChunk(


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adds body logging also when the response is being streamed.

#### How should this be manually tested?
Requires the same env vars (LOG_LEVEL debug and LOG_ENABLE_BODY).
