### PR TITLE
chore: build nlatest images with Node.js 21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -901,7 +901,7 @@ workflows:
           requires:
             - Scan repository for secrets
           dockerfile: dockerfiles/base/Dockerfile
-          nodejs_cycle: "20"
+          nodejs_cycle: "21"
           project_name: broker-nlatest
           post-steps:
             - notify-slack-on-failure


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR bumps Node.js version to 21 when building `*-nlatest` Docker images.
