### PR TITLE
Override tough-cookie to latest version that does not have vulns

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,9 @@
     "undefsafe": "^2.0.2",
     "uuid": "^8.1.0"
   },
+  "overrides": {
+    "tough-cookie": "4.1.3"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/snyk/broker.git"


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Overrides `tough-cookie` to the [latest release (4.1.3)](https://github.com/salesforce/tough-cookie/releases/tag/v4.1.3), used by the deprecated `requests` library. Fixes #579

#### How should this be manually tested?
@mihaibuzgau will tests it...

#### Any background context you want to provide?

`requests` depends on an outdated version but that library is deprecated so we need to fix manually

#### Snyk test results

before:
```
Issues with no direct upgrade or patch:
  ✗ Server-side Request Forgery (SSRF) [Medium Severity][https://security.snyk.io/vuln/SNYK-JS-REQUEST-3361831] in request@2.88.2
    introduced by request@2.88.2
  No upgrade or patch available
  ✗ Prototype Pollution [Medium Severity][https://security.snyk.io/vuln/SNYK-JS-TOUGHCOOKIE-5672873] in tough-cookie@2.5.0
    introduced by request@2.88.2 > tough-cookie@2.5.0 and 1 other path(s)
  This issue was fixed in versions: 4.1.3
```

after: 
```
Issues with no direct upgrade or patch:
  ✗ Server-side Request Forgery (SSRF) [Medium Severity][https://security.snyk.io/vuln/SNYK-JS-REQUEST-3361831] in request@2.88.2
    introduced by request@2.88.2
  No upgrade or patch available
```


#### Additional notes

- similar PR in the deprecated repo: https://github.com/request/request/pull/3461
