### PR TITLE
chore(circleci): don't monitor Broker dev images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,6 +320,7 @@ jobs:
       - snyk/scan:
           docker-image-name: <<parameters.project_name>>:$CIRCLE_WORKFLOW_ID
           fail-on-issues: false
+          monitor-on-build: false
           organization: platform-broker
           project: <<parameters.project_name>>
           severity-threshold: <<parameters.severity_threshold>>


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR excludes Broker Docker dev images from monitoring by running Snyk scans.
