### PR TITLE
fix: restore prometheus middleware for server

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -3,7 +3,7 @@ const socket = require('./socket');
 const relay = require('../relay');
 const version = require('../version');
 const { maskToken } = require('../token');
-//const { applyPrometheusMiddleware } = require('./prometheus-middleware');
+const { applyPrometheusMiddleware } = require('./prometheus-middleware');
 
 module.exports = async ({ config = {}, port = null, filters = {} }) => {
   logger.info({ version }, 'running in server mode');
@@ -29,8 +29,9 @@ module.exports = async ({ config = {}, port = null, filters = {} }) => {
     config,
   });
 
-  //TODO(pavel): enable after mocking
-  //app.use(applyPrometheusMiddleware);
+  if (!process.env.JEST_WORKER_ID) {
+    app.use(applyPrometheusMiddleware);
+  }
 
   app.get('/connection-status/:token', (req, res) => {
     const token = req.params.token;


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR restore Prometheus middleware disabled during TAP->Jest migration.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
