### PR TITLE
fix: get consolidated cfg for id with replaced env vars

### DIFF
--- a/lib/common/config/universal.ts
+++ b/lib/common/config/universal.ts
@@ -1,5 +1,5 @@
 import { log as logger } from '../../logs/logger';
-import { ConnectionConfig } from '../../client/types/config';
+import { Config, ConnectionConfig } from '../../client/types/config';
 import { expandPlaceholderValuesInFlatList, getConfig } from './config';
 
 export const getConfigForType = (type: string) => {
@@ -65,14 +65,13 @@ export const getConfigForIdentifier = (identifier: string, config) => {
   }
   const configToOverload = {
     ...(connectionType ? getConfigForType(connectionType) : {}),
-    ...(connectionKey
-      ? expandPlaceholderValuesInFlatList(
-          config.connections[connectionKey],
-          config.connections[connectionKey],
-        )
-      : {}),
+    ...(connectionKey ? config.connections[connectionKey] : {}),
   };
-  return configToOverload;
+  const configOverloaded = expandPlaceholderValuesInFlatList(
+    configToOverload,
+    configToOverload,
+  );
+  return configOverloaded as Config;
 };
 
 export const overloadConfigWithConnectionSpecificConfig = (

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -74,8 +74,8 @@ describe('config', () => {
       getConfig(),
     );
     expect(configData).toEqual({
-      BROKER_CLIENT_VALIDATION_AUTHORIZATION_HEADER: 'token $GITHUB_TOKEN',
-      BROKER_CLIENT_VALIDATION_URL: 'https://$GITHUB_API/user',
+      BROKER_CLIENT_VALIDATION_AUTHORIZATION_HEADER: 'token 123',
+      BROKER_CLIENT_VALIDATION_URL: 'https://api.github.com/user',
       BROKER_SERVER_URL: 'https://broker2.dev.snyk.io',
       BROKER_HA_MODE_ENABLED: 'false',
       BROKER_DISPATCHER_BASE_URL: 'https://api.dev.snyk.io',
@@ -85,8 +85,8 @@ describe('config', () => {
       GITHUB_GRAPHQL: 'api.github.com',
       GITHUB_RAW: 'raw.githubusercontent.com',
       GITHUB_TOKEN: '123',
-      GIT_PASSWORD: '$GITHUB_TOKEN',
-      GIT_URL: '$GITHUB',
+      GIT_PASSWORD: '123',
+      GIT_URL: 'github.com',
       GIT_USERNAME: 'x-access-token',
       identifier: 'dummyBrokerIdentifier',
       type: 'github',
@@ -114,8 +114,8 @@ describe('config', () => {
     );
     expect(configData).toEqual({
       BROKER_CLIENT_URL: 'dummy',
-      BROKER_CLIENT_VALIDATION_AUTHORIZATION_HEADER: 'token $GITHUB_TOKEN',
-      BROKER_CLIENT_VALIDATION_URL: 'https://$GITHUB_API/user',
+      BROKER_CLIENT_VALIDATION_AUTHORIZATION_HEADER: 'token 123',
+      BROKER_CLIENT_VALIDATION_URL: 'https://api.github.com/user',
       BROKER_SERVER_URL: 'https://broker2.dev.snyk.io',
       BROKER_HA_MODE_ENABLED: 'false',
       BROKER_DISPATCHER_BASE_URL: 'https://api.dev.snyk.io',
@@ -125,8 +125,8 @@ describe('config', () => {
       GITHUB_GRAPHQL: 'api.github.com',
       GITHUB_RAW: 'raw.githubusercontent.com',
       GITHUB_TOKEN: '123',
-      GIT_PASSWORD: '$GITHUB_TOKEN',
-      GIT_URL: '$GITHUB',
+      GIT_PASSWORD: '123',
+      GIT_URL: 'github.com',
       GIT_USERNAME: 'x-access-token',
       identifier: 'dummyBrokerIdentifier',
       type: 'github',


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Returns a config for a given identifier with the whole set of variables (default+inputted) replacing all placeholders to be ready for use.