### PR TITLE
chore: distinct dockerfiles for latest node versions

### DIFF
--- a/dockerfiles/artifactory/Dockerfile.nlatest
+++ b/dockerfiles/artifactory/Dockerfile.nlatest
@@ -1,0 +1,63 @@
+FROM snyk/ubuntu:nlatest as base
+
+MAINTAINER Snyk Ltd
+
+USER root
+
+RUN apt-get update && apt-get install -y ca-certificates
+
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+RUN npm install --global snyk-broker
+
+
+
+FROM snyk/ubuntu:nlatest as base
+
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+COPY --from=base /home/node/.npm-global /home/node/.npm-global
+
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Don't run as root
+WORKDIR /home/node
+USER node
+
+# Generate default accept filter
+RUN broker init artifactory
+# Support for OpenShift - have to run after init to get accept.json and .env
+USER root
+RUN chgrp -R 0 /home/node && chmod -R g=u,o= /home/node && chown -R node /home/node
+USER node
+
+######################################
+# Custom Broker Client configuration #
+# Redefine in derived Dockerfile,    #
+# or provide as runtime args `-e`    #
+######################################
+
+# Your unique Broker identifier
+# ENV BROKER_TOKEN <broker-token>
+
+# Your Artifactory URL to artifactory
+# NOTA BENE: without `/` character in the end of URL
+# ENV ARTIFACTORY_URL <yourdomain>.artifactory.com/artifactory
+
+# Provide RES_BODY_URL_SUB with the URL of the artifactory without credentials and http protocol
+# This URL substitution is required for NPM integration
+# ENV RES_BODY_URL_SUB=http://<yourdomain>.artifactory.com/artifactory
+
+# The port used by the broker client to accept internal connections
+# Default value is 7341
+# ENV PORT 7341
+
+# The URL of your broker client (including scheme and port)
+# This will be used as the webhook payload URL coming in from Jira
+# ENV BROKER_CLIENT_URL http://<broker.client.hostname>:$PORT
+
+EXPOSE $PORT
+
+CMD ["broker", "--verbose"]

--- a/dockerfiles/azure-repos/Dockerfile.nlatest
+++ b/dockerfiles/azure-repos/Dockerfile.nlatest
@@ -1,0 +1,63 @@
+FROM snyk/ubuntu:nlatest as base
+
+MAINTAINER Snyk Ltd
+
+USER root
+
+RUN apt-get update && apt-get install -y ca-certificates
+
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+RUN npm install --global snyk-broker
+
+
+
+FROM snyk/ubuntu:nlatest as base
+
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+COPY --from=base /home/node/.npm-global /home/node/.npm-global
+
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Don't run as root
+WORKDIR /home/node
+USER node
+
+# Generate default accept filter
+RUN broker init azure-repos
+# Support for OpenShift - have to run after init to get accept.json and .env
+USER root
+RUN chgrp -R 0 /home/node && chmod -R g=u,o= /home/node && chown -R node /home/node
+USER node
+
+######################################
+# Custom Broker Client configuration #
+# Redefine in derived Dockerfile,    #
+# or provide as runtime args `-e`    #
+######################################
+
+# https://dev.azure.com/{azure-repos-org}
+# ENV AZURE_REPOS_ORG <azure-repos-org>
+# Guide how to get/create the token https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=preview-page
+# Scopes: Ensure Custom defined is selected and under Code select Read & write
+# ENV AZURE_REPOS_TOKEN <azure-repos-token>
+# NOTA BENE: without `/` character in the end of URL
+# ENV AZURE_REPOS_HOST dev.azure.com
+
+# Your unique Broker identifier
+# ENV BROKER_TOKEN <broker-token>
+
+# The port used by the broker client to accept internal connections
+# Default value is 7341
+# ENV PORT 7341
+
+# The URL of your broker client (including scheme and port)
+# This will be used as the webhook payload URL
+# ENV BROKER_CLIENT_URL "https://<broker.client.hostname>:$PORT"
+
+EXPOSE $PORT
+
+CMD ["broker", "--verbose"]

