### PR TITLE
fix: avoid crashed on econnresets

### DIFF
--- a/lib/common/http/downstream-post-stream-to-server.ts
+++ b/lib/common/http/downstream-post-stream-to-server.ts
@@ -97,7 +97,7 @@ class BrokerServerPostResponseHandler {
             },
             'received error sending data via POST to Broker Server',
           );
-          this.#buffer.end(e);
+          this.#buffer.end(e.message);
         })
         .on('response', (r) => {
           r.on('error', (err) => {
@@ -171,7 +171,7 @@ class BrokerServerPostResponseHandler {
       // If we *don't* have a buffer object, then there was a major failure with the request (e.g., host not found), so
       // we will forward that directly to the Broker Server
       if (this.#buffer) {
-        this.#buffer.end(error);
+        this.#buffer.end(error.message);
       } else {
         const body = JSON.stringify({ error: error });
         this.#sendIoData(


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Pushes the error message in the buffer final message, a string, instead of the error type, causing a crash.