### PR TITLE
fix: bump openpgp to 5.10.1[ED-281]

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "minimatch": "^3.0.4",
     "minimist": "^1.2.5",
     "node-cache": "^5.1.0",
-    "openpgp": "^5.8.0",
+    "openpgp": "^5.10.1",
     "path-to-regexp": "^1.8.0",
     "primus": "^6.1.0",
     "primus-emitter": "^3.1.1",


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Bumps opengpg to version 5.10.1

#### Any background context you want to provide?
Addresses CVE-2023-41037
Jira task: [ED-281](https://snyksec.atlassian.net/browse/ED-281)

[ED-281]: https://snyksec.atlassian.net/browse/ED-281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