### PR TITLE
fix: HA mode to work through proxy

### DIFF
--- a/lib/client/checks/http/index.ts
+++ b/lib/client/checks/http/index.ts
@@ -29,7 +29,10 @@ const brokerServerStatusCheck = (config: Config): HttpCheck => {
 };
 
 const restApiStatusCheck = (config: Config): HttpCheck => {
-  const url = config.API_BASE_URL || 'https://api.snyk.io';
+  const url =
+    config.API_BASE_URL || config.BROKER_SERVER_URL
+      ? config.BROKER_SERVER_URL.replace('//broker.', '//api.')
+      : 'https://api.snyk.io';
   const enabled = highAvailabilityModeEnabled(config);
   return {
     id: 'rest-api-status',

--- a/lib/client/types/config.ts
+++ b/lib/client/types/config.ts
@@ -15,7 +15,6 @@ interface BrokerServer {
  * Configuration options for HA (high-availability) mode.
  */
 interface HighAvailabilityMode {
-  BROKER_DISPATCHER_BASE_URL: string;
   BROKER_HA_MODE_ENABLED: string;
 }
 


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Swaps axios for built in https calls to broker dispatcher for HA mode.

Also now infers the snyk api host from BROKER_SERVER_URL, while keeping the ability to override dispatcher url or api url separately, avoiding misconfiguration.

Finally, increased the retries interval. As allocations are kept for 60 second till release or broker client actually uses the allocation, there is no need to retry so quickly. 30s feels right timing.