### PR TITLE
Disable var substitution

### DIFF
--- a/lib/relay.js
+++ b/lib/relay.js
@@ -486,27 +486,33 @@ function forwardWebSocketRequest(filterRules, config, io, serverId) {
         // with an env var of the same name (SOME_ENV_VAR).
         // This is used (for example) to substitute the snyk url
         // with the broker's url when defining the target for an incoming webhook.
-        if (body) {
-          const parsedBody = tryJSONParse(body);
+        if (!config.disableVarsSubstitution) {
+          if (!config.disableBodyVarsSubstitution) {
+            if (body) {
+              const parsedBody = tryJSONParse(body);
 
-          if (parsedBody.BROKER_VAR_SUB) {
-            logContext.bodyVarsSubstitution = parsedBody.BROKER_VAR_SUB;
-            for (const path of parsedBody.BROKER_VAR_SUB) {
-              let source = undefsafe(parsedBody, path); // get the value
-              source = replace(source, config); // replace the variables
-              undefsafe(parsedBody, path, source); // put it back in
+              if (parsedBody.BROKER_VAR_SUB) {
+                logContext.bodyVarsSubstitution = parsedBody.BROKER_VAR_SUB;
+                for (const path of parsedBody.BROKER_VAR_SUB) {
+                  let source = undefsafe(parsedBody, path); // get the value
+                  source = replace(source, config); // replace the variables
+                  undefsafe(parsedBody, path, source); // put it back in
+                }
+                body = JSON.stringify(parsedBody);
+              }
             }
-            body = JSON.stringify(parsedBody);
           }
-        }
 
-        // check whether we want to do variable substitution on the headers
-        if (headers && headers['x-broker-var-sub']) {
-          logContext.headerVarsSubstitution = headers['x-broker-var-sub'];
-          for (const path of headers['x-broker-var-sub'].split(',')) {
-            let source = undefsafe(headers, path.trim()); // get the value
-            source = replace(source, config); // replace the variables
-            undefsafe(headers, path.trim(), source); // put it back in
+          if (!config.disableHeaderVarsSubstitution) {
+            // check whether we want to do variable substitution on the headers
+            if (headers && headers['x-broker-var-sub']) {
+              logContext.headerVarsSubstitution = headers['x-broker-var-sub'];
+              for (const path of headers['x-broker-var-sub'].split(',')) {
+                let source = undefsafe(headers, path.trim()); // get the value
+                source = replace(source, config); // replace the variables
+                undefsafe(headers, path.trim(), source); // put it back in
+              }
+            }
           }
         }
 

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -486,33 +486,31 @@ function forwardWebSocketRequest(filterRules, config, io, serverId) {
         // with an env var of the same name (SOME_ENV_VAR).
         // This is used (for example) to substitute the snyk url
         // with the broker's url when defining the target for an incoming webhook.
-        if (!config.disableVarsSubstitution) {
-          if (!config.disableBodyVarsSubstitution) {
-            if (body) {
-              const parsedBody = tryJSONParse(body);
+        if (!config.disableBodyVarsSubstitution && body) {
+          const parsedBody = tryJSONParse(body);
 
-              if (parsedBody.BROKER_VAR_SUB) {
-                logContext.bodyVarsSubstitution = parsedBody.BROKER_VAR_SUB;
-                for (const path of parsedBody.BROKER_VAR_SUB) {
-                  let source = undefsafe(parsedBody, path); // get the value
-                  source = replace(source, config); // replace the variables
-                  undefsafe(parsedBody, path, source); // put it back in
-                }
-                body = JSON.stringify(parsedBody);
-              }
+          if (parsedBody.BROKER_VAR_SUB) {
+            logContext.bodyVarsSubstitution = parsedBody.BROKER_VAR_SUB;
+            for (const path of parsedBody.BROKER_VAR_SUB) {
+              let source = undefsafe(parsedBody, path); // get the value
+              source = replace(source, config); // replace the variables
+              undefsafe(parsedBody, path, source); // put it back in
             }
+            body = JSON.stringify(parsedBody);
           }
+        }
 
-          if (!config.disableHeaderVarsSubstitution) {
-            // check whether we want to do variable substitution on the headers
-            if (headers && headers['x-broker-var-sub']) {
-              logContext.headerVarsSubstitution = headers['x-broker-var-sub'];
-              for (const path of headers['x-broker-var-sub'].split(',')) {
-                let source = undefsafe(headers, path.trim()); // get the value
-                source = replace(source, config); // replace the variables
-                undefsafe(headers, path.trim(), source); // put it back in
-              }
-            }
+        if (
+          !config.disableHeaderVarsSubstitution &&
+          headers &&
+          headers['x-broker-var-sub']
+        ) {
+          // check whether we want to do variable substitution on the headers
+          logContext.headerVarsSubstitution = headers['x-broker-var-sub'];
+          for (const path of headers['x-broker-var-sub'].split(',')) {
+            let source = undefsafe(headers, path.trim()); // get the value
+            source = replace(source, config); // replace the variables
+            undefsafe(headers, path.trim(), source); // put it back in
           }
         }
 

--- a/test/unit/relay-response-body.test.ts
+++ b/test/unit/relay-response-body.test.ts
@@ -16,6 +16,10 @@ requestDefaultsMock.mockImplementation((_options) => {
 import { response as relay } from '../../lib/relay';
 
 describe('body relay', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('relay swaps body values found in BROKER_VAR_SUB', (done) => {
     expect.hasAssertions();
 
@@ -56,6 +60,51 @@ describe('body relay', () => {
         expect(JSON.parse(arg.body).url).toEqual(
           `${config.HOST}:${config.PORT}/webhook`,
         );
+
+        done();
+      },
+    );
+  });
+
+  it('relay does NOT swap body values found in BROKER_VAR_SUB if disabled', (done) => {
+    expect.hasAssertions();
+
+    const brokerToken = 'test-broker';
+
+    const config = {
+      HOST: 'localhost',
+      PORT: '8001',
+      disableBodyVarsSubstitution: true,
+    };
+
+    const route = relay(
+      [
+        {
+          method: 'any',
+          url: '/*',
+        },
+      ],
+      config,
+    )(brokerToken);
+
+    const body = {
+      BROKER_VAR_SUB: ['url'],
+      url: '${HOST}:${PORT}/webhook',
+    };
+
+    route(
+      {
+        url: '/',
+        method: 'POST',
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        body: Buffer.from(JSON.stringify(body)),
+        headers: {},
+      },
+      () => {
+        expect(requestMock).toHaveBeenCalledTimes(1);
+        const arg = requestMock.mock.calls[0][0];
+        expect(JSON.parse(arg.body).url).toEqual('${HOST}:${PORT}/webhook');
 
         done();
       },


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adds couple of flags (disableBodyVarsSubstitution, disableHeaderVarsSubstitution) to disable variable replacement in some cases, to alleviate security concerns in some implementation with permissive filter rules.

#### How to use these flags?
When running, export disableHeaderVarsSubstitution=true and/or disableHeaderVarsSubstitution=true env vars to disable env var replacement in headers and/or body.