### PR TITLE
add some options for disabling variable substitution

### DIFF
--- a/lib/relay.js
+++ b/lib/relay.js
@@ -486,27 +486,33 @@ function forwardWebSocketRequest(filterRules, config, io, serverId) {
         // with an env var of the same name (SOME_ENV_VAR).
         // This is used (for example) to substitute the snyk url
         // with the broker's url when defining the target for an incoming webhook.
-        if (body) {
-          const parsedBody = tryJSONParse(body);
+        if (!config.disableVarsSubstitution) {
+          if (!config.disableBodyVarsSubstitution) {
+            if (body) {
+              const parsedBody = tryJSONParse(body);
 
-          if (parsedBody.BROKER_VAR_SUB) {
-            logContext.bodyVarsSubstitution = parsedBody.BROKER_VAR_SUB;
-            for (const path of parsedBody.BROKER_VAR_SUB) {
-              let source = undefsafe(parsedBody, path); // get the value
-              source = replace(source, config); // replace the variables
-              undefsafe(parsedBody, path, source); // put it back in
+              if (parsedBody.BROKER_VAR_SUB) {
+                logContext.bodyVarsSubstitution = parsedBody.BROKER_VAR_SUB;
+                for (const path of parsedBody.BROKER_VAR_SUB) {
+                  let source = undefsafe(parsedBody, path); // get the value
+                  source = replace(source, config); // replace the variables
+                  undefsafe(parsedBody, path, source); // put it back in
+                }
+                body = JSON.stringify(parsedBody);
+              }
             }
-            body = JSON.stringify(parsedBody);
           }
-        }
 
-        // check whether we want to do variable substitution on the headers
-        if (headers && headers['x-broker-var-sub']) {
-          logContext.headerVarsSubstitution = headers['x-broker-var-sub'];
-          for (const path of headers['x-broker-var-sub'].split(',')) {
-            let source = undefsafe(headers, path.trim()); // get the value
-            source = replace(source, config); // replace the variables
-            undefsafe(headers, path.trim(), source); // put it back in
+          if (!config.disableHeaderVarsSubstitution) {
+            // check whether we want to do variable substitution on the headers
+            if (headers && headers['x-broker-var-sub']) {
+              logContext.headerVarsSubstitution = headers['x-broker-var-sub'];
+              for (const path of headers['x-broker-var-sub'].split(',')) {
+                let source = undefsafe(headers, path.trim()); // get the value
+                source = replace(source, config); // replace the variables
+                undefsafe(headers, path.trim(), source); // put it back in
+              }
+            }
           }
         }
 


### PR DESCRIPTION
The new options are:
  --disableVarsSubstitution
  --disableHeaderVarsSubstitution
  --disableBodyVarsSubstitution

- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR allows the broker admin to disable the variable substitution feature in the broker.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
