### PR TITLE
feat: accept rules for fetching merge-base SHA [ZEN-810]

### DIFF
--- a/client-templates/azure-repos/accept.json.sample
+++ b/client-templates/azure-repos/accept.json.sample
@@ -286,6 +286,16 @@
       }
     },
     {
+      "//": "get merge base of two commits for given repository",
+      "method": "GET",
+      "path": "/:owner/_apis/git/repositories/:repo/commits/:commitId/mergebases",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
+    },
+    {
       "//": "update status of given commit",
       "method": "POST",
       "path": "/:owner/_apis/git/repositories/:repo/commits/:commitId/statuses",

--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -932,6 +932,17 @@
       }
     },
     {
+      "//": "get page of commits between two commits",
+      "method": "GET",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/commits",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
       "//": "used to create a Code Insights report",
       "method": "PUT",
       "path": "/rest/insights/:apiVersion/projects/:project/repos/:repo/commits/:sha/reports/:report",

--- a/client-templates/github-com/accept.json.sample
+++ b/client-templates/github-com/accept.json.sample
@@ -2026,6 +2026,12 @@
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
+      "//": "compares two commits against each other",
+      "method": "GET",
+      "path": "/repos/:name/:repo/compare/:base...:head",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
       "//": "search for open snyk pull requests",
       "method": "GET",
       "path": "/repos/:name/:repo/pulls",

--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -1540,6 +1540,12 @@
       "origin": "https://${GITLAB}"
     },
     {
+      "//": "get merge base of two commits for given project.",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/merge_base",
+      "origin": "https://${GITLAB}"
+    },
+    {
       "//": "used to redirect requests to snyk git client",
       "method": "any",
       "path": "/snykgit/*",

--- a/test/unit/__snapshots__/runtime-rules-hotloading.test.ts.snap
+++ b/test/unit/__snapshots__/runtime-rules-hotloading.test.ts.snap
@@ -298,6 +298,16 @@ Object {
       "path": "/:owner/_apis/git/repositories/:repo/commits",
     },
     Object {
+      "//": "get merge base of two commits for given repository",
+      "auth": Object {
+        "scheme": "basic",
+        "token": "\${BROKER_CLIENT_VALIDATION_BASIC_AUTH}",
+      },
+      "method": "GET",
+      "origin": "https://\${AZURE_REPOS_HOST}/\${AZURE_REPOS_ORG}",
+      "path": "/:owner/_apis/git/repositories/:repo/commits/:commitId/mergebases",
+    },
+    Object {
       "//": "update status of given commit",
       "auth": Object {
         "scheme": "basic",
@@ -1300,6 +1310,17 @@ Object {
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/api/1.0/projects/:project/repos/:repo/commits/:sha",
+    },
+    Object {
+      "//": "get page of commits between two commits",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/commits",
     },
     Object {
       "//": "used to create a Code Insights report",
@@ -3194,6 +3215,12 @@ Object {
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
       "path": "/repos/:name/:repo/git/refs/:ref",
+    },
+    Object {
+      "//": "compares two commits against each other",
+      "method": "GET",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/compare/:base...:head",
     },
     Object {
       "//": "search for open snyk pull requests",
@@ -6517,6 +6544,12 @@ Object {
       "path": "/api/v4/projects/:project/repository/commits/:sha",
     },
     Object {
+      "//": "get merge base of two commits for given project.",
+      "method": "GET",
+      "origin": "https://\${GITLAB}",
+      "path": "/api/v4/projects/:project/repository/merge_base",
+    },
+    Object {
       "//": "used to redirect requests to snyk git client",
       "method": "any",
       "origin": "\${GIT_CLIENT_URL}",
@@ -6829,6 +6862,16 @@ Object {
       "method": "GET",
       "origin": "https://\${AZURE_REPOS_HOST}/\${AZURE_REPOS_ORG}",
       "path": "/:owner/_apis/git/repositories/:repo/commits",
+    },
+    Object {
+      "//": "get merge base of two commits for given repository",
+      "auth": Object {
+        "scheme": "basic",
+        "token": "\${BROKER_CLIENT_VALIDATION_BASIC_AUTH}",
+      },
+      "method": "GET",
+      "origin": "https://\${AZURE_REPOS_HOST}/\${AZURE_REPOS_ORG}",
+      "path": "/:owner/_apis/git/repositories/:repo/commits/:commitId/mergebases",
     },
     Object {
       "//": "update status of given commit",
@@ -7863,6 +7906,17 @@ Object {
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/api/1.0/projects/:project/repos/:repo/commits/:sha",
+    },
+    Object {
+      "//": "get page of commits between two commits",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/commits",
     },
     Object {
       "//": "used to create a Code Insights report",
@@ -9790,6 +9844,12 @@ Object {
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
       "path": "/repos/:name/:repo/git/refs/:ref",
+    },
+    Object {
+      "//": "compares two commits against each other",
+      "method": "GET",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/compare/:base...:head",
     },
     Object {
       "//": "search for open snyk pull requests",
@@ -13137,6 +13197,12 @@ Object {
       "path": "/api/v4/projects/:project/repository/commits/:sha",
     },
     Object {
+      "//": "get merge base of two commits for given project.",
+      "method": "GET",
+      "origin": "https://\${GITLAB}",
+      "path": "/api/v4/projects/:project/repository/merge_base",
+    },
+    Object {
       "//": "used to redirect requests to snyk git client",
       "method": "any",
       "origin": "\${GIT_CLIENT_URL}",
@@ -13471,6 +13537,16 @@ Object {
       "method": "GET",
       "origin": "https://\${AZURE_REPOS_HOST}/\${AZURE_REPOS_ORG}",
       "path": "/:owner/_apis/git/repositories/:repo/commits",
+    },
+    Object {
+      "//": "get merge base of two commits for given repository",
+      "auth": Object {
+        "scheme": "basic",
+        "token": "\${BROKER_CLIENT_VALIDATION_BASIC_AUTH}",
+      },
+      "method": "GET",
+      "origin": "https://\${AZURE_REPOS_HOST}/\${AZURE_REPOS_ORG}",
+      "path": "/:owner/_apis/git/repositories/:repo/commits/:commitId/mergebases",
     },
     Object {
       "//": "update status of given commit",
@@ -14505,6 +14581,17 @@ Object {
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/api/1.0/projects/:project/repos/:repo/commits/:sha",
+    },
+    Object {
+      "//": "get page of commits between two commits",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/commits",
     },
     Object {
       "//": "used to create a Code Insights report",
@@ -16454,6 +16541,12 @@ Object {
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
       "path": "/repos/:name/:repo/git/refs/:ref",
+    },
+    Object {
+      "//": "compares two commits against each other",
+      "method": "GET",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/compare/:base...:head",
     },
     Object {
       "//": "search for open snyk pull requests",
@@ -19825,6 +19918,12 @@ Object {
       "path": "/api/v4/projects/:project/repository/commits/:sha",
     },
     Object {
+      "//": "get merge base of two commits for given project.",
+      "method": "GET",
+      "origin": "https://\${GITLAB}",
+      "path": "/api/v4/projects/:project/repository/merge_base",
+    },
+    Object {
       "//": "used to redirect requests to snyk git client",
       "method": "any",
       "origin": "\${GIT_CLIENT_URL}",
@@ -20167,6 +20266,16 @@ Object {
       "method": "GET",
       "origin": "https://\${AZURE_REPOS_HOST}/\${AZURE_REPOS_ORG}",
       "path": "/:owner/_apis/git/repositories/:repo/commits",
+    },
+    Object {
+      "//": "get merge base of two commits for given repository",
+      "auth": Object {
+        "scheme": "basic",
+        "token": "\${BROKER_CLIENT_VALIDATION_BASIC_AUTH}",
+      },
+      "method": "GET",
+      "origin": "https://\${AZURE_REPOS_HOST}/\${AZURE_REPOS_ORG}",
+      "path": "/:owner/_apis/git/repositories/:repo/commits/:commitId/mergebases",
     },
     Object {
       "//": "update status of given commit",
@@ -21201,6 +21310,17 @@ Object {
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/api/1.0/projects/:project/repos/:repo/commits/:sha",
+    },
+    Object {
+      "//": "get page of commits between two commits",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/commits",
     },
     Object {
       "//": "used to create a Code Insights report",
@@ -23128,6 +23248,12 @@ Object {
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
       "path": "/repos/:name/:repo/git/refs/:ref",
+    },
+    Object {
+      "//": "compares two commits against each other",
+      "method": "GET",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/compare/:base...:head",
     },
     Object {
       "//": "search for open snyk pull requests",
@@ -26475,6 +26601,12 @@ Object {
       "path": "/api/v4/projects/:project/repository/commits/:sha",
     },
     Object {
+      "//": "get merge base of two commits for given project.",
+      "method": "GET",
+      "origin": "https://\${GITLAB}",
+      "path": "/api/v4/projects/:project/repository/merge_base",
+    },
+    Object {
       "//": "used to redirect requests to snyk git client",
       "method": "any",
       "origin": "\${GIT_CLIENT_URL}",
@@ -26825,6 +26957,16 @@ Object {
       "method": "GET",
       "origin": "https://\${AZURE_REPOS_HOST}/\${AZURE_REPOS_ORG}",
       "path": "/:owner/_apis/git/repositories/:repo/commits",
+    },
+    Object {
+      "//": "get merge base of two commits for given repository",
+      "auth": Object {
+        "scheme": "basic",
+        "token": "\${BROKER_CLIENT_VALIDATION_BASIC_AUTH}",
+      },
+      "method": "GET",
+      "origin": "https://\${AZURE_REPOS_HOST}/\${AZURE_REPOS_ORG}",
+      "path": "/:owner/_apis/git/repositories/:repo/commits/:commitId/mergebases",
     },
     Object {
       "//": "update status of given commit",
@@ -27207,6 +27349,16 @@ Object {
       "method": "GET",
       "origin": "https://\${AZURE_REPOS_HOST}/\${AZURE_REPOS_ORG}",
       "path": "/:owner/_apis/git/repositories/:repo/commits",
+    },
+    Object {
+      "//": "get merge base of two commits for given repository",
+      "auth": Object {
+        "scheme": "basic",
+        "token": "\${BROKER_CLIENT_VALIDATION_BASIC_AUTH}",
+      },
+      "method": "GET",
+      "origin": "https://\${AZURE_REPOS_HOST}/\${AZURE_REPOS_ORG}",
+      "path": "/:owner/_apis/git/repositories/:repo/commits/:commitId/mergebases",
     },
     Object {
       "//": "update status of given commit",
@@ -28211,6 +28363,17 @@ Object {
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/api/1.0/projects/:project/repos/:repo/commits/:sha",
+    },
+    Object {
+      "//": "get page of commits between two commits",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/commits",
     },
     Object {
       "//": "used to create a Code Insights report",
@@ -29397,6 +29560,17 @@ Object {
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/api/1.0/projects/:project/repos/:repo/commits/:sha",
+    },
+    Object {
+      "//": "get page of commits between two commits",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/commits",
     },
     Object {
       "//": "used to create a Code Insights report",
@@ -31335,6 +31509,12 @@ Object {
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
       "path": "/repos/:name/:repo/git/refs/:ref",
+    },
+    Object {
+      "//": "compares two commits against each other",
+      "method": "GET",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/compare/:base...:head",
     },
     Object {
       "//": "search for open snyk pull requests",
@@ -33516,6 +33696,12 @@ Object {
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
       "path": "/repos/:name/:repo/git/refs/:ref",
+    },
+    Object {
+      "//": "compares two commits against each other",
+      "method": "GET",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/compare/:base...:head",
     },
     Object {
       "//": "search for open snyk pull requests",
@@ -38336,6 +38522,12 @@ Object {
       "path": "/api/v4/projects/:project/repository/commits/:sha",
     },
     Object {
+      "//": "get merge base of two commits for given project.",
+      "method": "GET",
+      "origin": "https://\${GITLAB}",
+      "path": "/api/v4/projects/:project/repository/merge_base",
+    },
+    Object {
       "//": "used to redirect requests to snyk git client",
       "method": "any",
       "origin": "\${GIT_CLIENT_URL}",
@@ -39945,6 +40137,12 @@ Object {
       "path": "/api/v4/projects/:project/repository/commits/:sha",
     },
     Object {
+      "//": "get merge base of two commits for given project.",
+      "method": "GET",
+      "origin": "https://\${GITLAB}",
+      "path": "/api/v4/projects/:project/repository/merge_base",
+    },
+    Object {
       "//": "used to redirect requests to snyk git client",
       "method": "any",
       "origin": "\${GIT_CLIENT_URL}",
@@ -40281,6 +40479,16 @@ Object {
       "method": "GET",
       "origin": "https://\${AZURE_REPOS_HOST}/\${AZURE_REPOS_ORG}",
       "path": "/:owner/_apis/git/repositories/:repo/commits",
+    },
+    Object {
+      "//": "get merge base of two commits for given repository",
+      "auth": Object {
+        "scheme": "basic",
+        "token": "\${BROKER_CLIENT_VALIDATION_BASIC_AUTH}",
+      },
+      "method": "GET",
+      "origin": "https://\${AZURE_REPOS_HOST}/\${AZURE_REPOS_ORG}",
+      "path": "/:owner/_apis/git/repositories/:repo/commits/:commitId/mergebases",
     },
     Object {
       "//": "update status of given commit",
@@ -41285,6 +41493,17 @@ Object {
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/api/1.0/projects/:project/repos/:repo/commits/:sha",
+    },
+    Object {
+      "//": "get page of commits between two commits",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/commits",
     },
     Object {
       "//": "used to create a Code Insights report",
@@ -43179,6 +43398,12 @@ Object {
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
       "path": "/repos/:name/:repo/git/refs/:ref",
+    },
+    Object {
+      "//": "compares two commits against each other",
+      "method": "GET",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/compare/:base...:head",
     },
     Object {
       "//": "search for open snyk pull requests",
@@ -46490,6 +46715,12 @@ Object {
       "path": "/api/v4/projects/:project/repository/commits/:sha",
     },
     Object {
+      "//": "get merge base of two commits for given project.",
+      "method": "GET",
+      "origin": "https://\${GITLAB}",
+      "path": "/api/v4/projects/:project/repository/merge_base",
+    },
+    Object {
       "//": "used to redirect requests to snyk git client",
       "method": "any",
       "origin": "\${GIT_CLIENT_URL}",
@@ -46802,6 +47033,16 @@ Object {
       "method": "GET",
       "origin": "https://\${AZURE_REPOS_HOST}/\${AZURE_REPOS_ORG}",
       "path": "/:owner/_apis/git/repositories/:repo/commits",
+    },
+    Object {
+      "//": "get merge base of two commits for given repository",
+      "auth": Object {
+        "scheme": "basic",
+        "token": "\${BROKER_CLIENT_VALIDATION_BASIC_AUTH}",
+      },
+      "method": "GET",
+      "origin": "https://\${AZURE_REPOS_HOST}/\${AZURE_REPOS_ORG}",
+      "path": "/:owner/_apis/git/repositories/:repo/commits/:commitId/mergebases",
     },
     Object {
       "//": "update status of given commit",
@@ -47806,6 +48047,17 @@ Object {
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/api/1.0/projects/:project/repos/:repo/commits/:sha",
+    },
+    Object {
+      "//": "get page of commits between two commits",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/commits",
     },
     Object {
       "//": "used to create a Code Insights report",
@@ -49700,6 +49952,12 @@ Object {
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
       "path": "/repos/:name/:repo/git/refs/:ref",
+    },
+    Object {
+      "//": "compares two commits against each other",
+      "method": "GET",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/compare/:base...:head",
     },
     Object {
       "//": "search for open snyk pull requests",
@@ -53009,6 +53267,12 @@ Object {
       "method": "GET",
       "origin": "https://\${GITLAB}",
       "path": "/api/v4/projects/:project/repository/commits/:sha",
+    },
+    Object {
+      "//": "get merge base of two commits for given project.",
+      "method": "GET",
+      "origin": "https://\${GITLAB}",
+      "path": "/api/v4/projects/:project/repository/merge_base",
     },
     Object {
       "//": "used to redirect requests to snyk git client",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR adds accept rules, whitelisting endpoints that are used to fetch merge-base SHA by scm agents.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?

#### Screenshots


#### Additional questions
These endpoints have query parameters in their path that I didn't add under `valid`, since they're dynamic (e.g. commit sha we receive from a webhook and pass forward to SCM). The query param may look as `?refs[]=6314fc95c55126c8d065d3144d8e3407c705bfea&refs[]=6314fc95c55126c8d065d3144d8e3407c705bfeb&refs[]=6314fc95c55126c8d065d3144d8e3407c705bfea&refs[]=fdf6812e451dfa1f4de3f900af3efb1b03b3c5c6`. 

**Q:** Is it correct as-is or should these by typed somehow to be whitelisted?