### PR TITLE
chore: enable slack notification on failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   prodsec: snyk/prodsec-orb@1.0
+  slack: circleci/slack@4.12.5
   snyk: snyk/snyk@1.7.2
 
 defaults: &defaults
@@ -148,6 +149,70 @@ commands:
           name: Prepare package.json and metadata.json for dev images
           command: |
             cd dockerfiles/.scripts && source prepare.sh
+  notify-slack-on-failure:
+    parameters:
+      channel:
+        type: string
+        default: "broker-alerts-cicd"
+    steps:
+      - slack/notify:
+          channel: <<parameters.channel>>
+          event: fail
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "CICD pipeline failed :circleci-fail:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Project*: ${CIRCLE_PROJECT_REPONAME}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Job*: ${CIRCLE_JOB}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch*: ${CIRCLE_BRANCH}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Author*: ${CIRCLE_USERNAME}"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Mentions*: ${SLACK_PARAM_MENTIONS}"
+                    }
+                  ],
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "emoji": true,
+                      "text": "View Job"
+                    },
+                    "url": "${CIRCLE_BUILD_URL}"
+                  }
+                }
+              ]
+            }
 
 jobs:
   install-npm-packages:
@@ -369,9 +434,13 @@ workflows:
 
       - release:
           name: Release to GitHub and NPM
-          context: nodejs-lib-release
+          context:
+            - nodejs-lib-release
+            - snyk-bot-slack
           requires:
             - Test
+          post-steps:
+            - notify-slack-on-failure
           filters:
             branches:
               only:
@@ -388,23 +457,33 @@ workflows:
 
       - build-and-save-docker-ubi-image:
           name: Build base UBI image
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Scan repository for secrets
           dockerfile: dockerfiles/base/Dockerfile.ubi
           project_name: broker-rhel-ubi
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - scan-docker-image:
           name: Scan base UBI image
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Build base UBI image
           project: snyk/broker-rhel-ubi
           project_name: broker-rhel-ubi
