### PR TITLE
fix: make env var replace in string

### DIFF
--- a/lib/common/config/config.ts
+++ b/lib/common/config/config.ts
@@ -195,10 +195,18 @@ export const expandPlaceholderValuesInFlatList = (
   for (const key of Object.keys(objectToExpand)) {
     if (
       typeof objectToExpand[key] == 'string' &&
-      objectToExpand[key].startsWith('$')
+      objectToExpand[key].indexOf('$') > -1
     ) {
-      objectToExpand[key] =
-        referenceConfig[objectToExpand[key].replace('$', '')];
+      const regex = /\$([a-zA-Z0-9_]+)/;
+      const match = regex.exec(objectToExpand[key]);
+      const extractedEnvVarName = match ? match[1] : '';
+
+      if (extractedEnvVarName) {
+        objectToExpand[key] = objectToExpand[key].replace(
+          `$${extractedEnvVarName}`,
+          referenceConfig[extractedEnvVarName],
+        );
+      }
     }
   }
   return objectToExpand;

--- a/test/unit/relay-response-body-universal.test.ts
+++ b/test/unit/relay-response-body-universal.test.ts
@@ -84,7 +84,7 @@ describe('body relay', () => {
       connections: {
         myconn: {
           identifier: brokerToken,
-          HOST: '$HOST2',
+          HOST: 'http://$HOST2',
           PORT: '8001',
           HOST2: 'localhost',
           type: 'github',
@@ -134,7 +134,7 @@ describe('body relay', () => {
         const arg = mockedFn.mock.calls[0][0];
         const url = JSON.parse(arg.body).url;
         expect(url).toEqual(
-          `${config.connections.myconn.HOST2}:${config.connections.myconn.PORT}/webhook`,
+          `http://${config.connections.myconn.HOST2}:${config.connections.myconn.PORT}/webhook`,
         );
       },
     );


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Replace env var placeholders in string, not just for "mirroring" env vars alone.