### PR TITLE
chore: add secrets-scan step for circleci [ED-262]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  prodsec: snyk/prodsec-orb@1.0
+
 defaults: &defaults
   docker:
     - image: cimg/node:18.16.0
@@ -76,12 +79,20 @@ workflows:
           name: Lint
           requires:
             - Install DEV
+      - prodsec/secrets-scan:
+          name: Scan repository for secrets
+          context:
+            - snyk-bot-slack
+          requires:
+            - Install DEV
+          channel: broker-alerts
       - release:
           name: Release to GitHub
           context: nodejs-lib-release
           requires:
             - Test
             - Lint
+            - Scan repository for secrets
           filters:
             branches:
               only:

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,14 @@
+[extend]
+useDefault = true
+
+[allowlist]
+description = "global allow list"
+paths = [
+  'test/*',
+]
+
+commits = [
+  # false positive for pgp prefix and suffix blocks
+  "555fe920c97af38fa78a875fbb858d5588a6ec80",
+  "a8335efefaa9f483294554c5086702457b735651",
+]


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR adds a secrets-scan step for CircleCI.
The commits with false positives are ignored:
- auto-generated values in `test/`folder
- pgp prefix and suffix pattern to detect and validate signatures