--- a/dockerfiles/bitbucket-server/Dockerfile.nlatest
+++ b/dockerfiles/bitbucket-server/Dockerfile.nlatest
@@ -1,0 +1,68 @@
+FROM snyk/ubuntu:nlatest as base
+
+MAINTAINER Snyk Ltd
+
+USER root
+
+RUN apt-get update && apt-get install -y ca-certificates
+
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+RUN npm install --global snyk-broker
+
+
+
+FROM snyk/ubuntu:nlatest as base
+
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+COPY --from=base /home/node/.npm-global /home/node/.npm-global
+
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Don't run as root
+WORKDIR /home/node
+USER node
+
+# Generate default accept filter
+RUN broker init bitbucket-server
+# Support for OpenShift - have to run after init to get accept.json and .env
+USER root
+RUN chgrp -R 0 /home/node && chmod -R g=u,o= /home/node && chown -R node /home/node
+USER node
+
+######################################
+# Custom Broker Client configuration #
+# Redefine in derived Dockerfile,    #
+# or provide as runtime args `-e`    #
+######################################
+
+# Your unique broker identifier
+# ENV BROKER_TOKEN <broker-token>
+
+# Your personal username to your bitbucket server account
+# ENV BITBUCKET_USERNAME <username>
+
+# Your personal password to your bitbucket server account
+# ENV BITBUCKET_PASSWORD <password>
+
+# Your Bitbucket Server host, excluding scheme
+# ENV BITBUCKET your.bitbucket.server.hostname
+
+# The Bitbucket server API URL
+# ENV BITBUCKET_API $BITBUCKET/rest/api/1.0
+
+# The port used by the broker client to accept internal connections
+# Default value is 7341
+# ENV PORT 7341
+
+# The URL of your broker client (including scheme and port)
+# This will be used as the webhook payload URL coming in from
+# your Bitbucket Server.
+# ENV BROKER_CLIENT_URL http://<broker.client.hostname>:$PORT
+
+EXPOSE $PORT
+
+CMD ["broker", "--verbose"]

--- a/dockerfiles/github-com/Dockerfile.nlatest
+++ b/dockerfiles/github-com/Dockerfile.nlatest
@@ -1,0 +1,58 @@
+FROM snyk/ubuntu:nlatest as base
+
+MAINTAINER Snyk Ltd
+
+USER root
+
+RUN apt-get update && apt-get install -y ca-certificates
+
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+RUN npm install --global snyk-broker
+
+
+
+FROM snyk/ubuntu:nlatest as base
+
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+COPY --from=base /home/node/.npm-global /home/node/.npm-global
+
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Don't run as root
+WORKDIR /home/node
+USER node
+
+# Generate default accept filter
+RUN broker init github-com
+# Support for OpenShift - have to run after init to get accept.json and .env
+USER root
+RUN chgrp -R 0 /home/node && chmod -R g=u,o= /home/node && chown -R node /home/node
+USER node
+
+######################################
+# Custom Broker Client configuration #
+# Redefine in derived Dockerfile,    #
+# or provide as runtime args `-e`    #
+######################################
+
+# Your unique broker identifier, copied from snyk.io org settings page
+# ENV BROKER_TOKEN <broker-token>
+
+# Your personal access token to your github.com / GHE account
+# ENV GITHUB_TOKEN <github-token>
+
+# The port used by the broker client to accept webhooks
+# Default value is 7341
+# ENV PORT 7341
+
+# The URL of your broker client (including scheme and port)
+# This will be used as the webhook payload URL coming in from GitHub
+# ENV BROKER_CLIENT_URL http://<broker.client.hostname>:$PORT
+
+EXPOSE $PORT
+
+CMD ["broker", "--verbose"]