+          post-steps:
+            - notify-slack-on-failure:
+                channel: broker-alerts-vulns
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push base UBI image
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -412,11 +491,15 @@ workflows:
           image_name: snyk/broker
           image_tag: base-rhel-ubi
           project_name: broker-rhel-ubi
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build artifactory UBI image
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BROKER_TYPE=artifactory"
@@ -426,6 +509,7 @@ workflows:
       - tag-and-push-docker-image:
           name: Push artifactory UBI image
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -433,20 +517,27 @@ workflows:
           image_name: snyk/broker
           image_tag: rhel-ubi-artifactory
           project_name: rhel-ubi-artifactory
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build azure-repos UBI image
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BROKER_TYPE=azure-repos"
           dockerfile: dockerfiles/Dockerfile.ubi
           project_name: rhel-ubi-azure-repos
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push azure-repos UBI image
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -454,20 +545,27 @@ workflows:
           image_name: snyk/broker
           image_tag: rhel-ubi-azure-repos
           project_name: rhel-ubi-azure-repos
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build bitbucket-server UBI image
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BROKER_TYPE=bitbucket-server"
           dockerfile: dockerfiles/Dockerfile.ubi
           project_name: rhel-ubi-bitbucket-server
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push bitbucket-server UBI image
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -475,20 +573,27 @@ workflows:
           image_name: snyk/broker
           image_tag: rhel-ubi-bitbucket-server
           project_name: rhel-ubi-bitbucket-server
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build container-registry-agent UBI image
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BROKER_TYPE=container-registry-agent"
           dockerfile: dockerfiles/container-registry-agent/Dockerfile.ubi
           project_name: rhel-ubi-container-registry-agent
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push bitbucket-server UBI image
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -496,20 +601,27 @@ workflows:
           image_name: snyk/broker
           image_tag: rhel-ubi-container-registry-agent
           project_name: rhel-ubi-container-registry-agent
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build github-com UBI image
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BROKER_TYPE=github-com"
           dockerfile: dockerfiles/Dockerfile.ubi
           project_name: rhel-ubi-github-com
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push github-com UBI image
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -517,20 +629,27 @@ workflows:
           image_name: snyk/broker
           image_tag: rhel-ubi-github-com
           project_name: rhel-ubi-github-com
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build github-enterprise UBI image
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BROKER_TYPE=github-enterprise"
           dockerfile: dockerfiles/Dockerfile.ubi
           project_name: rhel-ubi-github-enterprise
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push github-enterprise UBI image
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -538,20 +657,27 @@ workflows:
           image_name: snyk/broker
           image_tag: rhel-ubi-github-enterprise
           project_name: rhel-ubi-github-enterprise
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build gitlab UBI image
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BROKER_TYPE=gitlab"
           dockerfile: dockerfiles/Dockerfile.ubi
           project_name: rhel-ubi-gitlab
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push gitlab UBI image
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -559,20 +685,27 @@ workflows:
           image_name: snyk/broker
           image_tag: rhel-ubi-gitlab
           project_name: rhel-ubi-gitlab
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build jira UBI image
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BROKER_TYPE=jira"
           dockerfile: dockerfiles/Dockerfile.ubi
           project_name: rhel-ubi-jira
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push jira UBI image
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -580,20 +713,27 @@ workflows:
           image_name: snyk/broker
           image_tag: rhel-ubi-jira
           project_name: rhel-ubi-jira
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build nexus UBI image
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BROKER_TYPE=nexus"
           dockerfile: dockerfiles/Dockerfile.ubi
           project_name: rhel-ubi-nexus
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push nexus UBI image
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -601,20 +741,27 @@ workflows:
           image_name: snyk/broker
           image_tag: rhel-ubi-nexus
           project_name: rhel-ubi-nexus
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build nexus2 UBI image
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BROKER_TYPE=nexus2"
           dockerfile: dockerfiles/Dockerfile.ubi
           project_name: rhel-ubi-nexus2
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push nexus2 UBI image
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -622,6 +769,8 @@ workflows:
           image_name: snyk/broker
           image_tag: rhel-ubi-nexus2
           project_name: rhel-ubi-nexus2
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
   Release Docker images:
@@ -639,21 +788,31 @@ workflows:
 
       - build-and-save-docker-image:
           name: Build base image
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           dockerfile: dockerfiles/base/Dockerfile
           project_name: broker
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - scan-docker-image:
           name: Scan base image
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Build base image
           project: snyk/broker
           project_name: broker
+          post-steps:
+            - notify-slack-on-failure:
+                channel: broker-alerts-vulns
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push base image
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -661,26 +820,38 @@ workflows:
           image_name: snyk/broker
           image_tag: base
           project_name: broker
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build base image (nlatest)
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           additional_arguments: "--build-arg NODE_VERSION=20.6.0"
           dockerfile: dockerfiles/base/Dockerfile
           project_name: broker
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - scan-docker-image:
           name: Scan base image (nlatest)
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Build base image (nlatest)
           project: snyk/broker
           project_name: broker
