### PR TITLE
fix(commit-signing): normalize armored key if needed

### DIFF
--- a/lib/client/scm/index.ts
+++ b/lib/client/scm/index.ts
@@ -9,7 +9,7 @@ import {
   isGitHubCreateTreeEndpoint,
   validateForSymlinksInCreateTree,
 } from './github/tree';
-import { createSignature } from './pgp/sign';
+import { createSignature, normalizeArmoredKeyIfNeeded } from './pgp/sign';
 import { getCommitSigningGitHubFilterRules } from './github/commit-signing-filter-rules';
 import type { Config } from '../config';
 import type { FilterRule } from './types';
@@ -99,10 +99,14 @@ export async function signGitHubCommit(
 
   const messageRaw = stringifyGitHubCommitPayload(commit);
   logger.debug({ messageRaw }, 'raw message before creating pgp signature');
+
+  const armoredKey = normalizeArmoredKeyIfNeeded(
+    (config as Config).GPG_PRIVATE_KEY,
+  );
   const signature = await createSignature({
     messageRaw: messageRaw,
     privateKey: {
-      armoredKey: (config as Config).GPG_PRIVATE_KEY,
+      armoredKey,
       passphrase: (config as Config).GPG_PASSPHRASE,
     },
   });

--- a/lib/client/scm/pgp/sign.ts
+++ b/lib/client/scm/pgp/sign.ts
@@ -39,3 +39,10 @@ export function validatePrivateKey(pgpPrivateKey: PgpPrivateKey): void {
     throw new PgpPrivateKeyValidationError('missing END PGP PRIVATE KEY BLOCK');
   }
 }
+
+export function normalizeArmoredKeyIfNeeded(armoredKey: string): string {
+  // passing env vars for Docker containers appends additional backslash
+  // for already escaped values (e.g. will be \n -> \\n), this leads to
+  // "misformed armor key" error from openpgp library
+  return armoredKey.replace(/\\n/g, '\n');
+}

--- a/test/unit/client/scm/pgp/sign.test.ts
+++ b/test/unit/client/scm/pgp/sign.test.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import {
   createSignature,
+  normalizeArmoredKeyIfNeeded,
   validatePrivateKey,
 } from '../../../../../lib/client/scm/pgp/sign';
 import { Fixtures } from '../../../../helpers/fixtures';
@@ -67,6 +68,28 @@ invalid-openpgp-format-text
       const armoredKey = `-----BEGIN PGP PRIVATE KEY BLOCK-----\n\nabcdef`;
       expect(() => validatePrivateKey({ armoredKey })).toThrowError(
         new PgpPrivateKeyValidationError('missing END PGP PRIVATE KEY BLOCK'),
+      );
+    });
+  });
+
+  describe('normalizeArmoredKeyIfNeeded()', () => {
+    it('should replace double backslashes with single backslashes for line endings', async () => {
+      const armoredKey = `-----BEGIN PGP PRIVATE KEY BLOCK-----\\n\nabcdef`;
+
+      const normalizedArmorKey = normalizeArmoredKeyIfNeeded(armoredKey);
+
+      expect(normalizedArmorKey).toStrictEqual(
+        `-----BEGIN PGP PRIVATE KEY BLOCK-----\n\nabcdef`,
+      );
+    });
+
+    it('should replace all occurrences of double backslashes for line endings', async () => {
+      const armoredKey = `-----BEGIN PGP PRIVATE KEY BLOCK-----\\n\\na\\nb`;
+
+      const normalizedArmorKey = normalizeArmoredKeyIfNeeded(armoredKey);
+
+      expect(normalizedArmorKey).toStrictEqual(
+        `-----BEGIN PGP PRIVATE KEY BLOCK-----\n\na\nb`,
       );
     });
   });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR fixes the issue with "misformed armored key" and normalizes pgp private key if needed.

It happens if multi-line envvar will be passed to Docker via `-e FOO=BAR\nBAR` option. Then `FOO` gets `BAR\\nBAR` value.

#### Additional links:
- https://github.com/moby/moby/issues/32140