### PR TITLE
fix: properly structure qs params in dispatcher calls

### DIFF
--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -49,17 +49,22 @@ class DispatcherClient {
     time = -1,
   ) {
     const hashedToken = hashToken(token);
-    let queryStringParams = clientId
-      ? `?broker_client_id=${clientId}&request_type=${requestType}`
-      : '';
-    if (time != -1) {
-      queryStringParams = queryStringParams + `&latency=${Date.now() - time}`;
-    }
-    await this.#makeRequest(
-      { hashedToken, clientId, requestType: requestType },
+    const url = new URL(
       `${this.#url}/internal/brokerservers/${
         this.#id
-      }/connections/${hashedToken}${queryStringParams}`,
+      }/connections/${hashedToken}`,
+    );
+    if (clientId) {
+      url.searchParams.append('broker_client_id', clientId);
+    }
+    if (time != -1) {
+      url.searchParams.append('latency', Date.now() - time);
+    }
+    url.searchParams.append('request_type', requestType);
+
+    await this.#makeRequest(
+      { hashedToken, clientId, requestType: requestType },
+      url.toString(),
       'post',
       {
         data: {


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Handles the query string parameters properly.