--- a/dockerfiles/github-enterprise/Dockerfile.nlatest
+++ b/dockerfiles/github-enterprise/Dockerfile.nlatest
@@ -1,0 +1,67 @@
+FROM snyk/ubuntu:nlatest as base
+
+MAINTAINER Snyk Ltd
+
+USER root
+
+RUN apt-get update && apt-get install -y ca-certificates
+
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+RUN npm install --global snyk-broker
+
+
+
+FROM snyk/ubuntu:nlatest as base
+
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+COPY --from=base /home/node/.npm-global /home/node/.npm-global
+
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Don't run as root
+WORKDIR /home/node
+USER node
+
+# Generate default accept filter
+RUN broker init github-enterprise
+# Support for OpenShift - have to run after init to get accept.json and .env
+USER root
+RUN chgrp -R 0 /home/node && chmod -R g=u,o= /home/node && chown -R node /home/node
+USER node
+
+######################################
+# Custom Broker Client configuration #
+# Redefine in derived Dockerfile,    #
+# or provide as runtime args `-e`    #
+######################################
+
+# Your unique broker identifier, copied from snyk.io org settings page
+# ENV BROKER_TOKEN <broker-token>
+
+# Your personal access token to your github.com / GHE account
+# ENV GITHUB_TOKEN <github-token>
+
+# The host where your GitHub Enterprise is running, excluding scheme.
+# ENV GITHUB=your.ghe.domain.com
+
+# Github API endpoint, excluding scheme.
+# ENV GITHUB_API your.ghe.domain.com/api/v3
+
+# Github GraphQL API endpoint, excluding scheme.
+# ENV GITHUB_GRAPHQL your.ghe.domain.com/api
+
+# The port used by the broker client to accept webhooks
+# Default value is 7341
+# ENV PORT 7341
+
+# The URL of your broker client (including scheme and port)
+# This will be used as the webhook payload URL coming in from GitHub
+# ENV BROKER_CLIENT_URL http://<broker.client.hostname>:$PORT
+
+EXPOSE $PORT
+
+CMD ["broker", "--verbose"]

--- a/dockerfiles/gitlab/Dockerfile.nlatest
+++ b/dockerfiles/gitlab/Dockerfile.nlatest
@@ -1,0 +1,61 @@
+FROM snyk/ubuntu:nlatest as base
+
+MAINTAINER Snyk Ltd
+
+USER root
+
+RUN apt-get update && apt-get install -y ca-certificates
+
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+RUN npm install --global snyk-broker
+
+
+
+FROM snyk/ubuntu:nlatest as base
+
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+COPY --from=base /home/node/.npm-global /home/node/.npm-global
+
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Don't run as root
+WORKDIR /home/node
+USER node
+
+# Generate default accept filter
+RUN broker init gitlab
+# Support for OpenShift - have to run after init to get accept.json and .env
+USER root
+RUN chgrp -R 0 /home/node && chmod -R g=u,o= /home/node && chown -R node /home/node
+USER node
+
+######################################
+# Custom Broker Client configuration #
+# Redefine in derived Dockerfile,    #
+# or provide as runtime args `-e`    #
+######################################
+
+# Your unique broker identifier
+# ENV BROKER_TOKEN <broker-token>
+
+# your personal token to your Gitlab server account
+# ENV GITLAB_TOKEN <gitlab-token>
+
+# The Gitlab server API URL
+# ENV GITLAB your.gitlab.server.hostname
+
+# The port used by the broker client to accept internal connections
+# Default value is 7341
+# ENV PORT 7341
+
+# The URL of your broker client (including scheme and port)
+# This will be used as the webhook payload URL coming in from Gitlab
+# ENV BROKER_CLIENT_URL http://<broker.client.hostname>:$PORT
+
+EXPOSE $PORT
+
+CMD ["broker", "--verbose"]

