### PR TITLE
fix(docker): remove non-needed packages from RHEL UBI image

### DIFF
--- a/dockerfiles/base/Dockerfile.ubi
+++ b/dockerfiles/base/Dockerfile.ubi
@@ -67,11 +67,20 @@ RUN <<EOF
     rpm --erase --nodeps libarchive
     rpm --erase --nodeps libcurl
     rpm --erase --nodeps libsolv
+    rpm --erase --nodeps libssh
+    rpm --erase --nodeps libssh-config
     rpm --erase --nodeps libnghttp2
+    rpm --erase --nodeps libtasn1
+    rpm --erase --nodeps libxml2
+    rpm --erase --nodeps lz4-libs
+    rpm --erase --nodeps ncurses-base
+    rpm --erase --nodeps openldap
     rpm --erase --nodeps platform-python
     rpm --erase --nodeps platform-python-setuptools
     rpm --erase --nodeps python3-cloud-what
+    rpm --erase --nodeps python3-gpg
     rpm --erase --nodeps python3-libs
+    rpm --erase --nodeps python3-pip-wheel
     rpm --erase --nodeps python3-rpm
     rpm --erase --nodeps python3-setuptools-wheel
     rpm --erase --nodeps python3-subscription-manager-rhsm


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR removes some non-needed packages from RHEL UBI base image and reduces vulnerability risk. Following packages are removed:

- libssh
- libssh-config
- libtasn1
- libxml2
- lz4-libs
- ncurses-base
- openldap
- gpg
- python-pip-wheel

