### PR TITLE
fix: check if connection has been added to pool on close

### DIFF
--- a/lib/server/socket.js
+++ b/lib/server/socket.js
@@ -50,27 +50,32 @@ module.exports = ({ server, filters, config }) => {
     const close = (closeReason = 'none') => {
       if (token) {
         const maskedToken = maskToken(token);
-        const clientPool = connections
-          .get(token)
-          .filter((_) => _.socket !== socket);
-        logger.info(
-          {
-            closeReason,
-            maskedToken,
-            remainingConnectionsCount: clientPool.length,
-          },
-          'client connection closed',
-        );
-        if (clientPool.length) {
-          connections.set(token, clientPool);
+        const connectionsForToken = connections
+          .get(token);
+        if (connectionsForToken) {
+          const clientPool = connectionsForToken
+            .filter((_) => _.socket !== socket);
+          logger.info(
+            {
+              closeReason,
+              maskedToken,
+              remainingConnectionsCount: clientPool.length,
+            },
+            'client connection closed',
+          );
+          if (clientPool.length) {
+            connections.set(token, clientPool);
+          } else {
+            logger.info({maskedToken}, 'removing client');
+            connections.delete(token);
+          }
+          decrementSocketConnectionGauge();
+          setImmediate(
+            async () => await dispatcher.clientDisconnected(token, clientId),
+          );
         } else {
-          logger.info({ maskedToken }, 'removing client');
-          connections.delete(token);
+          logger.warn({maskedToken}, 'client disconnected before identifying itself');
         }
-        decrementSocketConnectionGauge();
-        setImmediate(
-          async () => await dispatcher.clientDisconnected(token, clientId),
-        );
       }
     };
 


### PR DESCRIPTION
Clients are only added to the connections map once they have identified themselves, however a client can close a connection before identification. And now that the token is fetched from the URL, means the if(token) check is longer an implicit "client has identified" check, so we *also* need to check if the map contains a value for the token - if it doesn't, the connection never identified itself.

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
