### PR TITLE
fix: update expire date for debug dependency

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,7 +5,7 @@ ignore:
   'npm:debug:20170905':
     - primus > setheader > debug:
         reason: Not vulnerable as `primus` doesn't run in debug mode
-        expires: '2019-10-10T18:14:53.642Z'
+        expires: '2024-02-09T12:00:00.000Z'
   'SNYK-JS-PREDEFINE-1054935':
     - primus > fusing > predefine:
         reason: Fixed in https://github.com/snyk/broker/pull/336


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR updates expire date for primus transitive `npm:debug:20170905` dependency in policy file.

#### Where should the reviewer start?


#### Additional questions
