### PR TITLE
fix: add server_id param only if serverId not empty

### DIFF
--- a/lib/client/socket.js
+++ b/lib/client/socket.js
@@ -21,9 +21,11 @@ function createWebSocket(
     pathname: `/primus/${token}`,
   });
 
-  const urlWithServerId = new URL(url);
-  urlWithServerId.searchParams.append('server_id', serverId);
-  url = urlWithServerId.toString();
+  if (serverId) {
+    const urlWithServerId = new URL(url);
+    urlWithServerId.searchParams.append('server_id', serverId);
+    url = urlWithServerId.toString();
+  }
 
   // Will exponentially back-off from 0.5 seconds to a maximum of 20 minutes
   // Retry for a total period of around 4.5 hours


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
In case that HA mode is not enabled, we don't add `server_id` query param to socket url.

#### Where should the reviewer start?


#### How should this be manually tested?
Running Broker client without HA mode should log url without `server_id` query param, e.g.
```
...
broker client is connecting to broker server (url=https://broker.dev.snyk.io, serverId="")
...
```


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
