### PR TITLE
fix: remove vulnerable libnghttp2 package from base ubi image

### DIFF
--- a/dockerfiles/base/Dockerfile.ubi
+++ b/dockerfiles/base/Dockerfile.ubi
@@ -53,6 +53,7 @@ RUN yum upgrade --assumeyes && \
     rpm --erase --nodeps libarchive && \
     rpm --erase --nodeps libcurl && \
     rpm --erase --nodeps libsolv && \
+    rpm --erase --nodeps libnghttp2 && \
     rpm --erase --nodeps platform-python && \
     rpm --erase --nodeps platform-python-setuptools && \
     rpm --erase --nodeps python3-cloud-what && \


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This fixes https://security.snyk.io/vuln/SNYK-RHEL8-LIBNGHTTP2-5958698

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
