### PR TITLE
feat: get username from rest API

### DIFF
--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -987,9 +987,9 @@
       }
     },
     {
-      "//": "used to get current user. so we'll be able to fetch current user's repos, that are not part of any project. we're using atlassian's SDK api. Because atlassian's BB server rest api currently doesn't support such functionality",
+      "//": "used to get current user. so we'll be able to fetch current user's repos, that are not part of any project.",
       "method": "GET",
-      "path": "/plugins/servlet/applinks/whoami",
+      "path": "/rest/api/1.0/application-properties",
       "origin": "https://${BITBUCKET}",
       "auth": {
         "scheme": "basic",

--- a/test/unit/__snapshots__/runtime-rules-hotloading.test.ts.snap
+++ b/test/unit/__snapshots__/runtime-rules-hotloading.test.ts.snap
@@ -1387,7 +1387,7 @@ Object {
       "path": "/rest/insights/:apiVersion/projects/:project/repos/:repo/commits/:sha/reports/:report/annotations",
     },
     Object {
-      "//": "used to get current user. so we'll be able to fetch current user's repos, that are not part of any project. we're using atlassian's SDK api. Because atlassian's BB server rest api currently doesn't support such functionality",
+      "//": "used to get current user. so we'll be able to fetch current user's repos, that are not part of any project.",
       "auth": Object {
         "password": "\${BITBUCKET_PASSWORD}",
         "scheme": "basic",
@@ -1395,7 +1395,7 @@ Object {
       },
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
-      "path": "/plugins/servlet/applinks/whoami",
+      "path": "/rest/api/1.0/application-properties",
     },
     Object {
       "//": "used to get the current user's project-like structure. So we'll be able to bind all user's private repos (that are not included in different project)",
@@ -8018,7 +8018,7 @@ Object {
       "path": "/rest/insights/:apiVersion/projects/:project/repos/:repo/commits/:sha/reports/:report/annotations",
     },
     Object {
-      "//": "used to get current user. so we'll be able to fetch current user's repos, that are not part of any project. we're using atlassian's SDK api. Because atlassian's BB server rest api currently doesn't support such functionality",
+      "//": "used to get current user. so we'll be able to fetch current user's repos, that are not part of any project.",
       "auth": Object {
         "password": "\${BITBUCKET_PASSWORD}",
         "scheme": "basic",
@@ -8026,7 +8026,7 @@ Object {
       },
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
-      "path": "/plugins/servlet/applinks/whoami",
+      "path": "/rest/api/1.0/application-properties",
     },
     Object {
       "//": "used to get the current user's project-like structure. So we'll be able to bind all user's private repos (that are not included in different project)",
@@ -15075,7 +15075,7 @@ Object {
       "path": "/rest/insights/:apiVersion/projects/:project/repos/:repo/commits/:sha/reports/:report/annotations",
     },
     Object {
-      "//": "used to get current user. so we'll be able to fetch current user's repos, that are not part of any project. we're using atlassian's SDK api. Because atlassian's BB server rest api currently doesn't support such functionality",
+      "//": "used to get current user. so we'll be able to fetch current user's repos, that are not part of any project.",
       "auth": Object {
         "password": "\${BITBUCKET_PASSWORD}",
         "scheme": "basic",
@@ -15083,7 +15083,7 @@ Object {
       },
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
-      "path": "/plugins/servlet/applinks/whoami",
+      "path": "/rest/api/1.0/application-properties",
     },
     Object {
       "//": "used to get the current user's project-like structure. So we'll be able to bind all user's private repos (that are not included in different project)",
@@ -16250,7 +16250,7 @@ Object {
       "path": "/rest/insights/:apiVersion/projects/:project/repos/:repo/commits/:sha/reports/:report/annotations",
     },
     Object {
-      "//": "used to get current user. so we'll be able to fetch current user's repos, that are not part of any project. we're using atlassian's SDK api. Because atlassian's BB server rest api currently doesn't support such functionality",
+      "//": "used to get current user. so we'll be able to fetch current user's repos, that are not part of any project.",
       "auth": Object {
         "password": "\${BITBUCKET_PASSWORD}",
         "scheme": "basic",
@@ -16258,7 +16258,7 @@ Object {
       },
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
-      "path": "/plugins/servlet/applinks/whoami",
+      "path": "/rest/api/1.0/application-properties",
     },
     Object {
       "//": "used to get the current user's project-like structure. So we'll be able to bind all user's private repos (that are not included in different project)",
@@ -28127,7 +28127,7 @@ Object {
       "path": "/rest/insights/:apiVersion/projects/:project/repos/:repo/commits/:sha/reports/:report/annotations",
     },
     Object {
-      "//": "used to get current user. so we'll be able to fetch current user's repos, that are not part of any project. we're using atlassian's SDK api. Because atlassian's BB server rest api currently doesn't support such functionality",
+      "//": "used to get current user. so we'll be able to fetch current user's repos, that are not part of any project.",
       "auth": Object {
         "password": "\${BITBUCKET_PASSWORD}",
         "scheme": "basic",
@@ -28135,7 +28135,7 @@ Object {
       },
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
-      "path": "/plugins/servlet/applinks/whoami",
+      "path": "/rest/api/1.0/application-properties",
     },
     Object {
       "//": "used to get the current user's project-like structure. So we'll be able to bind all user's private repos (that are not included in different project)",
@@ -34637,7 +34637,7 @@ Object {
       "path": "/rest/insights/:apiVersion/projects/:project/repos/:repo/commits/:sha/reports/:report/annotations",
     },
     Object {
-      "//": "used to get current user. so we'll be able to fetch current user's repos, that are not part of any project. we're using atlassian's SDK api. Because atlassian's BB server rest api currently doesn't support such functionality",
+      "//": "used to get current user. so we'll be able to fetch current user's repos, that are not part of any project.",
       "auth": Object {
         "password": "\${BITBUCKET_PASSWORD}",
         "scheme": "basic",
@@ -34645,7 +34645,7 @@ Object {
       },
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
-      "path": "/plugins/servlet/applinks/whoami",
+      "path": "/rest/api/1.0/application-properties",
     },
     Object {
       "//": "used to get the current user's project-like structure. So we'll be able to bind all user's private repos (that are not included in different project)",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Introduce another endpoint for getting the current user and removing the previous endpoint for new brokers.
This is not a breaking change as the previous endpoint is still supported in BBS for existing brokers.
~To be merged in only once the bitbucket-server code is deployed - BBS is deployed~

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