--- a/dockerfiles/jira/Dockerfile.nlatest
+++ b/dockerfiles/jira/Dockerfile.nlatest
@@ -1,0 +1,62 @@
+FROM snyk/ubuntu:nlatest as base
+
+MAINTAINER Snyk Ltd
+
+USER root
+
+RUN apt-get update && apt-get install -y ca-certificates
+
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+RUN npm install --global snyk-broker
+
+
+
+FROM snyk/ubuntu:nlatest as base
+
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+COPY --from=base /home/node/.npm-global /home/node/.npm-global
+
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Don't run as root
+WORKDIR /home/node
+USER node
+
+# Generate default accept filter
+RUN broker init jira
+# Support for OpenShift - have to run after init to get accept.json and .env
+USER root
+RUN chgrp -R 0 /home/node && chmod -R g=u,o= /home/node && chown -R node /home/node
+USER node
+
+######################################
+# Custom Broker Client configuration #
+# Redefine in derived Dockerfile,    #
+# or provide as runtime args `-e`    #
+######################################
+
+# Your unique broker identifier
+# ENV BROKER_TOKEN <broker-token>
+
+# Your personal credentials to your jira
+# ENV JIRA_USERNAME <username>
+# ENV JIRA_PASSWORD <password>
+
+# Your Jira Server host
+# ENV JIRA_HOSTNAME your.jira.server.hostname
+
+# The port used by the broker client to accept internal connections
+# Default value is 7341
+# ENV PORT 7341
+
+# The URL of your broker client (including scheme and port)
+# This will be used as the webhook payload URL coming in from Jira
+# ENV BROKER_CLIENT_URL http://<broker.client.hostname>:$PORT
+
+EXPOSE $PORT
+
+CMD ["broker", "--verbose"]

--- a/dockerfiles/nexus/Dockerfile.nlatest
+++ b/dockerfiles/nexus/Dockerfile.nlatest
@@ -1,0 +1,65 @@
+FROM snyk/ubuntu:nlatest as base
+
+MAINTAINER Snyk Ltd
+
+USER root
+
+RUN apt-get update && apt-get install -y ca-certificates
+
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+RUN npm install --global snyk-broker
+
+
+
+FROM snyk/ubuntu:nlatest as base
+
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+COPY --from=base /home/node/.npm-global /home/node/.npm-global
+
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Don't run as root
+WORKDIR /home/node
+USER node
+
+# Generate default accept filter
+RUN broker init nexus
+# Support for OpenShift - have to run after init to get accept.json and .env
+USER root
+RUN chgrp -R 0 /home/node && chmod -R g=u,o= /home/node && chown -R node /home/node
+USER node
+
+######################################
+# Custom Broker Client configuration #
+# Redefine in derived Dockerfile,    #
+# or provide as runtime args `-e`    #
+######################################
+
+# Your unique Broker identifier
+# ENV BROKER_TOKEN <broker-token>
+
+# The URL to your Nexus Repository Manager
+# NOTA BENE: without `/` character in the end of URL
+# If using basic auth, use https://<username>:<password>@<your.nexus.hostname>/repository
+# else use https://<your.nexus.hostname>/repository
+# ENV NEXUS_URL=http://<username>:<password>@<your.nexus.hostname>/repository
+
+# Provide RES_BODY_URL_SUB with the URL of the nexus without credentials and http protocol
+# This URL substitution is required for NPM integration
+# RES_BODY_URL_SUB=http://<your.nexus.hostname>/repository
+
+# The port used by the broker client to accept internal connections
+# Default value is 7341
+# ENV PORT 7341
+
+# The URL of your broker client (including scheme and port)
+# This will be used as the webhook payload URL coming in from Jira
+# ENV BROKER_CLIENT_URL http://<broker.client.hostname>:$PORT
+
+EXPOSE $PORT
+
+CMD ["broker", "--verbose"]