+          post-steps:
+            - notify-slack-on-failure:
+                channel: broker-alerts-vulns
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push base image (nlatest)
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -688,20 +859,27 @@ workflows:
           image_name: snyk/broker
           image_tag: base-nlatest
           project_name: broker
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build artifactory image
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BROKER_TYPE=artifactory"
           dockerfile: dockerfiles/Dockerfile
           project_name: artifactory
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push artifactory image
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -709,20 +887,27 @@ workflows:
           image_name: snyk/broker
           image_tag: artifactory
           project_name: artifactory
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build azure-repos image
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BROKER_TYPE=azure-repos"
           dockerfile: dockerfiles/Dockerfile
           project_name: azure-repos
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push azure-repos image
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -730,20 +915,27 @@ workflows:
           image_name: snyk/broker
           image_tag: azure-repos
           project_name: azure-repos
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build bitbucket-server image
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BROKER_TYPE=bitbucket-server"
           dockerfile: dockerfiles/Dockerfile
           project_name: bitbucket-server
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push bitbucket-server image
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -751,20 +943,27 @@ workflows:
           image_name: snyk/broker
           image_tag: bitbucket-server
           project_name: bitbucket-server
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build container-registry-agent image
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BROKER_TYPE=container-registry-agent"
           dockerfile: dockerfiles/container-registry-agent/Dockerfile
           project_name: container-registry-agent
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push container-registry-agent image
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -772,20 +971,27 @@ workflows:
           image_name: snyk/broker
           image_tag: container-registry-agent
           project_name: container-registry-agent
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build github-com image
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BROKER_TYPE=github-com"
           dockerfile: dockerfiles/Dockerfile
           project_name: github-com
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push github-com image
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -793,20 +999,27 @@ workflows:
           image_name: snyk/broker
           image_tag: github-com
           project_name: github-com
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build github-enterprise image
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BROKER_TYPE=github-enterprise"
           dockerfile: dockerfiles/Dockerfile
           project_name: github-enterprise
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push github-enterprise image
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -814,20 +1027,27 @@ workflows:
           image_name: snyk/broker
           image_tag: github-enterprise
           project_name: github-enterprise
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build gitlab image
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BROKER_TYPE=gitlab"
           dockerfile: dockerfiles/Dockerfile
           project_name: gitlab
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push gitlab image
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -835,20 +1055,27 @@ workflows:
           image_name: snyk/broker
           image_tag: gitlab
           project_name: gitlab
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build jira image
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BROKER_TYPE=jira"
           dockerfile: dockerfiles/Dockerfile
           project_name: jira
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push jira image
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -856,20 +1083,27 @@ workflows:
           image_name: snyk/broker
           image_tag: jira
           project_name: jira
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build nexus image
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BROKER_TYPE=nexus"
           dockerfile: dockerfiles/Dockerfile
           project_name: nexus
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push nexus image
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -877,20 +1111,27 @@ workflows:
           image_name: snyk/broker
           image_tag: nexus
           project_name: nexus
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build nexus2 image
-          context: team-broker-snyk
+          context:
+            snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BROKER_TYPE=nexus2"
           dockerfile: dockerfiles/Dockerfile
           project_name: nexus2
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push nexus2 image
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -898,20 +1139,27 @@ workflows:
           image_name: snyk/broker
           image_tag: nexus2
           project_name: nexus2
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build artifactory image (nlatest)
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:base-nlatest --build-arg BROKER_TYPE=artifactory"
           dockerfile: dockerfiles/Dockerfile
           project_name: artifactory-nlatest
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push artifactory image (nlatest)
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -919,20 +1167,27 @@ workflows:
           image_name: snyk/broker
           image_tag: artifactory-nlatest
           project_name: artifactory-nlatest
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build azure-repos image (nlatest)
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:base-nlatest --build-arg BROKER_TYPE=azure-repos"
           dockerfile: dockerfiles/Dockerfile
           project_name: azure-repos-nlatest
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push azure-repos image (nlatest)
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -940,20 +1195,27 @@ workflows:
           image_name: snyk/broker
           image_tag: azure-repos-nlatest
           project_name: azure-repos-nlatest
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build bitbucket-server image (nlatest)
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:base-nlatest --build-arg BROKER_TYPE=bitbucket-server"
           dockerfile: dockerfiles/Dockerfile
           project_name: bitbucket-server-nlatest
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push bitbucket-server image (nlatest)
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -961,20 +1223,27 @@ workflows:
           image_name: snyk/broker
           image_tag: bitbucket-server-nlatest
           project_name: bitbucket-server-nlatest
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build container-registry-agent image (nlatest)
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:base-nlatest --build-arg BROKER_TYPE=container-registry-agent"
           dockerfile: dockerfiles/container-registry-agent/Dockerfile
           project_name: container-registry-agent-nlatest
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push container-registry-agent image (nlatest)
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -982,20 +1251,27 @@ workflows:
           image_name: snyk/broker
           image_tag: container-registry-agent-nlatest
           project_name: container-registry-agent-nlatest
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build github-com image (nlatest)
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:base-nlatest --build-arg BROKER_TYPE=github-com"
           dockerfile: dockerfiles/Dockerfile
           project_name: github-com-nlatest
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push github-com image (nlatest)
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -1003,20 +1279,27 @@ workflows:
           image_name: snyk/broker
           image_tag: github-com-nlatest
           project_name: github-com-nlatest
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build github-enterprise image (nlatest)
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:base-nlatest --build-arg BROKER_TYPE=github-enterprise"
           dockerfile: dockerfiles/Dockerfile
           project_name: github-enterprise-nlatest
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push github-enterprise image (nlatest)
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -1024,20 +1307,27 @@ workflows:
           image_name: snyk/broker
           image_tag: github-enterprise-nlatest
           project_name: github-enterprise-nlatest
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build gitlab image (nlatest)
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:base-nlatest --build-arg BROKER_TYPE=gitlab"
           dockerfile: dockerfiles/Dockerfile
           project_name: gitlab-nlatest
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push gitlab image (nlatest)
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -1045,20 +1335,27 @@ workflows:
           image_name: snyk/broker
           image_tag: gitlab-nlatest
           project_name: gitlab-nlatest
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build jira image (nlatest)
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:base-nlatest --build-arg BROKER_TYPE=jira"
           dockerfile: dockerfiles/Dockerfile
           project_name: jira-nlatest
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push jira image (nlatest)
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -1066,20 +1363,27 @@ workflows:
           image_name: snyk/broker
           image_tag: jira-nlatest
           project_name: jira-nlatest
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build nexus image (nlatest)
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:base-nlatest --build-arg BROKER_TYPE=nexus"
           dockerfile: dockerfiles/Dockerfile
           project_name: nexus-nlatest
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push nexus image (nlatest)
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -1087,20 +1391,27 @@ workflows:
           image_name: snyk/broker
           image_tag: nexus-nlatest
           project_name: nexus-nlatest
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build nexus2 image (nlatest)
-          context: team-broker-snyk
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:base-nlatest --build-arg BROKER_TYPE=nexus2"
           dockerfile: dockerfiles/Dockerfile
           project_name: nexus2-nlatest
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
       - tag-and-push-docker-image:
           name: Push nexus2 image (nlatest)
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -1108,6 +1419,8 @@ workflows:
           image_name: snyk/broker
           image_tag: nexus2-nlatest
           project_name: nexus2-nlatest
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-tags-only
 
       - approve-build-github-com-dev:
