### PR TITLE
fix:validate urls returning non json response

### DIFF
--- a/lib/client/utils/credentials.ts
+++ b/lib/client/utils/credentials.ts
@@ -2,6 +2,7 @@ import { log as logger } from '../../logs/logger';
 import version from '../../common/utils/version';
 import { sanitise } from '../../logs/logger';
 import { makeRequestToDownstream } from '../../common/http/request';
+import { isJson } from '../../common/utils/json';
 
 const credsFromHeader = (s) => {
   if (s.indexOf(' ') >= 0) {
@@ -101,7 +102,10 @@ export const checkCredentials = async (
 
       logger.error(data, response && response.body, 'Systemcheck failed');
     } else {
-      const parsedBodyResponse = JSON.parse(response.body || {});
+      const parsedBodyResponse = isJson(response.headers)
+        ? JSON.parse(response.body)
+        : response.body;
+
       // const responseToReturn = response
       response.body = parsedBodyResponse;
       if (process.env.JEST_WORKER_ID) {
@@ -117,7 +121,6 @@ export const checkCredentials = async (
     if (process.env.JEST_WORKER_ID) {
       data['testError'] = error;
     }
-
     data['ok'] = false;
     data['error'] = error;
   }

--- a/test/functional/systemcheck.test.ts
+++ b/test/functional/systemcheck.test.ts
@@ -69,6 +69,34 @@ describe('broker client systemcheck endpoint', () => {
     ).not.toBeTruthy();
   });
 
+  it('good validation url, custom endpoint, no authorization, no json response', async () => {
+    bc = await createBrokerClient({
+      brokerServerUrl: `http://localhost:${bs.port}`,
+      brokerToken: 'broker-token-12345',
+      type: 'client',
+      brokerClientValidationUrl: `http://localhost:${tws.port}/echo/textresponse`,
+      brokerSystemcheckPath: '/custom-systemcheck',
+    });
+    await waitForBrokerClientConnection(bs);
+
+    const response = await axiosClient.get(
+      `http://localhost:${bc.port}/custom-systemcheck`,
+    );
+    expect(response.data).toBeInstanceOf(Array);
+    const systemCheckBody = response.data[0];
+    expect(response.status).toEqual(200);
+    expect(systemCheckBody).toStrictEqual({
+      brokerClientValidationMethod: 'GET',
+      brokerClientValidationTimeoutMs: expect.any(Number),
+      brokerClientValidationUrl: `http://localhost:${tws.port}/echo/textresponse`,
+      brokerClientValidationUrlStatusCode: 200,
+      maskedCredentials: null,
+      ok: true,
+      testResponse: expect.any(Object),
+    });
+    expect(systemCheckBody.testResponse.body).toEqual('OK');
+  });
+
   it('good validation url, authorization header', async () => {
     bc = await createBrokerClient({
       brokerServerUrl: `http://localhost:${bs.port}`,

--- a/test/setup/test-web-server.ts
+++ b/test/setup/test-web-server.ts
@@ -178,6 +178,15 @@ const applyEchoRoutes = (app: Express) => {
     },
   );
 
+  // mimics functionality of https://httpbin.org/headers
+  echoRouter.get(
+    '/echo/textresponse',
+    (req: express.Request, resp: express.Response) => {
+      resp.status(200);
+      resp.send('OK');
+    },
+  );
+
   echoRouter.post(
     '/echo-headers/:param?',
     (req: express.Request, resp: express.Response) => {


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Handles systemcheck correctly when the validation url doesn't return a json object, in case like artifactory for instance which only return 200 and "OK".