### PR TITLE
fix: rm indir debug pkg to satisfy scanners reporting fp

### DIFF
--- a/dockerfiles/github-com/Dockerfile
+++ b/dockerfiles/github-com/Dockerfile
@@ -22,6 +22,9 @@ COPY --from=base /home/node/.npm-global /home/node/.npm-global
 
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
+# Removing debug@0.7.4 (setheader transitive) to satisfy some scanners still reporting this false positive
+RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/setheader/node_modules/debug
+
 # Don't run as root
 WORKDIR /home/node
 USER node


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Drops unused transitive package triggering false positives in some scanners.
