### PR TITLE
fix: add missing filter rule for github-enterprise

### DIFF
--- a/client-templates/github-enterprise/accept.json.sample
+++ b/client-templates/github-enterprise/accept.json.sample
@@ -1322,6 +1322,12 @@
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
+      "//": "compares two commits against each other",
+      "method": "GET",
+      "path": "/repos/:name/:repo/compare/:base...:head",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
       "//": "search for open snyk pull requests",
       "method": "GET",
       "path": "/repos/:name/:repo/pulls",

--- a/test/unit/__snapshots__/runtime-rules-hotloading.test.ts.snap
+++ b/test/unit/__snapshots__/runtime-rules-hotloading.test.ts.snap
@@ -4698,6 +4698,12 @@ Object {
       "path": "/repos/:name/:repo/git/refs/:ref",
     },
     Object {
+      "//": "compares two commits against each other",
+      "method": "GET",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/compare/:base...:head",
+    },
+    Object {
       "//": "search for open snyk pull requests",
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
@@ -11445,6 +11451,12 @@ Object {
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
       "path": "/repos/:name/:repo/git/refs/:ref",
+    },
+    Object {
+      "//": "compares two commits against each other",
+      "method": "GET",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/compare/:base...:head",
     },
     Object {
       "//": "search for open snyk pull requests",
@@ -18264,6 +18276,12 @@ Object {
       "path": "/repos/:name/:repo/git/refs/:ref",
     },
     Object {
+      "//": "compares two commits against each other",
+      "method": "GET",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/compare/:base...:head",
+    },
+    Object {
       "//": "search for open snyk pull requests",
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
@@ -25065,6 +25083,12 @@ Object {
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
       "path": "/repos/:name/:repo/git/refs/:ref",
+    },
+    Object {
+      "//": "compares two commits against each other",
+      "method": "GET",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/compare/:base...:head",
     },
     Object {
       "//": "search for open snyk pull requests",
@@ -35697,6 +35721,12 @@ Object {
       "path": "/repos/:name/:repo/git/refs/:ref",
     },
     Object {
+      "//": "compares two commits against each other",
+      "method": "GET",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/compare/:base...:head",
+    },
+    Object {
       "//": "search for open snyk pull requests",
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
@@ -37172,6 +37202,12 @@ Object {
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
       "path": "/repos/:name/:repo/git/refs/:ref",
+    },
+    Object {
+      "//": "compares two commits against each other",
+      "method": "GET",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/compare/:base...:head",
     },
     Object {
       "//": "search for open snyk pull requests",
@@ -45523,6 +45559,12 @@ Object {
       "path": "/repos/:name/:repo/git/refs/:ref",
     },
     Object {
+      "//": "compares two commits against each other",
+      "method": "GET",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/compare/:base...:head",
+    },
+    Object {
       "//": "search for open snyk pull requests",
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
@@ -52183,6 +52225,12 @@ Object {
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
       "path": "/repos/:name/:repo/git/refs/:ref",
+    },
+    Object {
+      "//": "compares two commits against each other",
+      "method": "GET",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/compare/:base...:head",
     },
     Object {
       "//": "search for open snyk pull requests",


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR adds a missing filter to calculate merge-base SHA for github-enterprise.
Previous related PR: #607.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
