### PR TITLE
fix: not send empty server id qs

### DIFF
--- a/lib/stream-posts.js
+++ b/lib/stream-posts.js
@@ -48,7 +48,10 @@ class BrokerServerPostResponseHandler {
         this.#streamingId
       }`,
     );
-    url.searchParams.append('server_id', this.#serverId);
+    if (this.#serverId) {
+      url.searchParams.append('server_id', this.#serverId);
+    }
+
     const brokerServerPostRequestUrl = url.toString();
 
     const brokerServerPostRequest = request({


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Doesn't send the server_id query string empty when server id is not available.
Gets ignored anyways but cleaner that way.