### PR TITLE
chore(circleci): make regex for image tags more restrictive

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,10 +97,10 @@ commands:
             export IMAGE_NAME=<<parameters.image_name>>
             export IMAGE_TAG=${CIRCLE_TAG/v/''}-<<parameters.image_tag>>
             export IMAGE_TAG_LATEST=<<parameters.image_tag>>
-            [[ "$IMAGE_TAG" =~ .*"base".* ]] && export IMAGE_TAG=<<parameters.image_tag>>
-            [[ "$IMAGE_TAG" =~ .*"base".* ]] && export IMAGE_TAG_LATEST=<<parameters.image_tag>>
-            [[ "$IMAGE_TAG" =~ .*"dev".* ]] && export IMAGE_TAG=<<parameters.image_tag>>
-            [[ "$IMAGE_TAG" =~ .*"dev".* ]] && export IMAGE_TAG_LATEST=<<parameters.image_tag>>
+            [[ "$IMAGE_TAG" =~ ^base.* ]] && export IMAGE_TAG=<<parameters.image_tag>>
+            [[ "$IMAGE_TAG" =~ ^base.* ]] && export IMAGE_TAG_LATEST=<<parameters.image_tag>>
+            [[ "$IMAGE_TAG" =~ .*dev$ ]] && export IMAGE_TAG=<<parameters.image_tag>>
+            [[ "$IMAGE_TAG" =~ .*dev$ ]] && export IMAGE_TAG_LATEST=<<parameters.image_tag>>
 
             echo "Tagging Broker image $IMAGE_NAME:$IMAGE_TAG..."
             docker tag <<parameters.project_name>>:$CIRCLE_WORKFLOW_ID $IMAGE_NAME:$IMAGE_TAG


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR addresses the concern from [here](https://github.com/snyk/broker/pull/609#discussion_r1322502675). We want to have more restrictive regex for `base` and `dev` images:

- base: starts with base (e.g. base, base-nlatest, base-rhel-ubi)
- dev: ends with dev (e.g. github-com-dev, gitlab-dev etc)


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
