### PR TITLE
chore: add tracing for tracking disp retries

### DIFF
--- a/lib/axios.ts
+++ b/lib/axios.ts
@@ -3,15 +3,16 @@ const logger = require('./log');
 import axiosRetry from 'axios-retry';
 
 const axiosInstance = axios.create({
-  timeout: 5000,
+  timeout: 2500,
 });
 
 axiosRetry(axiosInstance, {
   retries: 3,
   retryCondition: () => true, // retry no matter what
+  shouldResetTimeout: true,
   retryDelay: axiosRetry.exponentialDelay,
   onRetry: (retryCount, error, requestConfig) => {
-    if (error) {
+    if (retryCount > 2) {
       logger.warn(
         {
           retryCount,
@@ -20,7 +21,7 @@ axiosRetry(axiosInstance, {
           requestId:
             requestConfig.headers && requestConfig.headers['Snyk-Request-Id'],
         },
-        'retrying request',
+        `retrying request x ${retryCount} `,
       );
     }
   },

--- a/test/functional/dispatcher-server-api.test.ts
+++ b/test/functional/dispatcher-server-api.test.ts
@@ -120,14 +120,13 @@ describe('Broker Server Dispatcher API interaction', () => {
       await expect(
         dispatcher.clientConnected(token, clientId, clientVersion),
       ).resolves.not.toThrowError();
-      expect(spyLogWarn).toHaveBeenCalledTimes(3);
-      for (let i = 0; i < 3; i++) {
-        const output = spyLogWarn.mock.calls[i][0] as Object;
-        expect(output['errorMessage']).toEqual(
-          'Request failed with status code 500',
-        );
-        expect(output['retryCount']).toEqual(i + 1);
-      }
+      expect(spyLogWarn).toHaveBeenCalledTimes(1);
+
+      const output = spyLogWarn.mock.calls[0][0] as Object;
+      expect(output['errorMessage']).toEqual(
+        'Request failed with status code 500',
+      );
+      expect(output['retryCount']).toEqual(3);
 
       expect(spyLogError).toBeCalledTimes(1);
       const errorOutput = spyLogError.mock.calls[0][0] as Object;


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Lowers timeout value for dispatcher notifications and log retries failure more clearly.

#### Any background context you want to provide?
Some very sporadic network communication errors appeared in logs. Attempting to log these more clearly to investigate further.