### PR TITLE
feat: add downstream timeout customization

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -2,6 +2,7 @@
     "BROKER_BOOT_MODE": "classic",
     "BROKER_SERVER_URL": "https://broker.snyk.io",
     "BROKER_HEALTHCHECK_PATH": "/healthcheck",
+    "BROKER_DOWNSTREAM_TIMEOUT": "60000",
     "ACCEPT_LARGE_MANIFESTS": "false",
     "ARTIFACTORY": {
         "BROKER_CLIENT_VALIDATION_URL":"https://$ARTIFACTORY_URL/api/system/ping",

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -25,7 +25,7 @@ const {
 const RequestClass = request.Request;
 request = request.defaults({
   ca: config.caCert,
-  timeout: 60000,
+  timeout: parseInt(config.BROKER_DOWNSTREAM_TIMEOUT) || 60000,
   agentOptions: {
     keepAlive: true,
     keepAliveMsecs: 60000,

--- a/test/unit/config-timeout.test.ts
+++ b/test/unit/config-timeout.test.ts
@@ -1,0 +1,8 @@
+describe('config custom timeout', () => {
+  it('contain custom timeout', () => {
+    process.env.BROKER_DOWNSTREAM_TIMEOUT = '120000';
+    const config2 = require('../../lib/config');
+    expect(config2.BROKER_DOWNSTREAM_TIMEOUT).toEqual('120000');
+    delete process.env.BROKER_DOWNSTREAM_TIMEOUT;
+  });
+});

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -10,6 +10,7 @@ describe('config', () => {
     process.env.GITHUB_USERNAME = 'git';
     process.env.GITHUB_PASSWORD_POOL = '9012, 3456';
     process.env.GITHUB_AUTH = 'Basic $GITHUB_USERNAME:$GITHUB_PASSWORD';
+
     const complexToken = (process.env.COMPLEX_TOKEN = '1234$$%#@!$!$@$$$');
 
     const config = require('../../lib/config');
@@ -27,5 +28,6 @@ describe('config', () => {
       'Basic git:9012',
       'Basic git:3456',
     ]);
+    expect(config.BROKER_DOWNSTREAM_TIMEOUT).toEqual('60000');
   });
 });


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Allows timeout customization between the Broker client and the downstream system (SCM, JIRA, etc..)

#### Where should the reviewer start?
 Had to split the test cases in 2 files to avoid overlap with process.env.
