### PR TITLE
fix: improve logging to make it easier for support and debugging

### DIFF
--- a/lib/relay.js
+++ b/lib/relay.js
@@ -13,7 +13,7 @@ const stream = require('stream');
 const NodeCache = require('node-cache');
 const metrics = require('./metrics');
 const config = require('./config');
-const { initStream, pipeStream } = require('./stream-posts');
+const { BrokerServerPostResponseHandler } = require('./stream-posts');
 
 class StreamResponseHandler {
   streamingID;
@@ -124,15 +124,18 @@ function forwardHttpRequest(filterRules) {
   const filters = Filters(filterRules);
 
   return (req, res) => {
+    // If this is the server, we should receive a Snyk-Request-Id header from upstream
+    // If this is the client, we will have to generate one
+    req.headers['snyk-request-id'] ||= uuid();
     const logContext = {
       url: req.url,
-      method: req.method,
-      headers: req.headers,
-      requestId: req.headers['snyk-request-id'] || uuid(),
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      requestId: req.headers['snyk-request-id'],
       maskedToken: req.maskedToken,
     };
 
-    logger.debug(logContext, 'received request over HTTP connection');
+    logger.info(logContext, 'received request over HTTP connection');
     filters(req, (error, result) => {
       if (error) {
         const reason =
@@ -159,8 +162,12 @@ function forwardHttpRequest(filterRules) {
         streamBuffer.on('error', (error) => {
           // This may be a duplicate error, as the most likely cause of this is the POST handler calling destroy.
           logger.error(
-            { ...logContext, error },
-            'caught error passing stream through to response',
+            {
+              ...logContext,
+              error,
+              stackTrace: new Error('stacktrace generator').stack,
+            },
+            'caught error piping stream through to HTTP response',
           );
           res.destroy(error);
         });
@@ -201,9 +208,9 @@ function forwardHttpRequest(filterRules) {
           streamingID: '',
         },
         (ioResponse) => {
-          logContext.ioStatus = ioResponse.status;
-          logContext.ioHeaders = ioResponse.headers;
-          logContext.ioRequestBodyType = typeof ioResponse.body;
+          logContext.responseStatus = ioResponse.status;
+          logContext.responseHeaders = ioResponse.headers;
+          logContext.responseBodyType = typeof ioResponse.body;
 
           const logMsg = 'sending response back to HTTP connection';
           if (ioResponse.status <= 200) {
@@ -252,8 +259,13 @@ function forwardHttpRequest(filterRules) {
             }
           } catch (err) {
             logger.error(
-              { ...logContext, encodingType, err },
-              'error forwarding response',
+              {
+                ...logContext,
+                encodingType,
+                err,
+                stackTrace: new Error('stacktrace generator').stack,
+              },
+              'error forwarding response from Web Socket to HTTP connection',
             );
           }
         },
@@ -316,50 +328,49 @@ function forwardWebSocketRequest(filterRules, config, io, serverId) {
       { url, headers = {}, method, body = null, streamingID = '' } = {},
       emit,
     ) => {
+      const requestId = headers['snyk-request-id'];
       const logContext = {
         url,
-        method,
-        headers,
-        requestId: headers['snyk-request-id'] || uuid(),
+        requestMethod: method,
+        requestHeaders: headers,
+        requestId,
         streamingID,
         maskedToken: maskToken(brokerToken),
         transport: io?.socket?.transport?.name ?? 'unknown',
       };
 
+      if (!requestId) {
+        // This should be a warning but older clients won't send one
+        // TODO make this a warning when significant majority of clients are on latest version
+        logger.trace(
+          logContext,
+          'Header Snyk-Request-Id not included in headers passed through',
+        );
+      }
+
       const realEmit = emit;
       emit = (responseData) => {
         // This only works client -> server, it's not possible to post data server -> client
+        delete logContext.requestMethod;
+        delete logContext.requestHeaders;
         if (io?.capabilities?.includes('receive-post-streams')) {
+          const postHandler = new BrokerServerPostResponseHandler(
+            logContext,
+            config,
+            brokerToken,
+            streamingID,
+            serverId,
+            requestId,
+          );
           if (responseData instanceof request.Request) {
             logger.trace(
               logContext,
               'posting streaming response back to Broker Server',
             );
-            pipeStream(
-              responseData,
-              logContext,
-              config,
-              brokerToken,
-              streamingID,
-              serverId,
-            );
+            postHandler.forwardRequest(responseData);
           } else {
             // Only for responses generated internally in the Broker Client/Server
-            const body = responseData.body;
-            delete responseData.body;
-            logger.trace(
-              { ...logContext, responseData, body },
-              "posting internal response back to Broker Server as it's expecting streaming response",
-            );
-            const buffer = initStream(
-              config,
-              brokerToken,
-              streamingID,
-              JSON.stringify(responseData),
-              serverId,
-            );
-            buffer.write(JSON.stringify(body));
-            buffer.end();
+            postHandler.sendData(responseData);
           }
         } else {
           if (streamingID) {
@@ -393,7 +404,7 @@ function forwardWebSocketRequest(filterRules, config, io, serverId) {
         }
       };
 
-      logger.debug(logContext, 'received request over websocket connection');
+      logger.info(logContext, 'received request over websocket connection');
 
       filters({ url, method, body, headers }, (filterError, result) => {
         if (filterError) {
@@ -541,8 +552,12 @@ function forwardWebSocketRequest(filterRules, config, io, serverId) {
             emit(request(req));
           } catch (e) {
             logger.error(
-              { ...logContext, error: e },
-              'caught error sending HTTP response back to caller',
+              {
+                ...logContext,
+                error: e,
+                stackTrace: new Error('stacktrace generator').stack,
+              },
+              'caught error sending HTTP response over WebSocket',
             );
           }
           return;
@@ -597,18 +612,21 @@ function isJson(responseHeaders) {
 }
 
 function logResponse(logContext, status, response, config = null) {
-  logContext.httpStatus = status;
-  logContext.httpHeaders = response.headers;
-  logContext.httpBody =
+  logContext.responseStatus = status;
+  logContext.responseHeaders = response.headers;
+  logContext.responseBody =
     config && config.LOG_ENABLE_BODY === 'true' ? response.body : null;
 
   logger.info(logContext, 'sending response back to websocket connection');
 }
 
 function logError(logContext, error) {
-  logContext.error = error;
   logger.error(
-    logContext,
+    {
+      ...logContext,
+      error,
+      stackTrace: new Error('stacktrace generator').stack,
+    },
     'error while sending websocket request over HTTP connection',
   );
 }

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -85,6 +85,7 @@ module.exports = async ({ config = {}, port = null, filters = {} }) => {
     const logContext = {
       maskedToken,
       streamingID,
+      requestId: req.headers['snyk-request-id'],
     };
     logger.info(logContext, 'Handling response-data request');
     req.maskedToken = maskedToken;
@@ -137,14 +138,21 @@ module.exports = async ({ config = {}, port = null, filters = {} }) => {
                 { ...logContext, statusAndHeaders },
                 'Converting to json',
               );
-              logger.debug(
-                {
-                  ...logContext,
-                  statusAndHeadersJson: JSON.parse(statusAndHeaders),
-                },
-                'Handling response-data request - io bits',
-              );
-              streamHandler.writeStatusAndHeaders(JSON.parse(statusAndHeaders));
+              const statusAndHeadersJson = JSON.parse(statusAndHeaders);
+              const logData = {
+                ...logContext,
+                statusAndHeadersJson,
+              };
+              const logMessage = 'Handling response-data request - io bits';
+              if (
+                statusAndHeadersJson.status > 299 &&
+                statusAndHeadersJson.status !== 404
+              ) {
+                logger.info(logData, logMessage);
+              } else {
+                logger.debug(logData, logMessage);
+              }
+              streamHandler.writeStatusAndHeaders(statusAndHeadersJson);
             } else {
               logger.trace(
                 {
@@ -177,7 +185,7 @@ module.exports = async ({ config = {}, port = null, filters = {} }) => {
         } catch (e) {
           logger.error(
             { ...logContext, statusAndHeaders, statusAndHeadersSize, error: e },
-            'caught error handling data event for streaming response',
+            'caught error handling data event for streaming HTTP response',
           );
         }
       })

--- a/lib/server/socket.js
+++ b/lib/server/socket.js
@@ -39,16 +39,17 @@ module.exports = ({ server, filters, config }) => {
   );
 
   io.on('connection', function (socket) {
-    logger.info('new client connection');
-    let token = null;
+    let token = socket.request.uri.pathname
+      .replaceAll(/\/primus\/([^/]+)\//g, '$1')
+      .toLowerCase();
     let clientId = null;
+    logger.info({ maskedToken: maskToken(token) }, 'new client connection');
 
     socket.send('identify', { capabilities: ['receive-post-streams'] });
 
     const close = (closeReason = 'none') => {
       if (token) {
         const maskedToken = maskToken(token);
-        const io = connections.get(token).filter((_) => _.socket === socket);
         const clientPool = connections
           .get(token)
           .filter((_) => _.socket !== socket);

--- a/lib/stream-posts.js
+++ b/lib/stream-posts.js
@@ -2,88 +2,136 @@ const request = require('request');
 const logger = require('./log');
 const stream = require('stream');
 const { replaceUrlPartialChunk } = require('./replace-vars');
-module.exports = {
-  initStream,
-  pipeStream,
-};
 
-function initStream(config, brokerToken, streamingID, ioData, serverId) {
-  const buffer = new stream.PassThrough({ highWaterMark: 1048576 });
+const BROKER_CONTENT_TYPE = 'application/vnd.broker.stream+octet-stream';
 
-  const url = new URL(
-    `${config.brokerServerUrl}/response-data/${brokerToken}/${streamingID}`,
-  );
-  url.searchParams.append('server_id', serverId);
-  const postRequestUrl = url.toString();
+class BrokerServerPostResponseHandler {
+  #buffer;
+  #logContext;
+  #config;
+  #brokerToken;
+  #streamingId;
+  #serverId;
+  #requestId;
 
-  const postRequest = request({
-    url: postRequestUrl,
-    method: 'post',
-    headers: {
-      'Content-Type': 'application/vnd.broker.stream+octet-stream',
-      Connection: 'close',
-    },
-  });
-  buffer.on('error', (e) =>
-    logger.error({ error: e }, 'received error sending data to buffer'),
-  );
-  buffer.pipe(
-    postRequest
-      .on('error', (e) => {
-        logger.error({ error: e }, 'received error sending data via POST');
-      })
-      .on('response', (r) => {
-        if (r.statusCode !== 200) {
+  constructor(
+    logContext,
+    config,
+    brokerToken,
+    streamingId,
+    serverId,
+    requestId,
+  ) {
+    this.#logContext = logContext;
+    this.#config = config;
+    this.#brokerToken = brokerToken;
+    this.#streamingId = streamingId;
+    this.#serverId = serverId;
+    this.#requestId = requestId;
+  }
+
+  #initBuffer() {
+    this.#buffer = new stream.PassThrough({ highWaterMark: 1048576 });
+
+    const url = new URL(
+      `${this.#config.brokerServerUrl}/response-data/${this.#brokerToken}/${
+        this.#streamingId
+      }`,
+    );
+    url.searchParams.append('server_id', this.#serverId);
+    const brokerServerPostRequestUrl = url.toString();
+
+    const brokerServerPostRequest = request({
+      url: brokerServerPostRequestUrl,
+      method: 'post',
+      headers: {
+        'Snyk-Request-Id': this.#requestId,
+        'Content-Type': BROKER_CONTENT_TYPE,
+        Connection: 'close',
+      },
+    });
+    this.#buffer.on('error', (e) =>
+      logger.error(
+        {
+          ...this.#logContext,
+          error: e,
+          stackTrace: new Error('stacktrace generator').stack,
+        },
+        'received error sending data to broker server post request buffer',
+      ),
+    );
+    this.#buffer.pipe(
+      brokerServerPostRequest
+        .on('error', (e) => {
           logger.error(
             {
-              statusCode: r.statusCode,
-              statusMessage: r.statusMessage,
-              headers: r.headers,
-              body: r.body?.toString(),
+              ...this.#logContext,
+              error: e,
+              stackTrace: new Error('stacktrace generator').stack,
             },
-            'Received unexpected response uploading data',
+            'received error sending data via POST to Broker Server',
           );
-        }
-      }),
-  );
-  logger.debug('Pipe set up');
-  const ioDataLength = ioData.length;
-  logger.debug(`ioData has length of ${ioDataLength}`);
-  // Would be nice if there were a Unit32Array or a writeUint32 method, but noooooo...
-  const ioDataLengthBinary = new Uint8Array(4);
-  ioDataLengthBinary[0] = ioDataLength & 0xff;
-  ioDataLengthBinary[1] = (ioDataLength >> 8) & 0xff;
-  ioDataLengthBinary[2] = (ioDataLength >> 16) & 0xff;
-  ioDataLengthBinary[3] = (ioDataLength >> 24) & 0xff;
-  buffer.cork();
-  buffer.write(ioDataLengthBinary);
-  buffer.write(ioData);
-  buffer.uncork();
-  return buffer;
-}
+          this.#buffer.destroy(e);
+        })
+        .on('response', (r) => {
+          if (r.statusCode !== 200) {
+            logger.error(
+              {
+                ...this.#logContext,
+                statusCode: r.statusCode,
+                statusMessage: r.statusMessage,
+                headers: r.headers,
+                body: r.body?.toString(),
+                stackTrace: new Error('stacktrace generator').stack,
+              },
+              'Received unexpected HTTP response POSTing data to Broker Server',
+            );
+          }
+        }),
+    );
+    logger.debug(this.#logContext, 'Pipe set up');
+  }
 
-function pipeStream(
-  rqst,
-  logContext,
-  config,
-  brokerToken,
-  streamingID,
-  serverId,
-) {
-  let prevPartialChunk;
-  let isResponseJson;
-  let buffer = null;
-  rqst
-    .on('error', (e) => {
-      logError(logContext, e);
-      if (buffer) {
-        buffer.destroy(e);
+  #sendIoData(ioData) {
+    const ioDataLength = ioData.length;
+    logger.debug(
+      { ...this.#logContext, ioDataLength },
+      `sending ioData (Status & Headers) to Broker Server`,
+    );
+    // Would be nice if there were a Unit32Array or a writeUint32 method, but noooooo...
+    const ioDataLengthBinary = new Uint8Array(4);
+    ioDataLengthBinary[0] = ioDataLength & 0xff;
+    ioDataLengthBinary[1] = (ioDataLength >> 8) & 0xff;
+    ioDataLengthBinary[2] = (ioDataLength >> 16) & 0xff;
+    ioDataLengthBinary[3] = (ioDataLength >> 24) & 0xff;
+    this.#buffer.cork();
+    this.#buffer.write(ioDataLengthBinary);
+    this.#buffer.write(ioData);
+    this.#buffer.uncork();
+  }
+
+  #handleRequestError() {
+    // For reasons unknown, doing foo.on(this.#func)
+    // doesn't work - you need return a function from here
+    return (error) => {
+      logger.error(
+        {
+          ...this.#logContext,
+          error,
+          stackTrace: new Error('stacktrace generator').stack,
+        },
+        'received error from request while piping to Broker Server',
+      );
+      // If we already have a buffer object, then we've already started sending data back to the original requestor,
+      // so we have to destroy the stream and let that flow through the system
+      // If we *don't* have a buffer object, then there was a major failure with the request (e.g., host not found), so
+      // we will forward that directly to the Broker Server
+      if (this.#buffer) {
+        this.#buffer.destroy(error);
       } else {
-        const body = JSON.stringify({ message: e.message });
-        const buffer = initStream(
-          config,
-          brokerToken,
-          streamingID,
+        const body = JSON.stringify({ error: error });
+        this.#initBuffer();
+        this.#sendIoData(
           JSON.stringify({
             status: 500,
             headers: {
@@ -91,82 +139,91 @@ function pipeStream(
               'Content-Type': 'application/json',
             },
           }),
-          serverId,
         );
-        buffer.write(body);
-        buffer.end();
+        this.#buffer.write(body);
+        this.#buffer.end();
       }
-    })
-    .on('response', (response) => {
-      logger.debug('Response received - setting up stream to Server');
-      const status = response?.statusCode || 500;
-      logResponse(logContext, status, response, config);
-      isResponseJson = isJson(response.headers);
-      const ioData = JSON.stringify({
-        status,
-        headers: response.headers,
-      });
-      buffer = initStream(config, brokerToken, streamingID, ioData, serverId);
-    })
-    .on('data', (chunk) => {
-      logResponse(
-        logContext,
-        'undefined',
-        { body: chunk.toString() },
-        config,
-        true,
-      );
-      logger.trace(`writing data of length ${chunk.length} to buffer`);
-      if (config.RES_BODY_URL_SUB && isResponseJson) {
-        const { newChunk, partial } = replaceUrlPartialChunk(
-          Buffer.from(chunk).toString(),
-          prevPartialChunk,
-          config,
+    };
+  }
+
+  forwardRequest(rqst) {
+    let prevPartialChunk;
+    let isResponseJson;
+    rqst
+      .on('error', this.#handleRequestError())
+      .on('response', (response) => {
+        const status = response?.statusCode || 500;
+        logger.info(
+          {
+            ...this.#logContext,
+            responseStatus: status,
+            responseHeaders: response.headers,
+          },
+          'response received, setting up stream to Broker Server',
         );
-        prevPartialChunk = partial;
-        chunk = newChunk;
-      }
-      if (!buffer.write(chunk)) {
-        logger.trace('pausing request stream');
-        rqst.pause();
-        buffer.once('drain', () => {
-          logger.trace('resuming request stream');
-          rqst.resume();
+        isResponseJson = isJson(response.headers);
+        const ioData = JSON.stringify({
+          status,
+          headers: response.headers,
         });
-      }
-    })
-    .on('end', () => {
-      logger.debug('writing end to buffer');
-      buffer.end();
-    });
+        this.#initBuffer();
+        this.#sendIoData(ioData);
+        logger.info(
+          this.#logContext,
+          'successfully sent status & headers to Broker Server',
+        );
+      })
+      .on('data', (chunk) => {
+        const httpBody =
+          this.#config && this.#config.LOG_ENABLE_BODY === 'true'
+            ? { body: chunk.toString() }.body
+            : null;
+        logger.debug(
+          { ...this.#logContext, chunkLength: chunk.length, httpBody },
+          'writing data to buffer',
+        );
+        if (this.#config.RES_BODY_URL_SUB && isResponseJson) {
+          const { newChunk, partial } = replaceUrlPartialChunk(
+            Buffer.from(chunk).toString(),
+            prevPartialChunk,
+            this.#config,
+          );
+          prevPartialChunk = partial;
+          chunk = newChunk;
+        }
+        if (!this.#buffer.write(chunk)) {
+          logger.trace(this.#logContext, 'pausing request stream');
+          rqst.pause();
+          this.#buffer.once('drain', () => {
+            logger.trace(this.#logContext, 'resuming request stream');
+            rqst.resume();
+          });
+        }
+      })
+      .on('end', () => {
+        logger.info(this.#logContext, 'writing end to buffer');
+        this.#buffer.end();
+      });
+  }
+
+  sendData(responseData) {
+    const body = responseData.body;
+    delete responseData.body;
+    logger.debug(
+      { ...this.#logContext, responseData, body },
+      'posting internal response back to Broker Server as it is expecting streaming response',
+    );
+    this.#initBuffer();
+    this.#sendIoData(JSON.stringify(responseData));
+    this.#buffer.write(JSON.stringify(body));
+    this.#buffer.end();
+  }
 }
 
 function isJson(responseHeaders) {
   return responseHeaders['content-type']?.includes('json') || false;
 }
 
-function logResponse(
-  logContext,
-  status,
-  response,
-  config = null,
-  debugOnly = false,
-) {
-  logContext.httpStatus = status;
-  logContext.httpHeaders = response.headers;
-  logContext.httpBody =
-    config && config.LOG_ENABLE_BODY === 'true' ? response.body : null;
-  if (debugOnly) {
-    logger.debug(logContext, 'posting response to Broker Server');
-  } else {
-    logger.info(logContext, 'posting response to Broker Server');
-  }
-}
-
-function logError(logContext, error) {
-  logContext.error = error;
-  logger.error(
-    logContext,
-    'error while sending websocket request over HTTP connection',
-  );
-}
+module.exports = {
+  BrokerServerPostResponseHandler,
+};


### PR DESCRIPTION
* Ensure that the Snyk-Request-Id is always present in headers, and generate one if not supplied (this makes it a lot easier to track requests across client and server)
* Add stack traces to several error logs to make it easier to understand what's triggering that error
* Make log messages more explicit about what they're doing, and make sure they're unique
* Rename status/headers/body/etc fields to make it clear if they're for the request or response
* Refactor stream-posts to use a class, which makes the code more readable, and should make it a bit easier to triage errors.
* Boost "request received" messages to INFO level, so it's easier to track requests across client & server
* Log out the status & headers when we receive a POST response (info or debug based on status to avoid excessive logs)

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules
