### PR TITLE
chore(docker): add missing oci labels for ubi base image

### DIFF
--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -102,7 +102,8 @@ LABEL org.opencontainers.image.authors="team-broker" \
       org.opencontainers.image.ref.name="snyk-broker" \
       org.opencontainers.image.source="https://github.com/snyk/broker" \
       org.opencontainers.image.vendor="Snyk, Ltd." \
-      org.opencontainers.image.version="${BROKER_VERSION:-local}"
+      org.opencontainers.image.version="${BROKER_VERSION:-local}" \
+      io.snyk.containers.image.dockerfile="/dockerfiles/base/Dockerfile"
 
 COPY --from=broker-builder /home/node/.npm-global /home/node/.npm-global
 COPY --from=broker-builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/dockerfiles/base/Dockerfile.ubi
+++ b/dockerfiles/base/Dockerfile.ubi
@@ -30,6 +30,16 @@ RUN rm -rf /opt/app-root/src/.npm-global/lib/node_modules/snyk-broker/node_modul
 
 FROM registry.access.redhat.com/ubi8/ubi
 
+ARG BROKER_VERSION
+
+LABEL org.opencontainers.image.authors="team-broker" \
+      org.opencontainers.image.documentation="https://docs.snyk.io/enterprise-setup/snyk-broker" \
+      org.opencontainers.image.ref.name="snyk-broker" \
+      org.opencontainers.image.source="https://github.com/snyk/broker" \
+      org.opencontainers.image.vendor="Snyk, Ltd." \
+      org.opencontainers.image.version="${BROKER_VERSION:-local}" \
+      io.snyk.containers.image.dockerfile="/dockerfiles/base/Dockerfile.ubi"
+
 ENV PATH="/opt/app-root/src/node_modules/.bin/:/opt/app-root/src/.npm-global/bin/:/opt/app-root/src/bin:/opt/app-root/bin:${PATH}"
 
 COPY --from=broker-builder /opt/app-root/src/.npm-global /opt/app-root/src/.npm-global


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR adds missing OCI annotations (labels) for RHEL UBI base image. We already do the same for Ubuntu-based image.
Additionally we add Snyk specific label [`io.snyk.containers.image.dockerfile`](https://docs.snyk.io/scan-applications/snyk-container/scan-your-dockerfile/automatically-link-your-dockerfile-with-container-images-using-labels#how-linked-images-work) for linking projects inside Snyk.
