### PR TITLE
feat: protection for symlink attack vector in case commit signing is used [ED-258]

### DIFF
--- a/lib/client/scm/github/commit.ts
+++ b/lib/client/scm/github/commit.ts
@@ -11,16 +11,14 @@ export function isGitHubCreateCommitEndpoint(options: {
 }
 
 export function convertBodyToGitHubCommitPayload(
-  body: unknown,
+  body: string,
   options: {
     committerName: string;
     committerEmail: string;
   },
 ): GitHubCommitPayload {
-  const bodyAsString = convertBodyToStringIfNeeded(body);
-
   try {
-    const bodyAsJson = JSON.parse(bodyAsString);
+    const bodyAsJson = JSON.parse(body);
     return {
       message: bodyAsJson.message,
       tree: bodyAsJson.tree,
@@ -43,20 +41,6 @@ export function convertBodyToGitHubCommitPayload(
     );
   }
 }
-
-const convertBodyToStringIfNeeded = (body: unknown): string => {
-  if (isUint8Array(body)) {
-    return Buffer.from(body).toString();
-  } else if (typeof body === 'string' || body instanceof String) {
-    return body as string;
-  } else {
-    throw new Error('body must be string or Uint8Array');
-  }
-};
-
-const isUint8Array = (data: unknown): data is Uint8Array => {
-  return !!(data && data instanceof Uint8Array);
-};
 
 const convertToDate = (input: unknown): Date => {
   if (input && typeof input === 'string') {

--- a/lib/client/scm/github/errors.ts
+++ b/lib/client/scm/github/errors.ts
@@ -4,3 +4,17 @@ export class GitHubCommitParsingError extends Error {
     Object.setPrototypeOf(this, GitHubCommitParsingError.prototype);
   }
 }
+
+export class GitHubTreeParsingError extends Error {
+  constructor(message: string) {
+    super(message);
+    Object.setPrototypeOf(this, GitHubTreeParsingError.prototype);
+  }
+}
+
+export class GitHubTreeValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    Object.setPrototypeOf(this, GitHubTreeValidationError.prototype);
+  }
+}

--- a/lib/client/scm/github/tree.ts
+++ b/lib/client/scm/github/tree.ts
@@ -1,0 +1,45 @@
+import * as logger from '../../../log';
+import { GitHubTreeParsingError, GitHubTreeValidationError } from './errors';
+import type { GitHubTree, GitHubCreateTreePayload } from './types';
+
+export function isGitHubCreateTreeEndpoint(options: {
+  method: string;
+  url: string;
+}): boolean {
+  // https://docs.github.com/en/rest/git/trees?apiVersion=2022-11-28#create-a-tree
+  return options.method === 'POST' && options.url.includes('/git/trees');
+}
+
+export function convertBodyToGitHubTreePayload(
+  body: string,
+): GitHubCreateTreePayload {
+  try {
+    const bodyAsJson = JSON.parse(body);
+    return {
+      owner: bodyAsJson.owner,
+      repo: bodyAsJson.repo,
+      base_tree: bodyAsJson.base_tree,
+      tree: bodyAsJson.tree as GitHubTree[],
+    } satisfies GitHubCreateTreePayload;
+  } catch (error) {
+    logger.error({ error }, 'Could not parse GitHub create tree payload body');
+    throw new GitHubTreeParsingError(
+      'Could not parse GitHub create tree payload body',
+    );
+  }
+}
+
+export function validateForSymlinksInCreateTree(
+  createTree: GitHubCreateTreePayload,
+): void {
+  const treesWithSymlink = createTree.tree.filter(
+    (tree) => tree.mode === '120000' && tree.type === 'commit',
+  );
+
+  if (treesWithSymlink.length > 0) {
+    const paths = treesWithSymlink.map((tree) => tree.path).join(', ');
+    throw new GitHubTreeValidationError(
+      `Symlinks are not allowed in GitHub tree payload: ${paths}`,
+    );
+  }
+}

--- a/lib/client/scm/github/types.ts
+++ b/lib/client/scm/github/types.ts
@@ -12,3 +12,17 @@ export type GitUser = {
   email: string;
   date: Date;
 };
+
+export type GitHubCreateTreePayload = {
+  owner: string;
+  repo: string;
+  base_tree: string;
+  tree: GitHubTree[];
+};
+
+export type GitHubTree = {
+  content: string;
+  mode: '040000' | '100644' | '100755' | '120000' | '160000';
+  path: string;
+  type: 'blob' | 'commit' | 'tree';
+};

--- a/lib/client/scm/index.ts
+++ b/lib/client/scm/index.ts
@@ -72,7 +72,8 @@ export async function signGitHubCommit(
   config: any,
   body: unknown,
 ): Promise<string> {
-  const commit = convertBodyToGitHubCommitPayload(body, {
+  const bodyAsString = convertBodyToStringIfNeeded(body);
+  const commit = convertBodyToGitHubCommitPayload(bodyAsString, {
     committerName: (config as Config).GIT_COMMITTER_NAME,
     committerEmail: (config as Config).GIT_COMMITTER_EMAIL,
   });
@@ -93,3 +94,17 @@ export async function signGitHubCommit(
 
   return Promise.resolve(JSON.stringify(commit));
 }
+
+const convertBodyToStringIfNeeded = (body: unknown): string => {
+  if (isUint8Array(body)) {
+    return Buffer.from(body).toString();
+  } else if (typeof body === 'string' || body instanceof String) {
+    return body as string;
+  } else {
+    throw new Error('body must be string or Uint8Array');
+  }
+};
+
+const isUint8Array = (data: unknown): data is Uint8Array => {
+  return !!(data && data instanceof Uint8Array);
+};

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -15,8 +15,10 @@ const metrics = require('./metrics');
 const config = require('./config');
 const { BrokerServerPostResponseHandler } = require('./stream-posts');
 const {
-  githubCommitSigningEnabled,
+  gitHubCommitSigningEnabled,
+  gitHubTreeCheckNeeded,
   signGitHubCommit,
+  validateGitHubTreePayload,
 } = require('./client/scm');
 
 const RequestClass = request.Request;
@@ -562,7 +564,22 @@ function forwardWebSocketRequest(filterRules, config, io, serverId) {
         headers['connection'] = 'Keep-Alive';
         headers['Keep-Alive'] = 'timeout=60, max=1000';
 
-        if (githubCommitSigningEnabled(config, { method, url })) {
+        if (gitHubTreeCheckNeeded(config, { method, url })) {
+          try {
+            validateGitHubTreePayload(body);
+          } catch (error) {
+            logger.error(
+              { error },
+              'error while checking github tree payload for symlinks',
+            );
+            return emit({
+              status: 401,
+              body: error.message,
+            });
+          }
+        }
+
+        if (gitHubCommitSigningEnabled(config, { method, url })) {
           try {
             body = await signGitHubCommit(config, body);
           } catch (error) {

--- a/test/unit/client/scm/github/commit.test.ts
+++ b/test/unit/client/scm/github/commit.test.ts
@@ -46,27 +46,8 @@ describe('client/scm/github/commit.ts', () => {
   });
 
   describe('convertBodyToGitHubCommitPayload()', () => {
-    it('should throw an error when body is null', async () => {
-      expect(() =>
-        convertBodyToGitHubCommitPayload(null, {
-          committerName: '',
-          committerEmail: '',
-        }),
-      ).toThrowError('body must be string or Uint8Array');
-    });
-
-    it('should throw an error when body is not string', async () => {
-      expect(() =>
-        convertBodyToGitHubCommitPayload(123456, {
-          committerName: '',
-          committerEmail: '',
-        }),
-      ).toThrowError('body must be string or Uint8Array');
-    });
-
     it('should convert to github commit payload when body is correct', async () => {
-      const body = Uint8Array.from(
-        Buffer.from(`{
+      const body = `{
 "message": "fix: package.json & package-lock.json",
 "tree": "1111111111111111111111111111111111111111",
 "parents": [
@@ -82,8 +63,7 @@ describe('client/scm/github/commit.ts', () => {
   "email": "broker-test-user@example.com",
   "date": "2023-05-06T08:08:08.888Z"
 }
-}`),
-      );
+}`;
       const commitPayload = convertBodyToGitHubCommitPayload(body, {
         committerName: 'broker-test-user',
         committerEmail: 'broker-test-user@example.com',

--- a/test/unit/client/scm/github/tree.test.ts
+++ b/test/unit/client/scm/github/tree.test.ts
@@ -1,0 +1,154 @@
+import {
+  convertBodyToGitHubTreePayload,
+  isGitHubCreateTreeEndpoint,
+  validateForSymlinksInCreateTree,
+} from '../../../../../lib/client/scm/github/tree';
+import type { GitHubCreateTreePayload } from '../../../../../lib/client/scm/github/types';
+import { GitHubTreeValidationError } from '../../../../../lib/client/scm/github/errors';
+
+describe('client/scm/github/tree.ts', () => {
+  describe('isGitHubCreateTreeEndpoint()', () => {
+    const httpMethods = [
+      ['GET'],
+      ['HEAD'],
+      ['PUT'],
+      ['DELETE'],
+      ['CONNECT'],
+      ['OPTIONS'],
+      ['TRACE'],
+      ['PATCH'],
+    ];
+    it.each(httpMethods)(
+      'should return false for %s http method',
+      async (httpMethod) => {
+        expect(
+          isGitHubCreateTreeEndpoint({ method: httpMethod, url: 'some-url' }),
+        ).toEqual(false);
+      },
+    );
+
+    it('should return false for POST method and not create-tree endpoint', async () => {
+      expect(
+        isGitHubCreateTreeEndpoint({
+          method: 'POST',
+          url: 'non-create-tree-endpoint',
+        }),
+      ).toEqual(false);
+    });
+
+    it('should return true for POST method and create-tree endpoint', async () => {
+      expect(
+        isGitHubCreateTreeEndpoint({
+          method: 'POST',
+          url: 'https://api.github.com/owner/repo/git/trees',
+        }),
+      ).toEqual(true);
+    });
+  });
+
+  describe('convertBodyToGitHubTreePayload()', () => {
+    it('should convert to github tree payload when body is correct ', async () => {
+      const body = `{
+  "owner": "owner",
+  "repo": "repo",
+  "base_tree": "0000000000000000000000000000000000000000",
+  "tree": [
+    {
+      "path": "package.json",
+      "content":"bla-bla-bla",
+      "type":"commit",
+      "mode":"100644"
+    },
+    {
+      "path":"package-lock.json",
+      "content":"bla-bla-bla-lock",
+      "type":"commit",
+      "mode":"100644"
+    }
+  ]
+}
+`;
+      const treePayload = convertBodyToGitHubTreePayload(body);
+
+      expect(treePayload).toStrictEqual({
+        owner: 'owner',
+        repo: 'repo',
+        tree: [
+          {
+            path: 'package.json',
+            content: 'bla-bla-bla',
+            type: 'commit',
+            mode: '100644',
+          },
+          {
+            path: 'package-lock.json',
+            content: 'bla-bla-bla-lock',
+            type: 'commit',
+            mode: '100644',
+          },
+        ],
+        base_tree: '0000000000000000000000000000000000000000',
+      });
+    });
+  });
+
+  describe('validateForSymlinksInCreateTree()', () => {
+    it('should throw a validation error when tree contains symlinks', async () => {
+      const createTree = {
+        owner: 'owner',
+        repo: 'repo',
+        base_tree: '0000000000000000000000000000000000000000',
+        tree: [
+          {
+            path: 'aaa.txt',
+            content: 'content',
+            type: 'commit',
+            mode: '120000',
+          },
+          {
+            path: 'bbb.txt',
+            content: 'content',
+            type: 'commit',
+            mode: '100644',
+          },
+          {
+            path: 'ccc.txt',
+            content: 'content',
+            type: 'commit',
+            mode: '120000',
+          },
+        ],
+      } satisfies GitHubCreateTreePayload;
+
+      expect(() => validateForSymlinksInCreateTree(createTree)).toThrowError(
+        GitHubTreeValidationError,
+      );
+    });
+
+    it('should not throw a validation error when tree has no symlinks', async () => {
+      const createTree = {
+        owner: 'owner',
+        repo: 'repo',
+        base_tree: '0000000000000000000000000000000000000000',
+        tree: [
+          {
+            path: 'aaa.txt',
+            content: 'content',
+            type: 'commit',
+            mode: '100644',
+          },
+          {
+            path: 'bbb.txt',
+            content: 'content',
+            type: 'commit',
+            mode: '100755',
+          },
+        ],
+      } satisfies GitHubCreateTreePayload;
+
+      expect(() =>
+        validateForSymlinksInCreateTree(createTree),
+      ).not.toThrowError(GitHubTreeValidationError);
+    });
+  });
+});

--- a/test/unit/client/scm/scm.test.ts
+++ b/test/unit/client/scm/scm.test.ts
@@ -1,5 +1,8 @@
 import { aConfig } from '../../../helpers/test-factories';
-import { commitSigningEnabled } from '../../../../lib/client/scm';
+import {
+  commitSigningEnabled,
+  signGitHubCommit,
+} from '../../../../lib/client/scm';
 
 describe('client/scm', () => {
   describe('commitSigningEnabled()', () => {
@@ -100,6 +103,20 @@ describe('client/scm', () => {
       });
 
       expect(commitSigningEnabled(config)).toEqual(false);
+    });
+  });
+
+  describe('signGitHubCommit()', () => {
+    it('should throw an error when body is null', async () => {
+      await expect(signGitHubCommit({}, null)).rejects.toThrowError(
+        'body must be string or Uint8Array',
+      );
+    });
+
+    it('should throw an error when body is not string', async () => {
+      await expect(signGitHubCommit({}, 123456)).rejects.toThrowError(
+        'body must be string or Uint8Array',
+      );
     });
   });
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR adds a protection for symlink attack vector in case of commit signing and throws an exception if `mode: 120000` is used in tree array.

GitHub documentation for tree object: https://docs.github.com/en/rest/git/trees?apiVersion=2022-11-28#create-a-tree

#### Additional info for reviewer
Because body parsing is needed to convert commit-signing and create-tree, method `convertBodyToStringIfNeeded()` is extracted and moved to the `lib/client/scm/index.ts` file. All tests are refactored as well.