### PR TITLE
fix: log downstream response info with verbose option

### DIFF
--- a/lib/common/http/request.ts
+++ b/lib/common/http/request.ts
@@ -160,13 +160,21 @@ export const makeStreamingRequestToDownstream = (
             response.statusCode >= 200 &&
             response.statusCode < 300
           ) {
-            logger.trace(
-              { statusCode: response.statusCode, url: localRequest.url },
-              `Successful request`,
+            logger.info(
+              {
+                statusCode: response.statusCode,
+                url: localRequest.url,
+                headers: config.LOG_INFO_VERBOSE ? response.headers : {},
+              },
+              `Successful downstream request`,
             );
           } else {
-            logger.debug(
-              { statusCode: response.statusCode, url: localRequest.url },
+            logger.warn(
+              {
+                statusCode: response.statusCode,
+                url: localRequest.url,
+                headers: response.headers,
+              },
               `Non 2xx HTTP Code Received`,
             );
           }


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adds logging for downstream response to log url and response code. Opt-in verbose mode also includes the headers if need be. Off by default as it adds quite a bit to the overall log volume.

