### PR TITLE
fix: add missing content length in prepared requests

### DIFF
--- a/lib/common/relay/prepareRequest.ts
+++ b/lib/common/relay/prepareRequest.ts
@@ -147,6 +147,8 @@ export const prepareRequestFromFilterResult = async (
   // Request library is buggy and will throw an error if we're POST'ing an empty body without an explicit Content-Length header
   if (!payload.body || payload.body.length === 0) {
     payload.headers['Content-Length'] = '0';
+  } else {
+    payload.headers['Content-length'] = payload.body.length;
   }
 
   payload.headers['connection'] = 'Keep-Alive';


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adds missing content-length header causing the occasional 413 error code responses.