### PR TITLE
feat(preflight-checks): add config check for broker client url validation [ED-273]

### DIFF
--- a/lib/client/checks/config/brokerClientUrlCheck.ts
+++ b/lib/client/checks/config/brokerClientUrlCheck.ts
@@ -11,7 +11,7 @@ export function validateBrokerClientUrl(
 
   const brokerClientUrl = config.BROKER_CLIENT_URL;
   try {
-    if (!isHttpUrl(brokerClientUrl)) {
+    if (brokerClientUrl && !isHttpUrl(brokerClientUrl)) {
       return {
         id: checkOptions.id,
         name: checkOptions.name,
@@ -29,7 +29,7 @@ export function validateBrokerClientUrl(
       } satisfies CheckResult;
     }
 
-    if (isHostnameLocalhost(brokerClientUrl)) {
+    if (brokerClientUrl && isHostnameLocalhost(brokerClientUrl)) {
       return {
         id: checkOptions.id,
         name: checkOptions.name,
@@ -75,7 +75,7 @@ function isHttpsWithoutCertificates(config: Config): boolean {
   );
 
   try {
-    if (urlContainsProtocol(brokerClientUrl, 'https:')) {
+    if (brokerClientUrl && urlContainsProtocol(brokerClientUrl, 'https:')) {
       const httpsCert = config.HTTPS_CERT || '';
       const httpsKey = config.HTTPS_KEY || '';
       logger.debug(

--- a/lib/client/checks/config/brokerClientUrlCheck.ts
+++ b/lib/client/checks/config/brokerClientUrlCheck.ts
@@ -1,0 +1,104 @@
+import { log as logger } from '../../../logs/logger';
+import type { CheckOptions, CheckResult } from '../types';
+import type { Config } from '../../types/config';
+import { urlContainsProtocol } from '../../../common/utils/urlValidator';
+
+export function validateBrokerClientUrl(
+  checkOptions: CheckOptions,
+  config: Config,
+): CheckResult {
+  logger.debug({ checkId: checkOptions.id }, 'executing config check');
+
+  const brokerClientUrl = config.BROKER_CLIENT_URL;
+  try {
+    if (!isHttpUrl(brokerClientUrl)) {
+      return {
+        id: checkOptions.id,
+        name: checkOptions.name,
+        status: 'error',
+        output: `Broker Client URL must use the HTTP or HTTPS protocols. Configured URL: ${brokerClientUrl}`,
+      } satisfies CheckResult;
+    }
+
+    if (isHttpsWithoutCertificates(config)) {
+      return {
+        id: checkOptions.id,
+        name: checkOptions.name,
+        status: 'error',
+        output: `Broker Client URL uses the HTTPS protocol: ${brokerClientUrl}, but HTTPS_CERT and HTTPS_KEY environment variables are missing.`,
+      } satisfies CheckResult;
+    }
+
+    if (isHostnameLocalhost(brokerClientUrl)) {
+      return {
+        id: checkOptions.id,
+        name: checkOptions.name,
+        status: 'warning',
+        output: `Broker Client URL is configured for localhost: ${brokerClientUrl}. Webhooks might not work`,
+      } satisfies CheckResult;
+    }
+
+    return {
+      id: checkOptions.id,
+      name: checkOptions.name,
+      status: 'passing',
+      output: 'config check: ok',
+    } satisfies CheckResult;
+  } catch (error) {
+    const errorMessage = `Error executing check with checkId ${checkOptions.id}`;
+    logger.debug({ error }, errorMessage);
+    throw new Error(errorMessage);
+  }
+}
+
+function isHttpUrl(brokerClientUrl: string): boolean {
+  logger.trace(
+    { url: brokerClientUrl },
+    'checking if URL is correctly configured',
+  );
+  try {
+    return (
+      urlContainsProtocol(brokerClientUrl, 'http:') ||
+      urlContainsProtocol(brokerClientUrl, 'https:')
+    );
+  } catch (error) {
+    logger.error({ error }, 'Error checking URL HTTP protocol');
+    return false;
+  }
+}
+
+function isHttpsWithoutCertificates(config: Config): boolean {
+  const brokerClientUrl = config.BROKER_CLIENT_URL;
+  logger.trace(
+    { url: brokerClientUrl },
+    'checking if HTTPS is correctly configured',
+  );
+
+  try {
+    if (urlContainsProtocol(brokerClientUrl, 'https:')) {
+      const httpsCert = config.HTTPS_CERT || '';
+      const httpsKey = config.HTTPS_KEY || '';
+      logger.debug(
+        { httpsCert: httpsCert, httpsKey: httpsKey },
+        'configured HTTPS certificate and key',
+      );
+      return httpsCert.length === 0 || httpsKey.length === 0;
+    }
+    return false;
+  } catch (error) {
+    logger.error({ error }, 'Error checking URL for HTTPS server');
+    return false;
+  }
+}
+
+function isHostnameLocalhost(brokerClientUrl: string): boolean {
+  logger.trace({ url: brokerClientUrl }, 'checking if localhost is used');
+
+  try {
+    const givenURL = new URL(brokerClientUrl);
+    return givenURL.hostname === 'localhost';
+  } catch (error) {
+    logger.error({ error }, 'Error checking URL for using localhost');
+    return false;
+  }
+}

--- a/lib/client/checks/config/index.ts
+++ b/lib/client/checks/config/index.ts
@@ -1,0 +1,19 @@
+import type { Config } from '../../types/config';
+import type { Check, CheckResult } from '../types';
+import { validateBrokerClientUrl } from './brokerClientUrlCheck';
+
+export function getConfigChecks(config: Config): Check[] {
+  return [brokerClientUrlCheck(config)];
+}
+
+const brokerClientUrlCheck = (config: Config): Check => {
+  const url = config.BROKER_CLIENT_URL;
+  return {
+    id: 'broker-client-url-validation',
+    name: 'Broker Client URL Validation Check',
+    enabled: url.length > 0,
+    check: function (): CheckResult {
+      return validateBrokerClientUrl({ id: this.id, name: this.name }, config);
+    },
+  } satisfies Check;
+};

--- a/lib/client/checks/config/index.ts
+++ b/lib/client/checks/config/index.ts
@@ -11,7 +11,7 @@ const brokerClientUrlCheck = (config: Config): Check => {
   return {
     id: 'broker-client-url-validation',
     name: 'Broker Client URL Validation Check',
-    enabled: url.length > 0,
+    enabled: url != undefined && url.length > 0,
     check: function (): CheckResult {
       return validateBrokerClientUrl({ id: this.id, name: this.name }, config);
     },

--- a/lib/client/checks/index.ts
+++ b/lib/client/checks/index.ts
@@ -1,4 +1,5 @@
 import { log as logger } from '../../logs/logger';
+import { getConfigChecks } from './config';
 import { getHttpChecks } from './http';
 import type { Config } from '../types/config';
 import type { Check, CheckResult } from './types';
@@ -29,6 +30,10 @@ export async function executePreflightChecks(
   const preflightChecks: Check[] = [];
   const httpChecks = getHttpChecks(config as Config).filter((c) => c.enabled);
   preflightChecks.push(...httpChecks);
+  const configChecks = getConfigChecks(config as Config).filter(
+    (c) => c.enabled,
+  );
+  preflightChecks.push(...configChecks);
 
   const preflightCheckResults: CheckResult[] = [];
   const results = await Promise.allSettled(

--- a/lib/client/checks/types.ts
+++ b/lib/client/checks/types.ts
@@ -30,6 +30,7 @@ export interface CheckResult {
 }
 
 export type CheckId = string;
+export type CheckOptions = { id: CheckId; name: string };
 export type CheckStatus = 'passing' | 'warning' | 'error';
 
 /**

--- a/lib/client/types/config.ts
+++ b/lib/client/types/config.ts
@@ -3,7 +3,7 @@ interface BackendAPI {
 }
 
 interface BrokerClient {
-  BROKER_CLIENT_URL: string;
+  BROKER_CLIENT_URL?: string;
   HTTPS_CERT: string;
   HTTPS_KEY: string;
   INSECURE_DOWNSTREAM: string;

--- a/lib/client/types/config.ts
+++ b/lib/client/types/config.ts
@@ -3,8 +3,11 @@ interface BackendAPI {
 }
 
 interface BrokerClient {
-  PREFLIGHT_CHECKS_ENABLED: string;
+  BROKER_CLIENT_URL: string;
+  HTTPS_CERT: string;
+  HTTPS_KEY: string;
   INSECURE_DOWNSTREAM: string;
+  PREFLIGHT_CHECKS_ENABLED: string;
 }
 
 interface BrokerServer {

--- a/lib/common/utils/urlValidator.ts
+++ b/lib/common/utils/urlValidator.ts
@@ -1,0 +1,16 @@
+import { log as logger } from '../../logs/logger';
+
+/**
+ * Returns `true` if URL contains a requested protocol, otherwise `false`.
+ * @param url url to check
+ * @param protocol protocol to compare
+ */
+export function urlContainsProtocol(url: string, protocol: string): boolean {
+  try {
+    const givenUrl = new URL(url);
+    return givenUrl.protocol === protocol;
+  } catch (error) {
+    logger.error({ error }, 'Error parsing url');
+    return false;
+  }
+}

--- a/test/helpers/test-factories.ts
+++ b/test/helpers/test-factories.ts
@@ -28,6 +28,7 @@ export const aHttpCheck = (fields: Partial<HttpCheck>): HttpCheck => {
 export const aConfig = (fields: Partial<Config>): Config => {
   return {
     API_BASE_URL: 'http://api:8080',
+    BROKER_CLIENT_URL: 'http://broker-client:8000',
     BROKER_DISPATCHER_BASE_URL: 'http://dispatcher:8080',
     BROKER_HA_MODE_ENABLED: 'false',
     BROKER_SERVER_URL: 'http://broker-server:8080',
@@ -38,5 +39,5 @@ export const aConfig = (fields: Partial<Config>): Config => {
     GPG_PRIVATE_KEY: '',
     INSECURE_DOWNSTREAM: 'false',
     ...fields,
-  };
+  } as Config;
 };

--- a/test/unit/client/checks/check.test.ts
+++ b/test/unit/client/checks/check.test.ts
@@ -1,8 +1,35 @@
 import { aConfig } from '../../../helpers/test-factories';
+import { getConfigChecks } from '../../../../lib/client/checks/config';
 import { getHttpChecks } from '../../../../lib/client/checks/http';
 
 describe('client/checks', () => {
   describe('preflightChecksEnabled()', () => {
+    it('should return true for broker-client-url-validation.enabled if broker client url is configured', () => {
+      const config = aConfig({
+        BROKER_CLIENT_URL: 'http://broker-client:8000',
+      });
+
+      const configChecks = getConfigChecks(config).filter(
+        (c) => c.id === 'broker-client-url-validation',
+      );
+
+      expect(configChecks).toHaveLength(1);
+      expect(configChecks[0].enabled).toEqual(true);
+    });
+
+    it('should return false for broker-client-url-validation.enabled if broker client url is not configured', () => {
+      const config = aConfig({
+        BROKER_CLIENT_URL: '',
+      });
+
+      const configChecks = getConfigChecks(config).filter(
+        (c) => c.id === 'broker-client-url-validation',
+      );
+
+      expect(configChecks).toHaveLength(1);
+      expect(configChecks[0].enabled).toEqual(false);
+    });
+
     it('should return true for rest-api-status.enabled if high availability mode is on', async () => {
       const config = aConfig({
         BROKER_HA_MODE_ENABLED: 'true',

--- a/test/unit/client/checks/check.test.ts
+++ b/test/unit/client/checks/check.test.ts
@@ -17,11 +17,24 @@ describe('client/checks', () => {
       expect(configChecks[0].enabled).toEqual(true);
     });
 
-    it('should return false for broker-client-url-validation.enabled if broker client url is not configured', () => {
+    it('should return false for broker-client-url-validation.enabled if broker client url is configured empty', () => {
       const config = aConfig({
         BROKER_CLIENT_URL: '',
       });
 
+      const configChecks = getConfigChecks(config).filter(
+        (c) => c.id === 'broker-client-url-validation',
+      );
+
+      expect(configChecks).toHaveLength(1);
+      expect(configChecks[0].enabled).toEqual(false);
+    });
+
+    it('should return false for broker-client-url-validation.enabled if broker client url is not configured at all', () => {
+      const config = aConfig({
+        BROKER_CLIENT_URL: '',
+      });
+      delete config['BROKER_CLIENT_URL'];
       const configChecks = getConfigChecks(config).filter(
         (c) => c.id === 'broker-client-url-validation',
       );

--- a/test/unit/client/checks/config/brokerClientUrlCheck.test.ts
+++ b/test/unit/client/checks/config/brokerClientUrlCheck.test.ts
@@ -1,0 +1,88 @@
+import { aConfig } from '../../../../helpers/test-factories';
+import { validateBrokerClientUrl } from '../../../../../lib/client/checks/config/brokerClientUrlCheck';
+
+describe('client/checks/config', () => {
+  describe('validateBrokerClientUrl()', () => {
+    it('should return error check result if protocol is missing', () => {
+      const id = `check_${Date.now()}`;
+      const config = aConfig({
+        BROKER_CLIENT_URL: 'broker-client:8000',
+      });
+
+      const checkResult = validateBrokerClientUrl({ id: id, name: id }, config);
+
+      expect(checkResult.status).toEqual('error');
+      expect(checkResult.output).toContain(
+        'Configured URL: broker-client:8000',
+      );
+    });
+
+    it('should return error check result for non http(s) protocol', () => {
+      const id = `check_${Date.now()}`;
+      const config = aConfig({
+        BROKER_CLIENT_URL: 'ftp://broker-client:8000',
+      });
+
+      const checkResult = validateBrokerClientUrl({ id: id, name: id }, config);
+
+      expect(checkResult.status).toEqual('error');
+      expect(checkResult.output).toContain(
+        'Configured URL: ftp://broker-client:8000',
+      );
+    });
+
+    it('should return error check result for https protocol without certificate and key', () => {
+      const id = `check_${Date.now()}`;
+      const config = aConfig({
+        BROKER_CLIENT_URL: 'https://broker-client:8000',
+      });
+
+      const checkResult = validateBrokerClientUrl({ id: id, name: id }, config);
+
+      expect(checkResult.status).toEqual('error');
+      expect(checkResult.output).toContain(
+        'HTTPS_CERT and HTTPS_KEY environment variables are missing',
+      );
+    });
+
+    it('should return warning check result for localhost', () => {
+      const id = `check_${Date.now()}`;
+      const config = aConfig({
+        BROKER_CLIENT_URL: 'http://localhost:8000',
+      });
+
+      const checkResult = validateBrokerClientUrl({ id: id, name: id }, config);
+
+      expect(checkResult.status).toEqual('warning');
+      expect(checkResult.output).toContain(
+        'Broker Client URL is configured for localhost',
+      );
+    });
+
+    it('should return passing check result for http protocol', () => {
+      const id = `check_${Date.now()}`;
+      const config = aConfig({
+        BROKER_CLIENT_URL: 'http://broker-client:8000',
+      });
+
+      const checkResult = validateBrokerClientUrl({ id: id, name: id }, config);
+
+      expect(checkResult.status).toEqual('passing');
+      expect(checkResult.output).toContain('config check: ok');
+    });
+
+    it('should return passing check result for https protocol with certificate and key', () => {
+      const id = `check_${Date.now()}`;
+      const config = aConfig({
+        BROKER_CLIENT_URL: 'https://broker-client:8000',
+        HTTPS_CERT: 'path-to-cert',
+        HTTPS_KEY: 'path-to-key',
+      });
+
+      const checkResult = validateBrokerClientUrl({ id: id, name: id }, config);
+
+      expect(checkResult.status).toEqual('passing');
+      expect(checkResult.output).toContain('config check: ok');
+    });
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR adds a preflight check for `BROKER_CLIENT_URL`. Following criteria are validated:
- protocol: can be only http or https
- in case of https protocol, [certificate and key](https://docs.snyk.io/enterprise-setup/snyk-broker/install-and-configure-snyk-broker/advanced-configuration-for-snyk-broker-docker-installation/https-for-broker-client-with-docker) must be configured
- if hostname is localhost, warning status will be set

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
