### PR TITLE
fix(docker): remove tough-cookie dependency pinning [HYB-123]

### DIFF
--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -89,9 +89,6 @@ RUN npm install --global snyk-broker
 
 # removing non-used (transitive) dependencies to fix vulnerabilities
 RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/setheader/node_modules/debug
-RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/tough-cookie
-RUN npm install --global tough-cookie@4.1.3
-RUN mv /home/node/.npm-global/lib/node_modules/tough-cookie /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules
 
 
 

--- a/dockerfiles/base/Dockerfile.ubi
+++ b/dockerfiles/base/Dockerfile.ubi
@@ -21,9 +21,6 @@ ENV BROKER_VERSION=${BROKER_VERSION}
 RUN npm install --global snyk-broker@${BROKER_VERSION}
 
 # removing non-used (transitive) dependencies to fix vulnerabilities
-RUN rm -rf /opt/app-root/src/.npm-global/lib/node_modules/snyk-broker/node_modules/tough-cookie
-RUN npm install --global tough-cookie@4.1.3
-RUN mv /opt/app-root/src/.npm-global/lib/node_modules/tough-cookie /opt/app-root/src/.npm-global/lib/node_modules/snyk-broker/node_modules
 RUN rm -rf /opt/app-root/src/.npm-global/lib/node_modules/snyk-broker/node_modules/setheader/node_modules/debug
 
 

--- a/package.json
+++ b/package.json
@@ -89,9 +89,6 @@
     "undefsafe": "^2.0.2",
     "uuid": "^8.1.0"
   },
-  "overrides": {
-    "tough-cookie": "4.1.3"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/snyk/broker.git"


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR removes `tough-cookie` version pinning. Since `request` package was removed in version [4.166.0](https://github.com/snyk/broker/releases/tag/v4.166.0), we don't need it anymore.


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
