### PR TITLE
chore: add hashedToken in logs for better troubleshooting

### DIFF
--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -1,4 +1,4 @@
-const { hashToken, maskToken } = require('./token');
+const { hashToken } = require('./token');
 const logger = require('./log');
 const config = require('./config');
 const { axiosInstance } = require('./axios');
@@ -42,12 +42,14 @@ class DispatcherClient {
   }
 
   async clientConnected(token, clientId, clientVersion) {
-    const maskedToken = maskToken(token);
+    const hashedToken = hashToken(token);
     await this.#makeRequest(
-      { maskedToken, clientId, requestType: 'client-connected' },
-      `${this.#url}/internal/brokerservers/${this.#id}/connections/${hashToken(
-        token,
-      )}${clientId ? `?broker_client_id=${clientId}` : ''}`,
+      { hashedToken, clientId, requestType: 'client-connected' },
+      `${this.#url}/internal/brokerservers/${
+        this.#id
+      }/connections/${hashedToken}${
+        clientId ? `?broker_client_id=${clientId}` : ''
+      }`,
       'post',
       {
         data: {
@@ -61,12 +63,14 @@ class DispatcherClient {
   }
 
   async clientDisconnected(token, clientId) {
-    const maskedToken = maskToken(token);
+    const hashedToken = hashToken(token);
     await this.#makeRequest(
-      { maskedToken, clientId, requestType: 'client-disconnected' },
-      `${this.#url}/internal/brokerservers/${this.#id}/connections/${hashToken(
-        token,
-      )}${clientId ? `?broker_client_id=${clientId}` : ''}`,
+      { hashedToken, clientId, requestType: 'client-disconnected' },
+      `${this.#url}/internal/brokerservers/${
+        this.#id
+      }/connections/${hashedToken}${
+        clientId ? `?broker_client_id=${clientId}` : ''
+      }`,
       'delete',
     );
   }

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -8,7 +8,7 @@ const { replace, replaceUrlPartialChunk } = require('./replace-vars');
 const tryJSONParse = require('./try-json-parse');
 const logger = require('./log');
 const version = require('./version');
-const { maskToken } = require('./token');
+const { maskToken, hashToken } = require('./token');
 const stream = require('stream');
 const NodeCache = require('node-cache');
 const metrics = require('./metrics');
@@ -144,6 +144,7 @@ function forwardHttpRequest(filterRules) {
       requestHeaders: req.headers,
       requestId: req.headers['snyk-request-id'],
       maskedToken: req.maskedToken,
+      hashedToken: req.hashedToken,
     };
 
     logger.info(logContext, 'received request over HTTP connection');
@@ -349,6 +350,7 @@ function forwardWebSocketRequest(filterRules, config, io, serverId) {
         requestId,
         streamingID,
         maskedToken: maskToken(brokerToken),
+        hashedToken: hashToken(brokerToken),
         transport: io?.socket?.transport?.name ?? 'unknown',
       };
 

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -2,7 +2,7 @@ const logger = require('../log');
 const socket = require('./socket');
 const relay = require('../relay');
 const version = require('../version');
-const { maskToken } = require('../token');
+const { maskToken, hashToken } = require('../token');
 const metrics = require('../metrics');
 const { applyPrometheusMiddleware } = require('./prometheus-middleware');
 
@@ -37,7 +37,7 @@ module.exports = async ({ config = {}, port = null, filters = {} }) => {
   app.get('/connection-status/:token', (req, res) => {
     const token = req.params.token;
     const maskedToken = maskToken(token);
-
+    const hashedToken = hashToken(token);
     if (connections.has(token)) {
       const clientsMetadata = connections.get(token).map((conn) => ({
         version: conn.metadata && conn.metadata.version,
@@ -45,7 +45,7 @@ module.exports = async ({ config = {}, port = null, filters = {} }) => {
       }));
       return res.status(200).json({ ok: true, clients: clientsMetadata });
     }
-    logger.warn({ maskedToken }, 'no matching connection found');
+    logger.warn({ maskedToken, hashedToken }, 'no matching connection found');
     return res.status(404).json({ ok: false });
   });
 
@@ -54,12 +54,17 @@ module.exports = async ({ config = {}, port = null, filters = {} }) => {
     (req, res, next) => {
       const token = req.params.token;
       const maskedToken = maskToken(token);
+      const hashedToken = hashToken(token);
       req.maskedToken = maskedToken;
+      req.hashedToken = hashedToken;
 
       // check if we have this broker in the connections
       if (!connections.has(token)) {
         metrics.incrementHttpRequestsTotal(false);
-        logger.warn({ maskedToken }, 'no matching connection found');
+        logger.warn(
+          { maskedToken, hashedToken },
+          'no matching connection found',
+        );
         return res.status(404).json({ ok: false });
       }
 
@@ -85,13 +90,16 @@ module.exports = async ({ config = {}, port = null, filters = {} }) => {
     const token = req.params.brokerToken;
     const streamingID = req.params.streamingId;
     const maskedToken = maskToken(token);
+    const hashedToken = hashToken(token);
     const logContext = {
+      hashedToken,
       maskedToken,
       streamingID,
       requestId: req.headers['snyk-request-id'],
     };
     logger.info(logContext, 'Handling response-data request');
     req.maskedToken = maskedToken;
+    req.hashedToken = hashedToken;
 
     const streamHandler = relay.StreamResponseHandler.create(streamingID);
     if (!streamHandler) {

--- a/lib/server/socket.js
+++ b/lib/server/socket.js
@@ -2,7 +2,7 @@ const Primus = require('primus');
 const Emitter = require('primus-emitter');
 const logger = require('../log');
 const relay = require('../relay');
-const { maskToken } = require('../token');
+const { maskToken, hashToken } = require('../token');
 const {
   incrementSocketConnectionGauge,
   decrementSocketConnectionGauge,
@@ -45,13 +45,17 @@ module.exports = ({ server, filters, config }) => {
     let clientId = null;
     let clientVersion = null;
     let identified = false;
-    logger.info({ maskedToken: maskToken(token) }, 'new client connection');
+    logger.info(
+      { maskedToken: maskToken(token), hashedToken: hashToken(token) },
+      'new client connection',
+    );
 
     socket.send('identify', { capabilities: ['receive-post-streams'] });
 
     const close = (closeReason = 'none') => {
       if (token) {
         const maskedToken = maskToken(token);
+        const hashedToken = hashToken(token);
         if (identified) {
           const clientPool = connections
             .get(token)
@@ -60,6 +64,7 @@ module.exports = ({ server, filters, config }) => {
             {
               closeReason,
               maskedToken,
+              hashedToken,
               remainingConnectionsCount: clientPool.length,
             },
             'client connection closed',
@@ -67,7 +72,7 @@ module.exports = ({ server, filters, config }) => {
           if (clientPool.length) {
             connections.set(token, clientPool);
           } else {
-            logger.info({ maskedToken }, 'removing client');
+            logger.info({ maskedToken, hashedToken }, 'removing client');
             connections.delete(token);
           }
           decrementSocketConnectionGauge();
@@ -76,7 +81,7 @@ module.exports = ({ server, filters, config }) => {
           );
         } else {
           logger.warn(
-            { maskedToken },
+            { maskedToken, hashedToken },
             'client disconnected before identifying itself',
           );
         }
@@ -105,9 +110,14 @@ module.exports = ({ server, filters, config }) => {
       }
 
       const maskedToken = maskToken(token);
+      const hashedToken = hashToken(token);
 
       logger.info(
-        { maskedToken, metadata: metadataWithoutFilters(clientData.metadata) },
+        {
+          maskedToken,
+          hashedToken,
+          metadata: metadataWithoutFilters(clientData.metadata),
+        },
         'new client connection identified',
       );
 

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -2,7 +2,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const fs = require('fs');
 const logger = require('./log');
-const { maskToken } = require('./token');
+const { maskToken, hashToken } = require('./token');
 
 module.exports = main;
 
@@ -49,6 +49,7 @@ function main(config = {}, altPort = null) {
     if (err) {
       const brokerToken = extractBrokerTokenFromUrl(req.url);
       const maskedToken = maskToken(brokerToken);
+      const hashedToken = hashToken(brokerToken);
       logger.error(
         {
           url: req.url.replaceAll(brokerToken, maskedToken),
@@ -56,6 +57,7 @@ function main(config = {}, altPort = null) {
           requestHeaders: req.headers,
           requestId: req.headers['snyk-request-id'] || '',
           maskedToken: maskedToken,
+          hashedToken: hashedToken,
           error: err,
         },
         'Error occurred receiving http request on broker webserver',


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Puts hashedToken in the logs. Secure way to clearly identify the connection, working well with the rest of the Broker stack component to connect the dots.

#### Where should the reviewer start?
Should be mostly alongside maskedToken except in the dispatcher calls where it replaces maskedToken in the logContext.