### PR TITLE
fix: insecure downstream does not apply to snyk calls

### DIFF
--- a/lib/common/http/utils.ts
+++ b/lib/common/http/utils.ts
@@ -1,7 +1,10 @@
 import { log as logger } from '../../logs/logger';
 export const switchToInsecure = (url: string) => {
-  logger.debug({ url }, 'Forcing insecure url');
   const urlToSwitch = new URL(url);
-  urlToSwitch.protocol = 'http';
+  if (!urlToSwitch.hostname.includes('.snyk.io')) {
+    logger.debug({ url }, 'Forcing insecure url');
+    urlToSwitch.protocol = 'http';
+  }
+
   return urlToSwitch.toString();
 };


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Insecure downstream mode should not apply to snyk calls, which must remain over http, notably for HA mode setup.
