### PR TITLE
fix: avoid inbound ws to be routed wrongly

### DIFF
--- a/lib/common/relay/forwardHttpRequest.ts
+++ b/lib/common/relay/forwardHttpRequest.ts
@@ -212,10 +212,7 @@ export const forwardHttpRequest = (
       return res.status(401).send({ message: 'blocked', reason, url: req.url });
     } else {
       incrementHttpRequestsTotal(false, 'inbound-request');
-      if (
-        filterResponse.stream ||
-        res?.locals?.capabilities?.includes('post-streams')
-      ) {
+      if (res?.locals?.capabilities?.includes('post-streams')) {
         makeWebsocketRequestWithStreamingResponse(filterResponse);
       } else {
         makeWebsocketRequestWithWebsocketResponse(filterResponse);


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Removing stream flag causing some websocket flow to be misdirected, causing "Trying to write into a close stream" message.