### PR TITLE
fix: avoid srv crash if cannot find socket for token

### DIFF
--- a/lib/server/socketHandlers/closeHandler.ts
+++ b/lib/server/socketHandlers/closeHandler.ts
@@ -18,6 +18,8 @@ export const handleConnectionCloseOnSocket = (
       const clientPool = connections
         .get(token)
         .filter((_) => _.socket !== socket);
+      const filteredClientPool =
+        clientPool?.filter((_) => _.socket !== socket) || '';
       logger.info(
         {
           closeReason,
@@ -27,8 +29,8 @@ export const handleConnectionCloseOnSocket = (
         },
         'client connection closed',
       );
-      if (clientPool.length) {
-        connections.set(token, clientPool);
+      if (filteredClientPool.length) {
+        connections.set(token, filteredClientPool);
       } else {
         logger.info({ maskedToken, hashedToken }, 'removing client');
         connections.delete(token);


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
In some situations, that should never occur really, the server crashes upon connection closure because it tries to filter on a non existing object, causing a server crash.
Avoiding this crash is preferred, irrespective of this case not being supposed to occur.
