### PR TITLE
feat: allow client to describe bitbucket branches by query string

### DIFF
--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -910,6 +910,17 @@
       }
     },
     {
+      "//": "Used to get a branch specified by query string",
+      "method": "GET",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/branches:filterText?",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
       "//": "get a specific commit identified by the commit hash or name of a branch",
       "method": "GET",
       "path": "/rest/api/1.0/projects/:project/repos/:repo/commits/:sha",

--- a/test/unit/__snapshots__/runtime-rules-hotloading.test.ts.snap
+++ b/test/unit/__snapshots__/runtime-rules-hotloading.test.ts.snap
@@ -1310,6 +1310,17 @@ Object {
       "path": "/rest/api/1.0/projects/:project/repos/:repo/branches/default",
     },
     Object {
+      "//": "Used to get a branch specified by query string",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/branches:filterText?",
+    },
+    Object {
       "//": "get a specific commit identified by the commit hash or name of a branch",
       "auth": Object {
         "password": "\${BITBUCKET_PASSWORD}",
@@ -7928,6 +7939,17 @@ Object {
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/api/1.0/projects/:project/repos/:repo/branches/default",
+    },
+    Object {
+      "//": "Used to get a branch specified by query string",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/branches:filterText?",
     },
     Object {
       "//": "get a specific commit identified by the commit hash or name of a branch",
@@ -14976,6 +14998,17 @@ Object {
       "path": "/rest/api/1.0/projects/:project/repos/:repo/branches/default",
     },
     Object {
+      "//": "Used to get a branch specified by query string",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/branches:filterText?",
+    },
+    Object {
       "//": "get a specific commit identified by the commit hash or name of a branch",
       "auth": Object {
         "password": "\${BITBUCKET_PASSWORD}",
@@ -16138,6 +16171,17 @@ Object {
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/api/1.0/projects/:project/repos/:repo/branches/default",
+    },
+    Object {
+      "//": "Used to get a branch specified by query string",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/branches:filterText?",
     },
     Object {
       "//": "get a specific commit identified by the commit hash or name of a branch",
@@ -28006,6 +28050,17 @@ Object {
       "path": "/rest/api/1.0/projects/:project/repos/:repo/branches/default",
     },
     Object {
+      "//": "Used to get a branch specified by query string",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/branches:filterText?",
+    },
+    Object {
       "//": "get a specific commit identified by the commit hash or name of a branch",
       "auth": Object {
         "password": "\${BITBUCKET_PASSWORD}",
@@ -34503,6 +34558,17 @@ Object {
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/api/1.0/projects/:project/repos/:repo/branches/default",
+    },
+    Object {
+      "//": "Used to get a branch specified by query string",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/branches:filterText?",
     },
     Object {
       "//": "get a specific commit identified by the commit hash or name of a branch",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

- Adds a rule that allows the Bitbucket Broker to describe branches specified by a query string, enabling Snyk Code analysis. This mechanism is used when a branch contains a `/` character.

#### Where should the reviewer start?

#### How should this be manually tested?

- Import a sample repository that has a default branch with a `/` in the name. Observe Snyk Code analysis succeeds after this rule has been added.

#### Any background context you want to provide?



#### Screenshots


#### Additional questions
