### PR TITLE
fix: log preflight check results when starting client

### DIFF
--- a/README.md
+++ b/README.md
@@ -750,6 +750,18 @@ Sometime it is required to load sensitive configurations (GitHub/Snyk's token) f
 * Change the workdir of the docker image to be `/broker`/
 Example of such file is located in your broker container at $HOME/.env
 
+### Preflight Checks
+The main objective of preflight checks is to catch errors and misconfigurations early, upon broker client startup rather than later when usage is occurring.
+Regardless of whether the checks were successful, the Broker client will be started. There are following checks available:
+
+| Check ID               | Description                                                                                                                                                                                                                                                | Configuration Defaults                                          |
+|------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
+| `broker-server-status` | **Broker Server Healthcheck** validates the connectivity to the Broker Server. It performs a GET request to `{BROKER_SERVER_URL}/healthcheck`                                                                                                              | If not specified, `BROKER_SERVER_URL` is https://broker.snyk.io |
+| `rest-api-status`      | **REST API Healthcheck** validates the connectivity to the [Snyk REST API](https://apidocs.snyk.io). It performs a GET request to `{API_BASE_URL}/rest/openapi`. This check is conditional and will be executed only if high availability mode is enabled. | If not specified, `API_BASE_URL` is https://api.snyk.io         |
+
+
+
+
 ### Troubleshooting
 
 #### Support of big manifest files (> 1Mb) for GitHub / GitHub Enterprise

--- a/lib/client/checks/index.ts
+++ b/lib/client/checks/index.ts
@@ -92,6 +92,8 @@ const logPreflightCheckResults = (results: CheckResult[]) => {
   console.log('### Preflight checks help to catch errors early, upon broker');
   console.log('### client startup. Note, that broker client will start');
   console.log('### whether the checks were successful or not.');
+  console.log('###');
+  console.log('### See more: https://github.com/snyk/broker#preflight-checks');
   console.log('##############################################################');
 
   const checks = results.map((check) => {

--- a/lib/client/checks/index.ts
+++ b/lib/client/checks/index.ts
@@ -46,6 +46,9 @@ export async function executePreflightChecks(
     );
     preflightCheckResults.push(checkResult);
   }
+
+  logPreflightCheckResults(preflightCheckResults);
+
   return Promise.resolve(preflightCheckResults);
 }
 
@@ -80,4 +83,19 @@ export const checksConfig = async (config: any) => {
     preflightCheckStore,
     httpCheckService,
   };
+};
+
+const logPreflightCheckResults = (results: CheckResult[]) => {
+  console.log('##############################################################');
+  console.log('### PREFLIGHT CHECKS RESULTS');
+  console.log('###');
+  console.log('### Preflight checks help to catch errors early, upon broker');
+  console.log('### client startup. Note, that broker client will start');
+  console.log('### whether the checks were successful or not.');
+  console.log('##############################################################');
+
+  const checks = results.map((check) => {
+    return { id: check.id, status: check.status };
+  });
+  console.table(checks);
 };


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR prints out results of preflight checks by Broker Client start.

We log using `console.log()` and not logger, so it is easier to distinguish output when running broker client in containerized environments

#### Where should the reviewer start?
Start Broker Client and verify that following output is present:
```bash
[2023-03-14T13:58:13.218Z]  INFO: snyk-broker/11708 on localhost: verifying if preflight checks are enabled (enabled=true)
##############################################################
### PREFLIGHT CHECKS RESULTS
###
### Preflight checks help to catch errors early, upon broker
### client startup. Note, that broker client will start
### whether the checks were successful or not.
###
### See more: https://github.com/snyk/broker#preflight-checks
##############################################################

┌─────────┬────────────────────────┬───────────┐
│ (index) │           id           │  status   │
├─────────┼────────────────────────┼───────────┤
│    0    │ 'broker-server-status' │ 'passing' │
│    1    │   'rest-api-status'    │ 'passing' │
└─────────┴────────────────────────┴───────────┘
[2023-03-14T13:58:13.984Z]  INFO: snyk-broker/11708 on localhost:
```


#### Additional questions
