### PR TITLE
fix(circleci): pin semantic-release version during release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,7 +426,9 @@ jobs:
           at: ~/broker
       - run:
           name: Release to GitHub
-          command: npm i @semantic-release/exec pkg --save-dev && npx semantic-release@19.0.5
+          command: |
+            npm install --save-exact --save-dev semantic-release@22.0.12 @semantic-release/exec@6.0.3 pkg@5.8.1
+            npx semantic-release
 
 workflows:
   CICD:


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR fixes failing semantic-release step because of Node.js 18/20 incompatibility. Now we install exact version during CircleCI step before executing `npx semantic-release` command.

- semantic-release@22.0.12 (23.+ versions are not compatible with Node.js 18)
- @semantic-release/exec@6.0.3
- pkg@5.8.1

Semantic-release recommends to pin version in CI to avoid any issues: https://semantic-release.gitbook.io/semantic-release/usage/installation#notes

Info about dropping Node.js 18: https://github.com/semantic-release/semantic-release/releases/tag/v23.0.0
