### PR TITLE
fix: add new metrics for tracking HTTP & WebSocket request counts

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -28,6 +28,18 @@ const unableToSizeResponseCounter = new Counter({
   help: 'A count of the number of times broker server was unable to size a response',
 });
 
+const httpRequestsTotal = new Counter({
+  name: 'http_request_total',
+  help: 'Number of HTTP requests',
+  labelNames: ['rejectedByFilter'],
+});
+
+const webSocketRequestsTotal = new Counter({
+  name: 'broker_ws_request_total',
+  help: 'Number of requests received via WebSocket',
+  labelNames: ['rejectedByFilter'],
+});
+
 function incrementSocketConnectionGauge() {
   socketConnectionGauge.inc(1);
 }
@@ -44,9 +56,19 @@ function incrementUnableToSizeResponse() {
   unableToSizeResponseCounter.inc(1);
 }
 
+function incrementHttpRequestsTotal(rejectedByFilter) {
+  httpRequestsTotal.inc({'rejectedByFilter': rejectedByFilter}, 1);
+}
+
+function incrementWebSocketRequestsTotal(rejectedByFilter) {
+  webSocketRequestsTotal.inc({'rejectedByFilter': rejectedByFilter}, 1);
+}
+
 module.exports = {
   incrementSocketConnectionGauge,
   decrementSocketConnectionGauge,
   observeResponseSize,
   incrementUnableToSizeResponse,
+  incrementHttpRequestsTotal,
+  incrementWebSocketRequestsTotal,
 };

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -141,6 +141,7 @@ function forwardHttpRequest(filterRules) {
     logger.info(logContext, 'received request over HTTP connection');
     filters(req, (error, result) => {
       if (error) {
+        metrics.incrementHttpRequestsTotal(true);
         const reason =
           'Request does not match any accept rule, blocking HTTP request';
         error.reason = reason;
@@ -151,6 +152,7 @@ function forwardHttpRequest(filterRules) {
           .status(401)
           .send({ message: error.message, reason, url: req.url });
       }
+      metrics.incrementHttpRequestsTotal(false);
 
       req.url = result.url;
       logContext.ioUrl = result.url;
@@ -411,6 +413,7 @@ function forwardWebSocketRequest(filterRules, config, io, serverId) {
 
       filters({ url, method, body, headers }, (filterError, result) => {
         if (filterError) {
+          metrics.incrementWebSocketRequestsTotal(true);
           const reason =
             'Response does not match any accept rule, blocking websocket request';
           logContext.error = filterError;
@@ -425,6 +428,7 @@ function forwardWebSocketRequest(filterRules, config, io, serverId) {
             },
           });
         }
+        metrics.incrementWebSocketRequestsTotal(false);
 
         if (result.url.startsWith('http') === false) {
           result.url = 'https://' + result.url;

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -3,6 +3,7 @@ const socket = require('./socket');
 const relay = require('../relay');
 const version = require('../version');
 const { maskToken } = require('../token');
+const metrics = require('../metrics');
 const { applyPrometheusMiddleware } = require('./prometheus-middleware');
 
 module.exports = async ({ config = {}, port = null, filters = {} }) => {
@@ -57,6 +58,7 @@ module.exports = async ({ config = {}, port = null, filters = {} }) => {
 
       // check if we have this broker in the connections
       if (!connections.has(token)) {
+        metrics.incrementHttpRequestsTotal(false);
         logger.warn({ maskedToken }, 'no matching connection found');
         return res.status(404).json({ ok: false });
       }
@@ -79,6 +81,7 @@ module.exports = async ({ config = {}, port = null, filters = {} }) => {
   );
 
   app.post('/response-data/:brokerToken/:streamingId', (req, res) => {
+    metrics.incrementHttpRequestsTotal(false);
     const token = req.params.brokerToken;
     const streamingID = req.params.streamingId;
     const maskedToken = maskToken(token);


### PR DESCRIPTION
Noticed that some of the metrics are working slightly differently these days, so added a couple of metrics to track the HTTP Request Count explicitly, and to track the number of requests received over the WebSocket connection as well.

Included a flag to indicate whether the request was blocked by a rule in `accept.json`, though that only applies to the instance that receives the request (e.g., the Server won't set that flag to `true` if a request is blocked by the Client's `accept.json`).