### PR TITLE
fix: add missing rules for CRA endpoints using api hosts

### DIFF
--- a/client-templates/container-registry-agent/accept.json.sample
+++ b/client-templates/container-registry-agent/accept.json.sample
@@ -19,6 +19,26 @@
       "//": "image scan result callback (v2)",
       "method": "POST",
       "path": "/api/v2/import/result"
+    },
+    {
+      "//": "(api hosts) image scan (discover) callback (v1)",
+      "method": "POST",
+      "path": "/v1/import/app"
+    },
+    {
+      "//": "(api hosts) image scan done callback (v2)",
+      "method": "POST",
+      "path": "/v2/import/done"
+    },
+    {
+      "//": "(api hosts) image scan (discover) callback (v1)",
+      "method": "POST",
+      "path": "/v1/recurring-tests/dependencies"
+    },
+    {
+      "//": "(api hosts) image scan result callback (v2)",
+      "method": "POST",
+      "path": "/v2/import/result"
     }
   ],
   "private": [


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adds missing rules to support Snyk general move to api.DOMAIN, removing the /api from the path for CRA usage. 
