### PR TITLE
chore(circleci): execute release workflow on tags only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              only: master
+              ignore: /.*/
 
       - build-and-push-docker-image:
           name: Build snyk/ubuntu image
@@ -161,7 +161,7 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              only: master
+              ignore: /.*/
 
       - build-and-push-docker-image:
           name: Build snyk/ubuntu image (nlatest)
@@ -175,7 +175,7 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              only: master
+              ignore: /.*/
 
       - build-and-push-docker-image:
           name: Build artifactory image (nlatest)
@@ -189,7 +189,7 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              only: master
+              ignore: /.*/
 
       - build-and-push-docker-image:
           name: Build jira image (nlatest)
@@ -203,4 +203,4 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              only: master
+              ignore: /.*/


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR fixes CircleCI issue when "Release Docker images" workflow was executed on `master` branch without tags. Now the workflow is executed on tags only.

CircleCI documentation: https://circleci.com/docs/workflows/#executing-workflows-for-a-git-tag

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
