### PR TITLE
feat: add support for kubernetes api

### DIFF
--- a/bin/kubernetes/start.sh
+++ b/bin/kubernetes/start.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+DEFAULT_K8S_SERVICE_ACCOUNT_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+
+if [ -z "$CA_CERT" ] && [ -f "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" ];
+then
+  export CA_CERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+fi
+
+export K8S_SERVICE_ACCOUNT_TOKEN="${K8S_SERVICE_ACCOUNT_TOKEN:-$DEFAULT_K8S_SERVICE_ACCOUNT_TOKEN}"
+
+if [ -z "$K8S_SERVICE_ACCOUNT_TOKEN" ]
+then
+      echo "A kubernetes token must be provided, either in a file at /var/run/secrets/kubernetes.io/serviceaccount/token or in an environment variable K8S_SERVICE_ACCOUNT_TOKEN"
+      exit 1
+fi
+
+broker --verbose

--- a/client-templates/kubernetes/.env.sample
+++ b/client-templates/kubernetes/.env.sample
@@ -1,0 +1,21 @@
+# your unique broker identifier
+BROKER_TOKEN=<broker-token>
+
+# (optional) the cluster url for the kubernetes api service
+CLUSTER_ENDPOINT=https://kubernetes.default
+
+# (optional) path to the ca cert for the kubernetes api servoce
+CA_CERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+# (optional) the service account token for kubernetes api authentication
+K8S_SERVICE_ACCOUNT_TOKEN=<service account token>
+
+# The URL of the Snyk broker server
+BROKER_SERVER_URL=https://broker.snyk.io
+
+# the fine detail accept rules that allow Snyk to make API requests to your
+# kubernetes api
+ACCEPT=accept.json
+
+# The path for the broker's internal healthcheck URL. Must start with a '/'.
+BROKER_HEALTHCHECK_PATH=/healthcheck

--- a/client-templates/kubernetes/accept.json.sample
+++ b/client-templates/kubernetes/accept.json.sample
@@ -1,0 +1,136 @@
+{
+  "public": [
+    {
+      "method": "any",
+      "path": "/*"
+    }
+  ],
+  "private": [
+    {
+      "method": "GET",
+      "path": "/api/v1/pods*",
+      "origin": "${CLUSTER_ENDPOINT}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${K8S_SERVICE_ACCOUNT_TOKEN}"
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/apis/networking.k8s.io/v1/ingresses*",
+      "origin": "${CLUSTER_ENDPOINT}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${K8S_SERVICE_ACCOUNT_TOKEN}"
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/apis/networking.k8s.io/v1/namespaces*",
+      "origin": "${CLUSTER_ENDPOINT}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${K8S_SERVICE_ACCOUNT_TOKEN}"
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/apis/apps/v1/replicasets*",
+      "origin": "${CLUSTER_ENDPOINT}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${K8S_SERVICE_ACCOUNT_TOKEN}"
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/apis/apps/v1/namespaces*",
+      "origin": "${CLUSTER_ENDPOINT}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${K8S_SERVICE_ACCOUNT_TOKEN}"
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/apis/batch/v1/namespaces*",
+      "origin": "${CLUSTER_ENDPOINT}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${K8S_SERVICE_ACCOUNT_TOKEN}"
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/api/v1/namespaces*",
+      "origin": "${CLUSTER_ENDPOINT}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${K8S_SERVICE_ACCOUNT_TOKEN}"
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/api/v1/services*",
+      "origin": "${CLUSTER_ENDPOINT}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${K8S_SERVICE_ACCOUNT_TOKEN}"
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/apis/apps/v1/deployments*",
+      "origin": "${CLUSTER_ENDPOINT}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${K8S_SERVICE_ACCOUNT_TOKEN}"
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/api/v1/configmaps*",
+      "origin": "${CLUSTER_ENDPOINT}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${K8S_SERVICE_ACCOUNT_TOKEN}"
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/apis/autoscaling/v1/horizontalpodautoscalers*",
+      "origin": "${CLUSTER_ENDPOINT}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${K8S_SERVICE_ACCOUNT_TOKEN}"
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/apis/autoscaling/v1/namespaces*",
+      "origin": "${CLUSTER_ENDPOINT}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${K8S_SERVICE_ACCOUNT_TOKEN}"
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/apis/metrics.k8s.io/v1beta1/namespaces/*",
+      "origin": "${CLUSTER_ENDPOINT}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${K8S_SERVICE_ACCOUNT_TOKEN}"
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/api/v1/namespaces/*",
+      "origin": "${CLUSTER_ENDPOINT}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${K8S_SERVICE_ACCOUNT_TOKEN}"
+      }
+    }
+  ]
+}

--- a/dockerfiles/kubernetes/Dockerfile
+++ b/dockerfiles/kubernetes/Dockerfile
@@ -1,0 +1,38 @@
+FROM snyk/ubuntu as base
+
+MAINTAINER Snyk Ltd
+
+USER root
+
+RUN apt update && apt install -y make python gcc
+RUN apt-get update && apt-get install -y ca-certificates
+
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+RUN npm install --global snyk-broker
+
+
+FROM snyk/ubuntu
+
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+COPY --from=base /home/node/.npm-global /home/node/.npm-global
+
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Don't run as root
+WORKDIR /home/node
+USER node
+
+# Generate default accept filter
+# RUN broker init kubernetes
+COPY ./client-templates/kubernetes/accept.json.sample /home/node/accept.json
+ENV ACCEPT=/home/node/accept.json
+
+COPY  ./bin/kubernetes/start.sh /home/node/start.sh
+ENV CLUSTER_ENDPOINT=https://kubernetes.default
+
+EXPOSE $PORT
+CMD ["/home/node/start.sh"]
+


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR adds support for kubernetes api as a broker client.

- it creates a dockerfile for the broker client
- it creates example configuration
- everything defaults to work in a kube environment to use the pods service account token.

#### Where should the reviewer start?

You will need access to the api of a kubernetes cluster and a service account token for that api.

Test 1:
Create the docker container. Then run it locally with the environment variables to run it against a kubernetes api "CLUSTER_URL" and "K8S_SERVICE_ACCOUNT_TOKEN". You may need to also mount a ca file with the correct authority for the cluster. Then confirm that the api service is accessable via the client.

Test 2:
Deploy the container to a kubernetes pod with the default settings. Assign the pod a service account and permissions to access the kube api. Then confirm that the api service is accessable via the client.

#### How should this be manually tested?

```
docker build . -f dockerfiles/kubernetes/Dockerfile -t snyk/broker:kubernetes
```

Running against an external kubernetes api:

```
docker run --restart=always \
           -p 8000:8000 \
           -e BROKER_TOKEN=kube-api \
           -e BROKER_SERVER_URL=https://my.broker.server \
           -e CLUSTER_URL=https://kubernetes.api.somewhere \
           -e K8S_SERVICE_ACCOUNT_TOKEN=service-account-token \
       snyk/broker:kubernetes
```

Running in a kubernetes pod:

```
docker run --restart=always \
           -p 8000:8000 \
           -e BROKER_TOKEN=kube-api \
           -e BROKER_SERVER_URL=http://my.broker.server \
       snyk/broker:kubernetes
```

#### Any background context you want to provide?


#### Screenshots


#### Additional questions
