### PR TITLE
feat: add ws or http response selection logic

### DIFF
--- a/lib/common/types/log.ts
+++ b/lib/common/types/log.ts
@@ -24,4 +24,5 @@ export interface ExtendedLogContext extends LogContext {
   responseBodyType?: string;
   ioErrorType?: string;
   ioOriginalBodySize?: string;
+  responseMedium?: string;
 }

--- a/test/functional/server-client-universal.test.ts
+++ b/test/functional/server-client-universal.test.ts
@@ -85,7 +85,12 @@ describe('proxy requests originating from behind the broker server', () => {
       `http://localhost:${bs.port}/broker/${process.env.BROKER_TOKEN_4}/echo-auth-header-with-bearer-auth/xyz`,
     );
 
-    // const response5 = await axiosClient.get(
+    const response5 = await axiosClient.get(
+      `http://localhost:${bs.port}/broker/${process.env.BROKER_TOKEN_4}/echo-auth-header-with-bearer-auth/xyz`,
+      { headers: { 'x-broker-ws-response': 'whatever' } },
+    );
+
+    // const response6 = await axiosClient.get(
     //   `http://localhost:${bs.port}/broker/${process.env.BROKER_TOKEN_3}/echo-auth-header-with-token-auth/xyz`,
     // );
 
@@ -101,6 +106,10 @@ describe('proxy requests originating from behind the broker server', () => {
     );
     expect(response4.status).toEqual(200);
     expect(response4.data).toEqual(`Bearer ${process.env.JIRA_PAT}`);
+
+    expect(response5.status).toEqual(200);
+    expect(response5.data).toEqual(`Bearer ${process.env.JIRA_PAT}`);
+    expect(response.headers['x-broker-ws-response']).not.toBeNull();
   });
 
   it('successfully warn logs requests without x-snyk-broker-type header', async () => {

--- a/test/functional/server-client.test.ts
+++ b/test/functional/server-client.test.ts
@@ -93,11 +93,43 @@ describe('proxy requests originating from behind the broker server', () => {
     expect(Buffer.from(response.data)).toEqual(body);
   });
 
+  it('successfully broker exact bytes of POST body with WS response', async () => {
+    // stringify the JSON unusually to ensure an unusual exact body
+    const body = Buffer.from(
+      JSON.stringify({ some: { example: 'json' } }, null, 5),
+    );
+    const response = await axiosClient.post(
+      `http://localhost:${bs.port}/broker/${brokerToken}/echo-body`,
+      body,
+      {
+        headers: {
+          'content-type': 'application/json',
+          'x-broker-ws-response': 'whatever',
+        },
+
+        transformResponse: (r) => r,
+      },
+    );
+    expect(response.status).toEqual(200);
+    expect(Buffer.from(response.data)).toEqual(body);
+    expect(response.headers['x-broker-ws-response']).not.toBeNull();
+  });
   it('successfully broker GET', async () => {
     const response = await axiosClient.get(
       `http://localhost:${bs.port}/broker/${brokerToken}/echo-param/xyz`,
     );
 
+    expect(response.headers['x-broker-ws-response']).not.toBeNull();
+    expect(response.status).toEqual(200);
+    expect(response.data).toEqual('xyz');
+  });
+
+  it('successfully broker GET with WS response', async () => {
+    const response = await axiosClient.get(
+      `http://localhost:${bs.port}/broker/${brokerToken}/echo-param/xyz`,
+      { headers: { 'x-broker-ws-response': 'whatever' } },
+    );
+    expect(response.headers['x-broker-ws-response']).not.toBeNull();
     expect(response.status).toEqual(200);
     expect(response.data).toEqual('xyz');
   });


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adds the ability to instruct the client to send the response over the websocket connection instead of the HTTPS POST based on header. Gives further control to refine desired behavior.

`x-broker-ws-response` presence alone suffices to indicate the desire to get the response via WS instead of the default HTTPS post.

