### PR TITLE
refactor: unify hash token token

### DIFF
--- a/lib/client/dispatcher/index.ts
+++ b/lib/client/dispatcher/index.ts
@@ -1,6 +1,6 @@
-import crypto = require('crypto');
 import logger = require('../../log');
 import { Config } from '../config';
+import { hashToken } from '../../token';
 import { HttpDispatcherServiceClient } from './client/api';
 import { ServerId, getServerIdFromDispatcher } from './dispatcher-service';
 
@@ -41,14 +41,14 @@ export async function getServerId(
   const baseUrl =
     haConfig.BROKER_DISPATCHER_BASE_URL || defaultBrokerDispatcherBaseUrl;
   const client = new HttpDispatcherServiceClient(baseUrl);
-  const token = hash(config.BROKER_TOKEN);
+  const hashedToken = hashToken(config.BROKER_TOKEN);
 
   const maxRetries = 30;
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       return await getServerIdFromDispatcher(client, {
         brokerClientId: brokerClientId,
-        hashedBrokerToken: token,
+        hashedBrokerToken: hashedToken,
       });
     } catch (err) {
       const timeout = 2 ** attempt * 100;
@@ -65,10 +65,4 @@ export async function getServerId(
 
 function getHAConfig(config: any): Config {
   return config as Config;
-}
-
-function hash(token: string): string {
-  const shasum = crypto.createHash('sha256');
-  shasum.update(token);
-  return shasum.digest('hex');
 }

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -1,7 +1,6 @@
-const { maskToken } = require('./token');
+const { hashToken, maskToken } = require('./token');
 const logger = require('./log');
 const config = require('./config');
-const crypto = require('crypto');
 const { axiosInstance } = require('./axios');
 const { v4: uuid } = require('uuid');
 
@@ -46,7 +45,7 @@ class DispatcherClient {
     const maskedToken = maskToken(token);
     await this.#makeRequest(
       { maskedToken, clientId, requestType: 'client-connected' },
-      `${this.#url}/internal/brokerservers/${this.#id}/connections/${hash(
+      `${this.#url}/internal/brokerservers/${this.#id}/connections/${hashToken(
         token,
       )}${clientId ? `?broker_client_id=${clientId}` : ''}`,
       'post',
@@ -64,7 +63,7 @@ class DispatcherClient {
     const maskedToken = maskToken(token);
     await this.#makeRequest(
       { maskedToken, clientId, requestType: 'client-disconnected' },
-      `${this.#url}/internal/brokerservers/${this.#id}/connections/${hash(
+      `${this.#url}/internal/brokerservers/${this.#id}/connections/${hashToken(
         token,
       )}${clientId ? `?broker_client_id=${clientId}` : ''}`,
       'delete',
@@ -131,12 +130,6 @@ class DispatcherClient {
   }
 }
 
-function hash(token) {
-  const shasum = crypto.createHash('sha256');
-  shasum.update(token);
-  return shasum.digest('hex');
-}
-
 let clientConnected;
 let clientDisconnected;
 let serverStarting;
@@ -192,5 +185,4 @@ module.exports = {
   clientDisconnected,
   serverStarting,
   serverStopping,
-  hash,
 };

--- a/lib/token.ts
+++ b/lib/token.ts
@@ -1,3 +1,11 @@
+import crypto = require('crypto');
+
+export function hashToken(token: string): string {
+  const shasum = crypto.createHash('sha256');
+  shasum.update(token);
+  return shasum.digest('hex');
+}
+
 export function maskToken(token) {
   if (!token || token === '') {
     return '';

--- a/lib/token.ts
+++ b/lib/token.ts
@@ -1,8 +1,4 @@
-module.exports = {
-  maskToken,
-};
-
-function maskToken(token) {
+export function maskToken(token) {
   if (!token || token === '') {
     return '';
   }

--- a/test/unit/token.test.ts
+++ b/test/unit/token.test.ts
@@ -1,19 +1,36 @@
-import { maskToken } from '../../lib/token';
+import { hashToken, maskToken } from '../../lib/token';
 
 describe('token', () => {
-  it('should return empty string if token is empty or null', async () => {
-    const maskedTokenForEmpty = maskToken('');
-    const maskedTokenForNull = maskToken('');
+  describe('hashToken', () => {
+    it('should hash input tokens using sha256', async () => {
+      const expectedSha256ForEmptyString =
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+      const expectedSha256ForTokenWord =
+        '3c469e9d6c5875d37a43f353d4f88e61fcf812c66eee3457465a40b0da4153e0';
 
-    expect(maskedTokenForEmpty).toEqual('');
-    expect(maskedTokenForNull).toEqual('');
+      const hashedTokenForEmptyString = hashToken('');
+      const hashedTokenForTokenWord = hashToken('token');
+
+      expect(hashedTokenForEmptyString).toEqual(expectedSha256ForEmptyString);
+      expect(hashedTokenForTokenWord).toEqual(expectedSha256ForTokenWord);
+    });
   });
 
-  it('should return four first and last characters when masking', async () => {
-    const maskedToken = maskToken('12345');
-    const maskedUUIDToken = maskToken('aaaabbbb-0160-4126-a00d-ccccccccdddd');
+  describe('maskToken', () => {
+    it('should return empty string if token is empty or null', async () => {
+      const maskedTokenForEmpty = maskToken('');
+      const maskedTokenForNull = maskToken('');
 
-    expect(maskedToken).toEqual('1234-...-2345');
-    expect(maskedUUIDToken).toEqual('aaaa-...-dddd');
+      expect(maskedTokenForEmpty).toEqual('');
+      expect(maskedTokenForNull).toEqual('');
+    });
+
+    it('should return four first and last characters when masking', async () => {
+      const maskedToken = maskToken('12345');
+      const maskedUUIDToken = maskToken('aaaabbbb-0160-4126-a00d-ccccccccdddd');
+
+      expect(maskedToken).toEqual('1234-...-2345');
+      expect(maskedUUIDToken).toEqual('aaaa-...-dddd');
+    });
   });
 });

--- a/test/unit/token.test.ts
+++ b/test/unit/token.test.ts
@@ -1,0 +1,19 @@
+import { maskToken } from '../../lib/token';
+
+describe('token', () => {
+  it('should return empty string if token is empty or null', async () => {
+    const maskedTokenForEmpty = maskToken('');
+    const maskedTokenForNull = maskToken('');
+
+    expect(maskedTokenForEmpty).toEqual('');
+    expect(maskedTokenForNull).toEqual('');
+  });
+
+  it('should return four first and last characters when masking', async () => {
+    const maskedToken = maskToken('12345');
+    const maskedUUIDToken = maskToken('aaaabbbb-0160-4126-a00d-ccccccccdddd');
+
+    expect(maskedToken).toEqual('1234-...-2345');
+    expect(maskedUUIDToken).toEqual('aaaa-...-dddd');
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR unifies `hash` functions used by Server and Client because of the parallel features implementations.
Additionally `/lib/token.js` is converted to TypeScript.

#### Where should the reviewer start?
Take a look on following files:

- `lib/client/dispatcher/index.ts`
- `lib/dispatcher.js`

and verify that `function hash(string)` is removed from both files. The function is moved into `/lib/token.ts` file.