@@ -1119,6 +1432,7 @@ workflows:
       - build-and-push-dev-docker-image:
           name: Build and push github-com image (dev)
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -1128,6 +1442,8 @@ workflows:
           image_name: snyk/broker
           image_tag: github-com-dev
           project_name: github-com-dev
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-dev-branch-only
 
       - approve-build-gitlab-dev:
@@ -1139,6 +1455,7 @@ workflows:
       - build-and-push-dev-docker-image:
           name: Build and push gitlab image (dev)
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -1148,6 +1465,8 @@ workflows:
           image_name: snyk/broker
           image_tag: gitlab-dev
           project_name: gitlab-dev
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-dev-branch-only
 
       - approve-build-nexus-dev:
@@ -1159,6 +1478,7 @@ workflows:
       - build-and-push-dev-docker-image:
           name: Build and push nexus image (dev)
           context:
+            - snyk-bot-slack
             - team-broker-docker-hub
             - team-broker-snyk
           requires:
@@ -1168,4 +1488,6 @@ workflows:
           image_name: snyk/broker
           image_tag: nexus-dev
           project_name: nexus-dev
+          post-steps:
+            - notify-slack-on-failure
           <<: *filter-dev-branch-only


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR adds Slack notifications for failed workflows:
 - "Release to NPM and GitHub" from CICD
 - every step in "Release Docker UBI images" and "Release Docker images"
 - vulnerability scan failures will be sent to "#broker-alerts-vulns" channel

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
