### PR TITLE
feat: send token prefix to disp for HA tunnel alloc fallbk stratgy

### DIFF
--- a/lib/client/dispatcher/client/api.ts
+++ b/lib/client/dispatcher/client/api.ts
@@ -29,6 +29,7 @@ export class HttpDispatcherServiceClient implements DispatcherServiceClient {
           data: {
             attributes: {
               deployment_location: data.deployment_location,
+              broker_token_first_char: data.broker_token_first_char,
             },
           },
         },

--- a/lib/client/dispatcher/dispatcher-service.ts
+++ b/lib/client/dispatcher/dispatcher-service.ts
@@ -1,5 +1,6 @@
 export type CreateConnectionRequestData = {
   deployment_location: string;
+  broker_token_first_char: string;
 };
 
 export type CreateConnectionRequestParams = {
@@ -23,8 +24,7 @@ export interface DispatcherServiceClient {
 export async function getServerIdFromDispatcher(
   client: DispatcherServiceClient,
   params: CreateConnectionRequestParams,
+  data: CreateConnectionRequestData,
 ): Promise<ServerId> {
-  return await client.createConnection(params, {
-    deployment_location: 'snyk-broker-client',
-  });
+  return await client.createConnection(params, data);
 }

--- a/lib/client/dispatcher/index.ts
+++ b/lib/client/dispatcher/index.ts
@@ -46,10 +46,19 @@ export async function getServerId(
   const maxRetries = 30;
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
-      return await getServerIdFromDispatcher(client, {
-        brokerClientId: brokerClientId,
-        hashedBrokerToken: hashedToken,
-      });
+      return await getServerIdFromDispatcher(
+        client,
+        {
+          brokerClientId: brokerClientId,
+          hashedBrokerToken: hashedToken,
+        },
+        {
+          deployment_location: `${
+            config.BROKER_CLIENT_LOCATION || 'snyk-broker-client'
+          }`,
+          broker_token_first_char: `${config.BROKER_TOKEN[0]}`,
+        },
+      );
     } catch (err) {
       const timeout = 2 ** attempt * 100;
       logger.warn(

--- a/test/functional/dispatcher-client-api.test.ts
+++ b/test/functional/dispatcher-client-api.test.ts
@@ -31,7 +31,7 @@ describe('Broker Dispatcher API client', () => {
           hashedBrokerToken: hashedToken,
           brokerClientId: '1',
         },
-        { deployment_location: 'test' },
+        { deployment_location: 'test', broker_token_first_char: 'a' },
       );
     } catch (err) {
       expect(err).toEqual(Error('Error getting connection allocation.'));
@@ -59,7 +59,7 @@ describe('Broker Dispatcher API client', () => {
         hashedBrokerToken: hashedToken,
         brokerClientId: '1',
       },
-      { deployment_location: 'test' },
+      { deployment_location: 'test', broker_token_first_char: 'a' },
     );
 
     expect(serverId).toEqual('server-id-from-dispatcher');

--- a/test/unit/client/dispatcher/dispatcher.test.ts
+++ b/test/unit/client/dispatcher/dispatcher.test.ts
@@ -1,6 +1,36 @@
+const nock = require('nock');
 import { getServerId } from '../../../../lib/client/dispatcher';
 
+const serverUrl = 'http://broker-server-dispatcher';
+
 describe('Dispatcher', () => {
+  beforeAll(async () => {
+    nock(`${serverUrl}`)
+      .persist()
+      .post(
+        `/hidden/broker/ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad/connections/random-client-id?version=2022-12-01~experimental`,
+        (requestBody) => {
+          return (
+            requestBody.data.attributes.deployment_location.length > 0 &&
+            requestBody.data.attributes.broker_token_first_char == 'a'
+          );
+        },
+      )
+
+      .reply((uri, requestBody) => {
+        const response = {
+          data: {
+            attributes: {
+              server_id: `${
+                JSON.parse(requestBody).data.attributes.deployment_location
+              }`,
+            },
+          },
+        };
+        return [200, response];
+      });
+  });
+
   it('getServerId without broker token should throw an error', async () => {
     const expectedError = new Error(
       'BROKER_TOKEN is required to successfully identify itself to the server',
@@ -8,9 +38,36 @@ describe('Dispatcher', () => {
     expectedError.name = 'MISSING_BROKER_TOKEN';
 
     try {
-      await getServerId({}, 'random-client-it');
+      await getServerId({}, 'random-client-id');
     } catch (error) {
       expect(error).toStrictEqual(expectedError);
+    }
+  });
+  it('getServerId valid request dispatcher request', async () => {
+    try {
+      const serverId = await getServerId(
+        {
+          BROKER_DISPATCHER_BASE_URL: serverUrl,
+          BROKER_TOKEN: 'abc',
+          BROKER_CLIENT_LOCATION: 'random cluster',
+        },
+        'random-client-id',
+      );
+      expect(serverId).toEqual('random cluster');
+    } catch (error) {
+      expect(error).toBeNull();
+    }
+  });
+
+  it('getServerId valid request dispatcher request without location', async () => {
+    try {
+      const serverId = await getServerId(
+        { BROKER_DISPATCHER_BASE_URL: serverUrl, BROKER_TOKEN: 'abc' },
+        'random-client-id',
+      );
+      expect(serverId).toEqual('snyk-broker-client');
+    } catch (error) {
+      expect(error).toBeNull();
     }
   });
 });


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

**Applies to High Availability Mode only**

Adds the first character of the broker token in the call to Broker Dispatcher for HA mode tunnel allocation to support a prefix-based fallback strategy.
Also starting to send non generic deployment location so it is easier to know where the broker client is running.