### PR TITLE
feat: upgrade dotenv to v16.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "bunyan": "^1.8.12",
     "camelcase": "^5.3.1",
     "clarify": "^2.0.0",
-    "dotenv": "^6.2.0",
+    "dotenv": "^16.0.3",
     "ejson": "^2.2.0",
     "engine.io": "^6.2.1",
     "engine.io-client": "^5.2.0",

--- a/test/fixtures/config/.env-multiline
+++ b/test/fixtures/config/.env-multiline
@@ -1,0 +1,10 @@
+VALUE_MULTILINE_DOUBLE_QUOTES="value
+multiline
+double
+quotes"
+
+VALUE_MULTILINE_SINGLE_QUOTES='value
+multiline
+single
+quotes'
+

--- a/test/fixtures/config/.env-singleline
+++ b/test/fixtures/config/.env-singleline
@@ -1,0 +1,4 @@
+BROKER_TOKEN=broker token
+BROKER_TOKEN_DOUBLE_QUOTES="broker token double quotes"
+BROKER_TOKEN_SINGLE_QUOTES='broker token single quotes'
+#BROKER_TOKEN_COMMENTED=broker token commented

--- a/test/helpers/fixtures.ts
+++ b/test/helpers/fixtures.ts
@@ -14,6 +14,10 @@ export class Fixtures {
     });
   }
 
+  static getPathToFixtures(directory: string): string {
+    return path.resolve(DEFAULT_FIXTURES_ROOT, directory);
+  }
+
   static getPathToClientFixtures(): string {
     return path.resolve(DEFAULT_FIXTURES_ROOT, 'client');
   }

--- a/test/unit/dotenv-parse.test.ts
+++ b/test/unit/dotenv-parse.test.ts
@@ -1,0 +1,37 @@
+const dotenv = require('dotenv');
+import { Fixtures } from '../helpers/fixtures';
+
+const envSingleLine = Fixtures.get(
+  '.env-singleline',
+  Fixtures.getPathToFixtures('config'),
+);
+const envMultiLine = Fixtures.get(
+  '.env-multiline',
+  Fixtures.getPathToFixtures('config'),
+);
+
+describe('dotenv', () => {
+  it('should correctly parse env file with singleline values', async () => {
+    const parsedConfig = dotenv.parse(envSingleLine);
+
+    expect(parsedConfig.BROKER_TOKEN).toEqual('broker token');
+    expect(parsedConfig.BROKER_TOKEN_DOUBLE_QUOTES).toEqual(
+      'broker token double quotes',
+    );
+    expect(parsedConfig.BROKER_TOKEN_SINGLE_QUOTES).toEqual(
+      'broker token single quotes',
+    );
+    expect(parsedConfig.BROKER_TOKEN_COMMENTED).toBeFalsy();
+  });
+
+  it('should correctly parse env file with multiline values', async () => {
+    const parsedConfig = dotenv.parse(envMultiLine);
+
+    expect(parsedConfig.VALUE_MULTILINE_DOUBLE_QUOTES).toEqual(
+      'value\nmultiline\ndouble\nquotes',
+    );
+    expect(parsedConfig.VALUE_MULTILINE_SINGLE_QUOTES).toEqual(
+      'value\nmultiline\nsingle\nquotes',
+    );
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR upgrades `dotenv` package to v16.0.3 and adds support for multiline values in .env files.


#### Where should the reviewer start?
Take a look on `tests/unit/dotenv-parse.test.ts` to see different test scenarios and config files. Later after refactoring `lib/config.js` this unit test will be refactored to cover config functionality and not "just" testing 3rd party lib.
