### PR TITLE
fix: peg node extra ca cert to ca_cert env var

### DIFF
--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -110,3 +110,5 @@ COPY --from=broker-builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-
 
 WORKDIR /home/node
 USER node
+
+ENV NODE_EXTRA_CA_CERTS=${CA_CERT}

--- a/dockerfiles/base/Dockerfile.ubi
+++ b/dockerfiles/base/Dockerfile.ubi
@@ -85,3 +85,4 @@ RUN yum upgrade --assumeyes && \
     rpm --erase --nodeps rpm-libs
 
 USER snyk
+ENV NODE_EXTRA_CA_CERTS=${CA_CERT}

--- a/dockerfiles/container-registry-agent/Dockerfile
+++ b/dockerfiles/container-registry-agent/Dockerfile
@@ -14,6 +14,8 @@ USER root
 RUN chgrp -R 0 /home/node && chmod -R g=u,o= /home/node && chown -R node /home/node
 USER node
 
+ENV NODE_EXTRA_CA_CERTS=${CA_CERT}
+
 EXPOSE $PORT
 
 ENTRYPOINT ["/home/node/docker-entrypoint.sh"]

--- a/dockerfiles/container-registry-agent/Dockerfile.ubi
+++ b/dockerfiles/container-registry-agent/Dockerfile.ubi
@@ -9,6 +9,8 @@ USER root
 RUN broker init container-registry-agent
 USER snyk
 
+ENV NODE_EXTRA_CA_CERTS=${CA_CERT}
+
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 CMD ["broker", "--verbose"]


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Pegs the extra ca cert env var for node to CA_CERT that's in the docs today.