### PR TITLE
fix: rm tough-cookie vuln

### DIFF
--- a/dockerfiles/artifactory/Dockerfile
+++ b/dockerfiles/artifactory/Dockerfile
@@ -14,7 +14,9 @@ RUN npm install --global snyk-broker
 
 # Removing debug@0.7.4 (setheader transitive) to satisfy some scanners still reporting this false positive
 RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/setheader/node_modules/debug
-
+RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/tough-cookie
+RUN npm i -g tough-cookie@4.1.3
+RUN mv /home/node/.npm-global/lib/node_modules/tough-cookie /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules
 
 FROM snyk/ubuntu
 

--- a/dockerfiles/artifactory/Dockerfile.nlatest
+++ b/dockerfiles/artifactory/Dockerfile.nlatest
@@ -14,7 +14,9 @@ RUN npm install --global snyk-broker
 
 # Removing debug@0.7.4 (setheader transitive) to satisfy some scanners still reporting this false positive
 RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/setheader/node_modules/debug
-
+RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/tough-cookie
+RUN npm i -g tough-cookie@4.1.3
+RUN mv /home/node/.npm-global/lib/node_modules/tough-cookie /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules
 
 FROM snyk/ubuntu:nlatest
 

--- a/dockerfiles/azure-repos/Dockerfile
+++ b/dockerfiles/azure-repos/Dockerfile
@@ -14,7 +14,9 @@ RUN npm install --global snyk-broker
 
 # Removing debug@0.7.4 (setheader transitive) to satisfy some scanners still reporting this false positive
 RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/setheader/node_modules/debug
-
+RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/tough-cookie
+RUN npm i -g tough-cookie@4.1.3
+RUN mv /home/node/.npm-global/lib/node_modules/tough-cookie /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules
 
 FROM snyk/ubuntu
 

--- a/dockerfiles/azure-repos/Dockerfile.nlatest
+++ b/dockerfiles/azure-repos/Dockerfile.nlatest
@@ -14,7 +14,9 @@ RUN npm install --global snyk-broker
 
 # Removing debug@0.7.4 (setheader transitive) to satisfy some scanners still reporting this false positive
 RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/setheader/node_modules/debug
-
+RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/tough-cookie
+RUN npm i -g tough-cookie@4.1.3
+RUN mv /home/node/.npm-global/lib/node_modules/tough-cookie /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules
 
 FROM snyk/ubuntu:nlatest
 

--- a/dockerfiles/bitbucket-server/Dockerfile
+++ b/dockerfiles/bitbucket-server/Dockerfile
@@ -14,7 +14,9 @@ RUN npm install --global snyk-broker
 
 # Removing debug@0.7.4 (setheader transitive) to satisfy some scanners still reporting this false positive
 RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/setheader/node_modules/debug
-
+RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/tough-cookie
+RUN npm i -g tough-cookie@4.1.3
+RUN mv /home/node/.npm-global/lib/node_modules/tough-cookie /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules
 
 FROM snyk/ubuntu
 

--- a/dockerfiles/bitbucket-server/Dockerfile.nlatest
+++ b/dockerfiles/bitbucket-server/Dockerfile.nlatest
@@ -14,7 +14,9 @@ RUN npm install --global snyk-broker
 
 # Removing debug@0.7.4 (setheader transitive) to satisfy some scanners still reporting this false positive
 RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/setheader/node_modules/debug
-
+RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/tough-cookie
+RUN npm i -g tough-cookie@4.1.3
+RUN mv /home/node/.npm-global/lib/node_modules/tough-cookie /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules
 
 FROM snyk/ubuntu:nlatest
 

--- a/dockerfiles/container-registry-agent/Dockerfile
+++ b/dockerfiles/container-registry-agent/Dockerfile
@@ -14,7 +14,9 @@ RUN npm install --global snyk-broker
 
 # Removing debug@0.7.4 (setheader transitive) to satisfy some scanners still reporting this false positive
 RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/setheader/node_modules/debug
-
+RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/tough-cookie
+RUN npm i -g tough-cookie@4.1.3
+RUN mv /home/node/.npm-global/lib/node_modules/tough-cookie /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules
 
 FROM node:16-alpine3.16
 

--- a/dockerfiles/github-com/Dockerfile
+++ b/dockerfiles/github-com/Dockerfile
@@ -14,7 +14,9 @@ RUN npm install --global snyk-broker
 
 # Removing debug@0.7.4 (setheader transitive) to satisfy some scanners still reporting this false positive
 RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/setheader/node_modules/debug
-
+RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/tough-cookie
+RUN npm i -g tough-cookie@4.1.3
+RUN mv /home/node/.npm-global/lib/node_modules/tough-cookie /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules
 
 FROM snyk/ubuntu
 

--- a/dockerfiles/github-com/Dockerfile.nlatest
+++ b/dockerfiles/github-com/Dockerfile.nlatest
@@ -14,7 +14,9 @@ RUN npm install --global snyk-broker
 
 # Removing debug@0.7.4 (setheader transitive) to satisfy some scanners still reporting this false positive
 RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/setheader/node_modules/debug
-
+RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/tough-cookie
+RUN npm i -g tough-cookie@4.1.3
+RUN mv /home/node/.npm-global/lib/node_modules/tough-cookie /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules
 
 FROM snyk/ubuntu:nlatest
 

--- a/dockerfiles/github-enterprise/Dockerfile
+++ b/dockerfiles/github-enterprise/Dockerfile
@@ -14,7 +14,9 @@ RUN npm install --global snyk-broker
 
 # Removing debug@0.7.4 (setheader transitive) to satisfy some scanners still reporting this false positive
 RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/setheader/node_modules/debug
