### PR TITLE
fix: bump http server timeout

### DIFF
--- a/lib/common/http/downstream-post-stream-to-server.ts
+++ b/lib/common/http/downstream-post-stream-to-server.ts
@@ -6,9 +6,7 @@ import version from '../utils/version';
 
 let streamPostRequestHandler = request;
 streamPostRequestHandler = request.defaults({
-  timeout: process.env.BROKER_DOWNSTREAM_TIMEOUT
-    ? parseInt(process.env.BROKER_DOWNSTREAM_TIMEOUT)
-    : 60000,
+  timeout: 600000,
   agentOptions: {
     keepAlive: true,
     keepAliveMsecs: 60000,

--- a/lib/common/http/webserver.ts
+++ b/lib/common/http/webserver.ts
@@ -82,6 +82,7 @@ export const webserver = (config, altPort: number) => {
         },
         app,
       ).listen(port);
+  server.timeout = 600000;
 
   return { app, server };
 };


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Increases the webserver timeout value for long running queries in case of large (mono)repos.
Mainly applicable to client=>server flows