### PR TITLE
feat: add insecure downstream mode

### DIFF
--- a/lib/client/hooks/startup/processHooks.ts
+++ b/lib/client/hooks/startup/processHooks.ts
@@ -77,6 +77,13 @@ export const processStartUpHooks = async (
       );
     }
 
+    if (clientOpts.config.INSECURE_DOWNSTREAM) {
+      logger.warn(
+        {},
+        'Caution! Running in insecure downstream mode, making downstream calls over http, data is not encrypted',
+      );
+    }
+
     return {
       preflightCheckResults: preflightCheckResults.length
         ? preflightCheckResults

--- a/lib/client/types/config.ts
+++ b/lib/client/types/config.ts
@@ -4,6 +4,7 @@ interface BackendAPI {
 
 interface BrokerClient {
   PREFLIGHT_CHECKS_ENABLED: string;
+  INSECURE_DOWNSTREAM: string;
 }
 
 interface BrokerServer {

--- a/lib/common/http/utils.ts
+++ b/lib/common/http/utils.ts
@@ -1,0 +1,7 @@
+import { log as logger } from '../../logs/logger';
+export const switchToInsecure = (url: string) => {
+  logger.debug({ url }, 'Forcing insecure url');
+  const urlToSwitch = new URL(url);
+  urlToSwitch.protocol = 'http';
+  return urlToSwitch.toString();
+};

--- a/test/helpers/test-factories.ts
+++ b/test/helpers/test-factories.ts
@@ -36,6 +36,7 @@ export const aConfig = (fields: Partial<Config>): Config => {
     GIT_COMMITTER_EMAIL: '',
     GPG_PASSPHRASE: '',
     GPG_PRIVATE_KEY: '',
+    INSECURE_DOWNSTREAM: 'false',
     ...fields,
   };
 };


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adds an insecure downstream mode forcing downstream requests to be made over http instead of https.
To use only in particular cases where there is just no other options.

#### Any background context you want to provide?
Today, connecting over http to the downstream system requires bringing a custom accept.json with overriden values, causing friction since you not only need to mount a file, but also deal with the GIT and IAC rules you need to add manually if you want them, not making use of the ACCEPT_IAC or ACCEPT_GIT options smoothing out this entire process.

With this change, you can connect over http while still leveraging the ACCEPT_ flags.