-
+RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/tough-cookie
+RUN npm i -g tough-cookie@4.1.3
+RUN mv /home/node/.npm-global/lib/node_modules/tough-cookie /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules
 
 FROM snyk/ubuntu
 

--- a/dockerfiles/github-enterprise/Dockerfile.nlatest
+++ b/dockerfiles/github-enterprise/Dockerfile.nlatest
@@ -14,7 +14,9 @@ RUN npm install --global snyk-broker
 
 # Removing debug@0.7.4 (setheader transitive) to satisfy some scanners still reporting this false positive
 RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/setheader/node_modules/debug
-
+RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/tough-cookie
+RUN npm i -g tough-cookie@4.1.3
+RUN mv /home/node/.npm-global/lib/node_modules/tough-cookie /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules
 
 FROM snyk/ubuntu:nlatest
 

--- a/dockerfiles/gitlab/Dockerfile
+++ b/dockerfiles/gitlab/Dockerfile
@@ -14,7 +14,9 @@ RUN npm install --global snyk-broker
 
 # Removing debug@0.7.4 (setheader transitive) to satisfy some scanners still reporting this false positive
 RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/setheader/node_modules/debug
-
+RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/tough-cookie
+RUN npm i -g tough-cookie@4.1.3
+RUN mv /home/node/.npm-global/lib/node_modules/tough-cookie /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules
 
 FROM snyk/ubuntu
 

--- a/dockerfiles/gitlab/Dockerfile.nlatest
+++ b/dockerfiles/gitlab/Dockerfile.nlatest
@@ -14,7 +14,9 @@ RUN npm install --global snyk-broker
 
 # Removing debug@0.7.4 (setheader transitive) to satisfy some scanners still reporting this false positive
 RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/setheader/node_modules/debug
-
+RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/tough-cookie
+RUN npm i -g tough-cookie@4.1.3
+RUN mv /home/node/.npm-global/lib/node_modules/tough-cookie /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules
 
 FROM snyk/ubuntu:nlatest
 

--- a/dockerfiles/jira/Dockerfile
+++ b/dockerfiles/jira/Dockerfile
@@ -14,7 +14,9 @@ RUN npm install --global snyk-broker
 
 # Removing debug@0.7.4 (setheader transitive) to satisfy some scanners still reporting this false positive
 RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/setheader/node_modules/debug
-
+RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/tough-cookie
+RUN npm i -g tough-cookie@4.1.3
+RUN mv /home/node/.npm-global/lib/node_modules/tough-cookie /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules
 
 FROM snyk/ubuntu
 

--- a/dockerfiles/jira/Dockerfile.nlatest
+++ b/dockerfiles/jira/Dockerfile.nlatest
@@ -14,7 +14,9 @@ RUN npm install --global snyk-broker
 
 # Removing debug@0.7.4 (setheader transitive) to satisfy some scanners still reporting this false positive
 RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/setheader/node_modules/debug
-
+RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/tough-cookie
+RUN npm i -g tough-cookie@4.1.3
+RUN mv /home/node/.npm-global/lib/node_modules/tough-cookie /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules
 
 FROM snyk/ubuntu:nlatest
 

--- a/dockerfiles/nexus/Dockerfile
+++ b/dockerfiles/nexus/Dockerfile
@@ -14,7 +14,9 @@ RUN npm install --global snyk-broker
 
 # Removing debug@0.7.4 (setheader transitive) to satisfy some scanners still reporting this false positive
 RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/setheader/node_modules/debug
-
+RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/tough-cookie
+RUN npm i -g tough-cookie@4.1.3
+RUN mv /home/node/.npm-global/lib/node_modules/tough-cookie /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules
 
 FROM snyk/ubuntu
 

--- a/dockerfiles/nexus/Dockerfile.nlatest
+++ b/dockerfiles/nexus/Dockerfile.nlatest
@@ -12,6 +12,11 @@ ENV PATH=$PATH:/home/node/.npm-global/bin
 
 RUN npm install --global snyk-broker
 
+# Removing debug@0.7.4 (setheader transitive) to satisfy some scanners still reporting this false positive
+RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/setheader/node_modules/debug
+RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/tough-cookie
+RUN npm i -g tough-cookie@4.1.3
+RUN mv /home/node/.npm-global/lib/node_modules/tough-cookie /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules
 
 
 FROM snyk/ubuntu:nlatest

--- a/dockerfiles/nexus2/Dockerfile
+++ b/dockerfiles/nexus2/Dockerfile
@@ -12,6 +12,11 @@ ENV PATH=$PATH:/home/node/.npm-global/bin
 
 RUN npm install --global snyk-broker
 
+# Removing debug@0.7.4 (setheader transitive) to satisfy some scanners still reporting this false positive
+RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/setheader/node_modules/debug
+RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/tough-cookie
+RUN npm i -g tough-cookie@4.1.3
+RUN mv /home/node/.npm-global/lib/node_modules/tough-cookie /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules
 
 
 FROM snyk/ubuntu

--- a/dockerfiles/nexus2/Dockerfile.nlatest
+++ b/dockerfiles/nexus2/Dockerfile.nlatest
@@ -14,6 +14,9 @@ RUN npm install --global snyk-broker
 
 # Removing debug@0.7.4 (setheader transitive) to satisfy some scanners still reporting this false positive
 RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/setheader/node_modules/debug
+RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/tough-cookie
+RUN npm i -g tough-cookie@4.1.3
+RUN mv /home/node/.npm-global/lib/node_modules/tough-cookie /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules
 
 
 FROM snyk/ubuntu:nlatest


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Removes tough cookie from code, swapping it out by 4.1.3. The npm override didn't actually worked after dedupping.