--- a/dockerfiles/nexus2/Dockerfile.nlatest
+++ b/dockerfiles/nexus2/Dockerfile.nlatest
@@ -1,0 +1,65 @@
+FROM snyk/ubuntu:nlatest as base
+
+MAINTAINER Snyk Ltd
+
+USER root
+
+RUN apt-get update && apt-get install -y ca-certificates
+
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+RUN npm install --global snyk-broker
+
+
+
+FROM snyk/ubuntu:nlatest as base
+
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+COPY --from=base /home/node/.npm-global /home/node/.npm-global
+
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Don't run as root
+WORKDIR /home/node
+USER node
+
+# Generate default accept filter
+RUN broker init nexus2
+# Support for OpenShift - have to run after init to get accept.json and .env
+USER root
+RUN chgrp -R 0 /home/node && chmod -R g=u,o= /home/node && chown -R node /home/node
+USER node
+
+######################################
+# Custom Broker Client configuration #
+# Redefine in derived Dockerfile,    #
+# or provide as runtime args `-e`    #
+######################################
+
+# Your unique Broker identifier
+# ENV BROKER_TOKEN <broker-token>
+
+# The URL to your Nexus Repository Manager
+# NOTA BENE: without `/` character in the end of URL
+# If using basic auth, use https://<username>:<password>@<your.nexus.hostname>/nexus/content
+# else use https://<your.nexus.hostname>/nexus/content
+# ENV NEXUS_URL=<username>:<password>@<your.nexus.hostname>/nexus/content
+
+# Provide RES_BODY_URL_SUB with the URL of the nexus without credentials and http protocol
+# This URL substitution is required for NPM integration
+# RES_BODY_URL_SUB=http://<your.nexus.hostname>/nexus/content
+
+# The port used by the broker client to accept internal connections
+# Default value is 7341
+# ENV PORT 7341
+
+# The URL of your broker client (including scheme and port)
+# This will be used as the webhook payload URL coming in from Jira
+# ENV BROKER_CLIENT_URL http://<broker.client.hostname>:$PORT
+
+EXPOSE $PORT
+
+CMD ["broker", "--verbose"]

--- a/dockerfiles/ubuntu/Dockerfile.nlatest
+++ b/dockerfiles/ubuntu/Dockerfile.nlatest
@@ -1,0 +1,55 @@
+# This image is the base image that all other broker clients are built on top of.
+# The following image is reachable through the snyk/ubuntu:latest image in DockerHub.
+# Note that there's no need to build it; All broker client Dockerfiles use the snyk/ubuntu:latest.
+
+FROM ubuntu:20.04
+
+RUN groupadd --gid 1000 node \
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node \
+  && apt update && apt upgrade -y && apt install gpg curl xz-utils -y
+
+ENV NODE_VERSION 19.6.0
+
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+  amd64) ARCH='x64';; \
+  ppc64el) ARCH='ppc64le';; \
+  s390x) ARCH='s390x';; \
+  arm64) ARCH='arm64';; \
+  armhf) ARCH='armv7l';; \
+  i386) ARCH='x86';; \
+  *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  # gpg keys listed at https://github.com/nodejs/node#release-keys
+  && set -ex \
+  && for key in \
+  4ED778F539E3634C779C87C6D7062848A1AB005C \
+  94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+  1C050899334244A8AF75E53792EF661D867B9DFA \
+  71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+  8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+  C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+  C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
+  DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+  A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+  108F52B48DB57BB0CC439B2997B01419BD92F80A \
+  B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+  ; do \
+  gpg --batch --keyserver hkp://keys.openpgp.org --recv-keys "$key" || \
+  gpg --batch --keyserver hkp://pgp.mit.edu --recv-keys "$key" || \
+  gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  # smoke tests
+  && node --version \
+  && npm --version
+
+RUN apt remove gpg curl xz-utils libsqlite3-0 -y && apt autoremove -y --purge
+
+USER node


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adds dockerfiles to build the broker client versions on the latest node version, as node experimental versions on the edge to facilitate testing.

#### Where should you start
The new dockerfiles are identical to the main Dockerfile for each versions, but use the :nlatest tag for snyk/ubuntu image.

A separate ubuntu image dockerfile also pulls the latest node version, and build process will publish it with the nlatest tag.
