### PR TITLE
fix: adjust checks output if all passing

### DIFF
--- a/lib/client/checks/index.ts
+++ b/lib/client/checks/index.ts
@@ -86,11 +86,21 @@ const logPreflightCheckResults = (results: CheckResult[]) => {
     return { id: check.id, status: check.status };
   });
   nonPassingChecksDetails.push(
-    '#############################################################################################',
+    '##########################################################################################',
   );
   console.log('### Preflight checks summary');
   console.table(checks);
   console.log('\n');
-  console.log(nonPassingChecksDetails.join('\n###'));
-  console.log('\n\n');
+  if (checks.some((x) => x.status != 'passing')) {
+    console.log(nonPassingChecksDetails.join('\n###'));
+  } else {
+    console.log(
+      '#############################################################################################',
+    );
+    console.log('### All Preflight checks passing');
+    console.log(
+      '#############################################################################################',
+    );
+  }
+  console.log('\n');
 };


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adds concise success summary

```
##############################################################
### PREFLIGHT CHECKS RESULTS - NON BLOCKING
###
### Preflight checks help to catch errors early, upon broker
### client startup. Note, that broker client will start
### whether the checks were successful or not.
###
##############################################################


### Preflight checks summary
┌─────────┬────────────────────────────────┬───────────┐
│ (index) │               id               │  status   │
├─────────┼────────────────────────────────┼───────────┤
│    0    │     'broker-server-status'     │ 'passing' │
│    1    │ 'broker-client-url-validation' │ 'passing' │
└─────────┴────────────────────────────────┴───────────┘


#############################################################################################
### All Preflight checks passing
#############################################################################################
```

