### PR TITLE
fix: check BROKER_TOKEN before calling dispatcher

### DIFF
--- a/lib/client/dispatcher/config.ts
+++ b/lib/client/dispatcher/config.ts
@@ -3,5 +3,5 @@
  */
 export type HAConfiguration = {
   BROKER_DISPATCHER_BASE_URL: string;
-  BROKER_HA_MODE_ENABLED: boolean;
+  BROKER_HA_MODE_ENABLED: string;
 };

--- a/lib/client/dispatcher/index.ts
+++ b/lib/client/dispatcher/index.ts
@@ -26,9 +26,17 @@ export function highAvailabilityModeEnabled(config: any): boolean {
 
 export async function getServerId(
   config: any,
-  brokerToken: string,
   brokerClientId: string,
 ): Promise<ServerId | null> {
+  if (!config.BROKER_TOKEN) {
+    logger.error({ token: config.BROKER_TOKEN }, 'missing client token');
+    const error = new Error(
+      'BROKER_TOKEN is required to successfully identify itself to the server',
+    );
+    error.name = 'MISSING_BROKER_TOKEN';
+    throw error;
+  }
+
   const haConfig = getHAConfig(config);
   const baseUrl =
     haConfig.BROKER_DISPATCHER_BASE_URL || defaultBrokerDispatcherBaseUrl;

--- a/lib/client/dispatcher/index.ts
+++ b/lib/client/dispatcher/index.ts
@@ -7,14 +7,21 @@ import { ServerId, getServerIdFromDispatcher } from './dispatcher-service';
 export const defaultBrokerDispatcherBaseUrl = 'https://api.snyk.io';
 
 export function highAvailabilityModeEnabled(config: any): boolean {
-  const haConfig = getHAConfig(config);
+  // high availability mode is disabled per default
+  let highAvailabilityModeEnabled = false;
 
-  logger.info(
-    { enabled: haConfig.BROKER_HA_MODE_ENABLED },
-    'checking for HA mode',
-  );
+  const highAvailabilityModeEnabledValue = (config as HAConfiguration)
+    .BROKER_HA_MODE_ENABLED;
 
-  return haConfig.BROKER_HA_MODE_ENABLED;
+  if (typeof highAvailabilityModeEnabledValue !== 'undefined') {
+    highAvailabilityModeEnabled =
+      highAvailabilityModeEnabledValue.toLowerCase() === 'true' ||
+      highAvailabilityModeEnabledValue.toLowerCase() === 'yes';
+  }
+
+  logger.info({ enabled: highAvailabilityModeEnabled }, 'checking for HA mode');
+
+  return highAvailabilityModeEnabled;
 }
 
 export async function getServerId(

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -15,7 +15,7 @@ module.exports = async ({ port = null, config = {}, filters = {} }) => {
 
   let serverId = '';
   if (highAvailabilityModeEnabled(config)) {
-    serverId = await getServerId(config, config.BROKER_TOKEN, brokerClientId);
+    serverId = await getServerId(config, brokerClientId);
 
     if (serverId === null) {
       logger.warn({}, 'could not receive server id from Broker Dispatcher');

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -16,7 +16,15 @@ const config = require('./config');
 const { BrokerServerPostResponseHandler } = require('./stream-posts');
 
 const RequestClass = request.Request;
-request = request.defaults({ca: config.caCert, timeout: 60000, agentOptions: {keepAlive: true, keepAliveMsecs: 60000, maxTotalSockets: 1000}});
+request = request.defaults({
+  ca: config.caCert,
+  timeout: 60000,
+  agentOptions: {
+    keepAlive: true,
+    keepAliveMsecs: 60000,
+    maxTotalSockets: 1000,
+  },
+});
 
 class StreamResponseHandler {
   streamingID;

--- a/lib/stream-posts.js
+++ b/lib/stream-posts.js
@@ -3,7 +3,14 @@ const logger = require('./log');
 const stream = require('stream');
 const { replaceUrlPartialChunk } = require('./replace-vars');
 
-request = request.defaults({timeout: 60000, agentOptions: {keepAlive: true, keepAliveMsecs: 60000, maxTotalSockets: 1000}});
+request = request.defaults({
+  timeout: 60000,
+  agentOptions: {
+    keepAlive: true,
+    keepAliveMsecs: 60000,
+    maxTotalSockets: 1000,
+  },
+});
 
 const BROKER_CONTENT_TYPE = 'application/vnd.broker.stream+octet-stream';
 

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "test": "jest --detectOpenHandles",
     "test:bin": "(cd test/bin; ./container-registry-agent/docker-entrypoint-test.sh)",
     "test:bin:docker": "docker run --rm -it -v $PWD:/home/broker -w /home/broker/test/bin/ snyk/ubuntu ./container-registry-agent/docker-entrypoint-test.sh",
-    "lint": "prettier --check '{lib,test,cli}/**/*.{js,ts}' && eslint --color --cache '{cli,lib,test}/**/*.{js,ts}'",
-    "check-tests": "! grep 'test.only' test/**/*.test.js -n"
+    "lint": "prettier --check '{lib,test,cli}/**/*.{js,ts}' && eslint --color --cache '{cli,lib,test}/**/*.{js,ts}'"
   },
   "keywords": [],
   "author": "Snyk.io",

--- a/test/unit/client/dispatcher/dispatcher.test.ts
+++ b/test/unit/client/dispatcher/dispatcher.test.ts
@@ -1,0 +1,16 @@
+import { getServerId } from '../../../../lib/client/dispatcher';
+
+describe('Dispatcher', () => {
+  it('getServerId without broker token should throw an error', async () => {
+    const expectedError = new Error(
+      'BROKER_TOKEN is required to successfully identify itself to the server',
+    );
+    expectedError.name = 'MISSING_BROKER_TOKEN';
+
+    try {
+      await getServerId({}, 'random-client-it');
+    } catch (error) {
+      expect(error).toStrictEqual(expectedError);
+    }
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR does the following:
- check if `BROKER_TOKEN` config variable exists before making an API call to the dispatcher
- improve check for HA mode. All config values getting from snyk-config are strings, so changing type of `BROKER_HA_MODE_ENABLED` from boolean to string.
- format all source files with Prettier (`npm run format` command) for consistency
- remove a non-relevant NPM task `check-tests`: folder structure is changed.

#### Where should the reviewer start?
Take a look on `getServerId()` function.
