### PR TITLE
fix: pass serverId to the client socket

### DIFF
--- a/lib/client/socket.js
+++ b/lib/client/socket.js
@@ -21,6 +21,10 @@ function createWebSocket(
     pathname: `/primus/${token}`,
   });
 
+  const urlWithServerId = new URL(url);
+  urlWithServerId.searchParams.append('server_id', serverId);
+  url = urlWithServerId.toString();
+
   // Will exponentially back-off from 0.5 seconds to a maximum of 20 minutes
   // Retry for a total period of around 4.5 hours
   const io = new Socket(url, {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This is the cherry-pick from 924d59c7321b29d548fcf07eec129a9a4e53fe6f (excluding package.json changes with version).

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
