### PR TITLE
fix: update Node.js to v18.16.1

### DIFF
--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -8,7 +8,7 @@ RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node \
   && apt update && apt upgrade -y && apt install gpg curl xz-utils -y
 
-ENV NODE_VERSION 18.16.0
+ENV NODE_VERSION 18.16.1
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/dockerfiles/ubuntu/Dockerfile.nlatest
+++ b/dockerfiles/ubuntu/Dockerfile.nlatest
@@ -8,7 +8,7 @@ RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node \
   && apt update && apt upgrade -y && apt install gpg curl xz-utils -y
 
-ENV NODE_VERSION 20.0.0
+ENV NODE_VERSION 20.4.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/package.json
+++ b/package.json
@@ -114,6 +114,6 @@
     "outputPath": "binary-releases"
   },
   "volta": {
-    "node": "18.16.0"
+    "node": "18.16.1"
   }
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR updates Node.js version in Docker images:
- v18.16.1. Security release from Node.js: https://github.com/nodejs/node/releases/tag/v18.16.1
- v20.4.0 for nlatest
