### PR TITLE
feat: add fallback api route for webhook if ws conn down [HYB-448]

### DIFF
--- a/lib/client/checks/http/index.ts
+++ b/lib/client/checks/http/index.ts
@@ -1,5 +1,4 @@
 import { executeHttpRequest } from './http-executor';
-import { highAvailabilityModeEnabled } from '../../dispatcher';
 import type { CheckResult, HttpCheck } from '../types';
 import type { Config } from '../../types/config';
 
@@ -33,11 +32,10 @@ const restApiStatusCheck = (config: Config): HttpCheck => {
     config.API_BASE_URL || config.BROKER_SERVER_URL
       ? config.BROKER_SERVER_URL.replace('//broker.', '//api.')
       : 'https://api.snyk.io';
-  const enabled = highAvailabilityModeEnabled(config);
   return {
     id: 'rest-api-status',
     name: 'REST API Healthcheck',
-    enabled: enabled,
+    enabled: true,
 
     url: `${url}/rest/openapi`,
     method: 'GET',

--- a/lib/client/routesHandler/healthcheckHandler.ts
+++ b/lib/client/routesHandler/healthcheckHandler.ts
@@ -1,13 +1,13 @@
-import primus from 'primus';
 import { Request, Response } from 'express';
 import version from '../../common/utils/version';
+import { isWebsocketConnOpen } from '../utils/socketHelpers';
 
 export const healthCheckHandler =
   // io is available in res.locals.io
   (req: Request, res: Response) => {
     // healthcheck state depends on websocket connection status
     // value of primus.Spark.OPEN means the websocket connection is open
-    const isConnOpen = res.locals.io.readyState === primus.Spark.OPEN;
+    const isConnOpen = isWebsocketConnOpen(res.locals.io);
     const status = isConnOpen ? 200 : 500;
     const data = {
       ok: isConnOpen,

--- a/lib/client/utils/socketHelpers.ts
+++ b/lib/client/utils/socketHelpers.ts
@@ -1,0 +1,5 @@
+import primus from 'primus';
+
+export const isWebsocketConnOpen = (io) => {
+  return io.readyState === primus.Spark.OPEN;
+};

--- a/lib/common/relay/forwardHttpRequestOverHttp.ts
+++ b/lib/common/relay/forwardHttpRequestOverHttp.ts
@@ -1,0 +1,85 @@
+import { Request, Response } from 'express';
+import { loadFilters } from '../filter/filtersAsync';
+import { v4 as uuid } from 'uuid';
+
+import { log as logger } from '../../logs/logger';
+import { incrementHttpRequestsTotal } from '../utils/metrics';
+
+import { ExtendedLogContext } from '../types/log';
+import { makeRequestToDownstream } from '../http/request';
+
+// 1. Request coming in over HTTP conn (logged)
+// 2. Filter for rule match (log and block if no match)
+// 3. Relay over websocket conn (logged)
+// 4. Get response over websocket conn (logged)
+// 5. Send response over HTTP conn
+export const forwardHttpRequestOverHttp = (filterRules, config) => {
+  const filters = loadFilters(filterRules);
+
+  return (req: Request, res: Response) => {
+    // If this is the server, we should receive a Snyk-Request-Id header from upstream
+    // If this is the client, we will have to generate one
+    req.headers['snyk-request-id'] ||= uuid();
+    const logContext: ExtendedLogContext = {
+      url: req.url,
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      requestId:
+        req.headers['snyk-request-id'] &&
+        Array.isArray(req.headers['snyk-request-id'])
+          ? req.headers['snyk-request-id'].join(',')
+          : req.headers['snyk-request-id'] || '',
+      maskedToken: req['maskedToken'],
+      hashedToken: req['hashedToken'],
+    };
+
+    const simplifiedContext = logContext;
+    delete simplifiedContext.requestHeaders;
+    logger.info(simplifiedContext, '[HTTP Flow] Received request');
+    const filterResponse = filters(req);
+    if (!filterResponse) {
+      incrementHttpRequestsTotal(true, 'inbound-request');
+      const reason =
+        'Request does not match any accept rule, blocking HTTP request';
+      logContext.error = 'blocked';
+      logger.warn(logContext, reason);
+      // TODO: respect request headers, block according to content-type
+      return res.status(401).send({ message: 'blocked', reason, url: req.url });
+    } else {
+      incrementHttpRequestsTotal(false, 'inbound-request');
+
+      const apiDomain = new URL(
+        config.API_BASE_URL ||
+          (config.BROKER_SERVER_URL
+            ? config.BROKER_SERVER_URL.replace('//broker.', '//api.')
+            : 'https://api.snyk.io'),
+      );
+
+      const requestUri = new URL(req.url, apiDomain);
+      req.headers['host'] = requestUri.host;
+
+      const filteredReq = {
+        url: requestUri.toString(),
+        method: req.method,
+        body: req.body,
+        headers: req.headers,
+      };
+
+      makeRequestToDownstream(filteredReq)
+        .then((resp) => {
+          if (resp.statusCode) {
+            res.status(resp.statusCode).set(resp.headers).send(resp.body);
+          } else {
+            res.status(500).send(resp.statusText);
+          }
+        })
+        .catch((err) => {
+          logger.error(
+            logContext,
+            err,
+            'Failed to forward webhook event to Snyk Platform',
+          );
+        });
+    }
+  };
+};

--- a/test/fixtures/client/filters-webhook.json
+++ b/test/fixtures/client/filters-webhook.json
@@ -1,0 +1,11 @@
+{
+  "private": [
+    
+  ],
+  "public": [
+    {
+      "path": "/webhook/github/:webhookId",
+      "method": "POST"
+    }
+  ]
+}

--- a/test/fixtures/server/filters-webhook.json
+++ b/test/fixtures/server/filters-webhook.json
@@ -1,0 +1,12 @@
+{
+  "private": [
+    {
+      "path": "/webhook/*",
+      "method": "POST",
+      "origin": "http://localhost:9000"
+    }
+  ],
+  "public": [
+
+  ]
+}

--- a/test/fixtures/webhook/payload.json
+++ b/test/fixtures/webhook/payload.json
@@ -1,0 +1,214 @@
+{
+  "ref": "refs/heads/master",
+  "before": "879eca4d50ee4018f92e6abf61fdd66301cba93b",
+  "after": "82b06b89af77ef21b71400e42d21391952b97100",
+  "repository": {
+    "id": 120047522,
+    "node_id": "MDEwOlJlcG9zaXRvcnkxMjAwNDc1MjI=",
+    "name": "goof",
+    "full_name": "aarlaud-playground/goof",
+    "private": false,
+    "owner": {
+      "name": "aarlaud-playground",
+      "email": null,
+      "login": "aarlaud-playground",
+      "id": 36091540,
+      "node_id": "MDEyOk9yZ2FuaXphdGlvbjM2MDkxNTQw",
+      "avatar_url": "https://avatars.githubusercontent.com/u/36091540?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/aarlaud-playground",
+      "html_url": "https://github.com/aarlaud-playground",
+      "followers_url": "https://api.github.com/users/aarlaud-playground/followers",
+      "following_url": "https://api.github.com/users/aarlaud-playground/following{/other_user}",
+      "gists_url": "https://api.github.com/users/aarlaud-playground/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/aarlaud-playground/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/aarlaud-playground/subscriptions",
+      "organizations_url": "https://api.github.com/users/aarlaud-playground/orgs",
+      "repos_url": "https://api.github.com/users/aarlaud-playground/repos",
+      "events_url": "https://api.github.com/users/aarlaud-playground/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/aarlaud-playground/received_events",
+      "type": "Organization",
+      "site_admin": false
+    },
+    "html_url": "https://github.com/aarlaud-playground/goof",
+    "description": "Super vulnerable todo list application",
+    "fork": true,
+    "url": "https://github.com/aarlaud-playground/goof",
+    "forks_url": "https://api.github.com/repos/aarlaud-playground/goof/forks",
+    "keys_url": "https://api.github.com/repos/aarlaud-playground/goof/keys{/key_id}",
+    "collaborators_url": "https://api.github.com/repos/aarlaud-playground/goof/collaborators{/collaborator}",
+    "teams_url": "https://api.github.com/repos/aarlaud-playground/goof/teams",
+    "hooks_url": "https://api.github.com/repos/aarlaud-playground/goof/hooks",
+    "issue_events_url": "https://api.github.com/repos/aarlaud-playground/goof/issues/events{/number}",
+    "events_url": "https://api.github.com/repos/aarlaud-playground/goof/events",
+    "assignees_url": "https://api.github.com/repos/aarlaud-playground/goof/assignees{/user}",
+    "branches_url": "https://api.github.com/repos/aarlaud-playground/goof/branches{/branch}",
+    "tags_url": "https://api.github.com/repos/aarlaud-playground/goof/tags",
+    "blobs_url": "https://api.github.com/repos/aarlaud-playground/goof/git/blobs{/sha}",
+    "git_tags_url": "https://api.github.com/repos/aarlaud-playground/goof/git/tags{/sha}",
+    "git_refs_url": "https://api.github.com/repos/aarlaud-playground/goof/git/refs{/sha}",
+    "trees_url": "https://api.github.com/repos/aarlaud-playground/goof/git/trees{/sha}",
+    "statuses_url": "https://api.github.com/repos/aarlaud-playground/goof/statuses/{sha}",
+    "languages_url": "https://api.github.com/repos/aarlaud-playground/goof/languages",
+    "stargazers_url": "https://api.github.com/repos/aarlaud-playground/goof/stargazers",
+    "contributors_url": "https://api.github.com/repos/aarlaud-playground/goof/contributors",
+    "subscribers_url": "https://api.github.com/repos/aarlaud-playground/goof/subscribers",
+    "subscription_url": "https://api.github.com/repos/aarlaud-playground/goof/subscription",
+    "commits_url": "https://api.github.com/repos/aarlaud-playground/goof/commits{/sha}",
+    "git_commits_url": "https://api.github.com/repos/aarlaud-playground/goof/git/commits{/sha}",
+    "comments_url": "https://api.github.com/repos/aarlaud-playground/goof/comments{/number}",
+    "issue_comment_url": "https://api.github.com/repos/aarlaud-playground/goof/issues/comments{/number}",
+    "contents_url": "https://api.github.com/repos/aarlaud-playground/goof/contents/{+path}",
+    "compare_url": "https://api.github.com/repos/aarlaud-playground/goof/compare/{base}...{head}",
+    "merges_url": "https://api.github.com/repos/aarlaud-playground/goof/merges",
+    "archive_url": "https://api.github.com/repos/aarlaud-playground/goof/{archive_format}{/ref}",
+    "downloads_url": "https://api.github.com/repos/aarlaud-playground/goof/downloads",
+    "issues_url": "https://api.github.com/repos/aarlaud-playground/goof/issues{/number}",
+    "pulls_url": "https://api.github.com/repos/aarlaud-playground/goof/pulls{/number}",
+    "milestones_url": "https://api.github.com/repos/aarlaud-playground/goof/milestones{/number}",
+    "notifications_url": "https://api.github.com/repos/aarlaud-playground/goof/notifications{?since,all,participating}",
+    "labels_url": "https://api.github.com/repos/aarlaud-playground/goof/labels{/name}",
+    "releases_url": "https://api.github.com/repos/aarlaud-playground/goof/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/aarlaud-playground/goof/deployments",
+    "created_at": 1517619638,
+    "updated_at": "2022-10-13T11:53:48Z",
+    "pushed_at": 1706706273,
+    "git_url": "git://github.com/aarlaud-playground/goof.git",
+    "ssh_url": "git@github.com:aarlaud-playground/goof.git",
+    "clone_url": "https://github.com/aarlaud-playground/goof.git",
+    "svn_url": "https://github.com/aarlaud-playground/goof",
+    "homepage": null,
+    "size": 169,
+    "stargazers_count": 0,
+    "watchers_count": 0,
+    "language": "JavaScript",
+    "has_issues": false,
+    "has_projects": true,
+    "has_downloads": true,
+    "has_wiki": true,
+    "has_pages": false,
+    "has_discussions": false,
+    "forks_count": 0,
+    "mirror_url": null,
+    "archived": false,
+    "disabled": false,
+    "open_issues_count": 36,
+    "license": null,
+    "allow_forking": true,
+    "is_template": false,
+    "web_commit_signoff_required": false,
+    "topics": [
+
+    ],
+    "visibility": "public",
+    "forks": 0,
+    "open_issues": 36,
+    "watchers": 0,
+    "default_branch": "master",
+    "stargazers": 0,
+    "master_branch": "master",
+    "organization": "aarlaud-playground",
+    "custom_properties": {
+
+    }
+  },
+  "pusher": {
+    "name": "aarlaud",
+    "email": "aarlaud@hotmail.com"
+  },
+  "organization": {
+    "login": "aarlaud-playground",
+    "id": 36091540,
+    "node_id": "MDEyOk9yZ2FuaXphdGlvbjM2MDkxNTQw",
+    "url": "https://api.github.com/orgs/aarlaud-playground",
+    "repos_url": "https://api.github.com/orgs/aarlaud-playground/repos",
+    "events_url": "https://api.github.com/orgs/aarlaud-playground/events",
+    "hooks_url": "https://api.github.com/orgs/aarlaud-playground/hooks",
+    "issues_url": "https://api.github.com/orgs/aarlaud-playground/issues",
+    "members_url": "https://api.github.com/orgs/aarlaud-playground/members{/member}",
+    "public_members_url": "https://api.github.com/orgs/aarlaud-playground/public_members{/member}",
+    "avatar_url": "https://avatars.githubusercontent.com/u/36091540?v=4",
+    "description": null
+  },
+  "sender": {
+    "login": "aarlaud",
+    "id": 5722228,
+    "node_id": "MDQ6VXNlcjU3MjIyMjg=",
+    "avatar_url": "https://avatars.githubusercontent.com/u/5722228?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/aarlaud",
+    "html_url": "https://github.com/aarlaud",
+    "followers_url": "https://api.github.com/users/aarlaud/followers",
+    "following_url": "https://api.github.com/users/aarlaud/following{/other_user}",
+    "gists_url": "https://api.github.com/users/aarlaud/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/aarlaud/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/aarlaud/subscriptions",
+    "organizations_url": "https://api.github.com/users/aarlaud/orgs",
+    "repos_url": "https://api.github.com/users/aarlaud/repos",
+    "events_url": "https://api.github.com/users/aarlaud/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/aarlaud/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "created": false,
+  "deleted": false,
+  "forced": false,
+  "base_ref": null,
+  "compare": "https://github.com/aarlaud-playground/goof/compare/879eca4d50ee...82b06b89af77",
+  "commits": [
+    {
+      "id": "82b06b89af77ef21b71400e42d21391952b97100",
+      "tree_id": "d7102a794bc126bf3cf3c2a4b7bbf01cfff47438",
+      "distinct": true,
+      "message": "Update backstage-catalog-info.yaml",
+      "timestamp": "2024-01-31T14:04:33+01:00",
+      "url": "https://github.com/aarlaud-playground/goof/commit/82b06b89af77ef21b71400e42d21391952b97100",
+      "author": {
+        "name": "aarlaud",
+        "email": "aarlaud@hotmail.com",
+        "username": "aarlaud"
+      },
+      "committer": {
+        "name": "GitHub",
+        "email": "noreply@github.com",
+        "username": "web-flow"
+      },
+      "added": [
+
+      ],
+      "removed": [
+
+      ],
+      "modified": [
+        "backstage-catalog-info.yaml"
+      ]
+    }
+  ],
+  "head_commit": {
+    "id": "82b06b89af77ef21b71400e42d21391952b97100",
+    "tree_id": "d7102a794bc126bf3cf3c2a4b7bbf01cfff47438",
+    "distinct": true,
+    "message": "Update backstage-catalog-info.yaml",
+    "timestamp": "2024-01-31T14:04:33+01:00",
+    "url": "https://github.com/aarlaud-playground/goof/commit/82b06b89af77ef21b71400e42d21391952b97100",
+    "author": {
+      "name": "aarlaud",
+      "email": "aarlaud@hotmail.com",
+      "username": "aarlaud"
+    },
+    "committer": {
+      "name": "GitHub",
+      "email": "noreply@github.com",
+      "username": "web-flow"
+    },
+    "added": [
+
+    ],
+    "removed": [
+
+    ],
+    "modified": [
+      "backstage-catalog-info.yaml"
+    ]
+  }
+}

--- a/test/functional/webhook.test.ts
+++ b/test/functional/webhook.test.ts
@@ -1,0 +1,83 @@
+const PORT = 9999;
+process.env.BROKER_SERVER_URL = `http://localhost:${PORT}`;
+import path from 'path';
+import { axiosClient } from '../setup/axios-client';
+import {
+  BrokerClient,
+  closeBrokerClient,
+  createBrokerClient,
+  waitForBrokerServerConnection,
+} from '../setup/broker-client';
+import {
+  BrokerServer,
+  closeBrokerServer,
+  createBrokerServer,
+  waitForBrokerClientConnection,
+} from '../setup/broker-server';
+import { TestWebServer, createTestWebServer } from '../setup/test-web-server';
+import { DEFAULT_TEST_WEB_SERVER_PORT } from '../setup/constants';
+
+const fixtures = path.resolve(__dirname, '..', 'fixtures');
+const serverAccept = path.join(fixtures, 'server', 'filters-webhook.json');
+const clientAccept = path.join(fixtures, 'client', 'filters-webhook.json');
+
+describe('proxy requests originating from behind the broker client', () => {
+  let tws: TestWebServer;
+  let bs: BrokerServer;
+  let bc: BrokerClient;
+  let brokerToken: string;
+  let serverMetadata: unknown;
+  process.env.API_BASE_URL = `http://localhost:${DEFAULT_TEST_WEB_SERVER_PORT}`;
+
+  beforeAll(async () => {
+    tws = await createTestWebServer();
+
+    bs = await createBrokerServer({ port: PORT, filters: serverAccept });
+
+    bc = await createBrokerClient({
+      brokerServerUrl: `http://localhost:${bs.port}`,
+      brokerToken: 'broker-token-12345',
+      filters: clientAccept,
+      type: 'client',
+    });
+    ({ brokerToken } = await waitForBrokerClientConnection(bs));
+  });
+
+  afterAll(async () => {
+    await tws.server.close();
+    await closeBrokerClient(bc);
+    await closeBrokerServer(bs);
+    delete process.env.BROKER_SERVER_URL;
+  });
+
+  it('server identifies self to client', async () => {
+    serverMetadata = await waitForBrokerServerConnection(bc);
+
+    expect(brokerToken).toEqual('broker-token-12345');
+    expect(serverMetadata).toMatchObject({
+      capabilities: ['receive-post-streams'],
+    });
+  });
+
+  it('successfully broker Webhook call via tunnel', async () => {
+    const response = await axiosClient.post(
+      `http://localhost:${bc.port}/webhook/github/12345678-1234-1234-1234-123456789abc`,
+      { some: { example: 'json' } },
+    );
+
+    expect(response.status).toEqual(200);
+    expect(response.data).toStrictEqual('Received webhook via websocket');
+  });
+
+  it('successfully broker Webhook call via API', async () => {
+    await closeBrokerServer(bs);
+
+    const response = await axiosClient.post(
+      `http://localhost:${bc.port}/webhook/github/12345678-1234-1234-1234-000000000000`,
+      { some: { example: 'json' } },
+    );
+
+    expect(response.status).toEqual(200);
+    expect(response.data).toStrictEqual('Received webhook via API');
+  });
+});

--- a/test/setup/test-web-server.ts
+++ b/test/setup/test-web-server.ts
@@ -96,6 +96,21 @@ const applyMiddlewares = (app: Express) => {
 const applyEchoRoutes = (app: Express) => {
   const echoRouter = express.Router();
 
+  echoRouter.post(
+    '/webhook/github/12345678-1234-1234-1234-123456789abc',
+    (_: express.Request, resp: express.Response) => {
+      resp.status(200);
+      resp.send('Received webhook via websocket');
+    },
+  );
+  echoRouter.post(
+    '/webhook/github/12345678-1234-1234-1234-000000000000',
+    (_: express.Request, resp: express.Response) => {
+      resp.status(200);
+      resp.send('Received webhook via API');
+    },
+  );
+
   echoRouter.get('/test', (_: express.Request, resp: express.Response) => {
     resp.status(200);
     resp.send('All good');

--- a/test/unit/client/checks/check.test.ts
+++ b/test/unit/client/checks/check.test.ts
@@ -64,7 +64,7 @@ describe('client/checks', () => {
       );
 
       expect(httpChecks).toHaveLength(1);
-      expect(httpChecks[0].enabled).toEqual(false);
+      expect(httpChecks[0].enabled).toEqual(true);
     });
   });
 });


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adds a fallback mechanism for webhook events to be relayed via HTTPS to the API in case the WS tunnel is down for any reason.