### PR TITLE
fix: add tls terminated broker client url case handling in checks [ED-350]

### DIFF
--- a/lib/client/checks/config/index.ts
+++ b/lib/client/checks/config/index.ts
@@ -12,8 +12,11 @@ const brokerClientUrlCheck = (config: Config): Check => {
     id: 'broker-client-url-validation',
     name: 'Broker Client URL Validation Check',
     enabled: url != undefined && url.length > 0,
-    check: function (): CheckResult {
-      return validateBrokerClientUrl({ id: this.id, name: this.name }, config);
+    check: async function (): Promise<CheckResult> {
+      return await validateBrokerClientUrl(
+        { id: this.id, name: this.name },
+        config,
+      );
     },
   } satisfies Check;
 };


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
In some cases, one can specify the BROKER_CLIENT_URL to be using https without having to provide a cert and key because TLS is terminated before the request makes it to the broker client.

This PR adds extra checks in the config preflight check to attempt identifying this scenario. If the https call to the broker client doesn’t resolve, a flag should indicate TLS termination so the check passes, without forcing us to globally disable this check. Based on the amount of cases in which broker client urls are misconfigured, it is necessary.

If one adds the BROKER_CLIENT_URL_TLS_TERMINATED=true env var, the BROKER_CLIENT_URL will ignore the fact that even though it is configured to https, the broker client doesn't have any https cert+key.
Otherwise the checks will perform its duty of reporting what appears to be a misconfiguration.

