### PR TITLE
fix: url encoded header fix

### DIFF
--- a/defaultFilters/apprisk.json
+++ b/defaultFilters/apprisk.json
@@ -11,25 +11,25 @@
       {
         "//": "Get All Project Details",
         "method": "GET",
-        "path": "/projects",
+        "path": "/cxrestapi/projects",
         "origin": "https://${CHECKMARX}"
       },
       {
         "//": "Get Remote Source Settings for GIT",
         "method": "GET",
-        "path": "/projects/:id/sourceCode/remoteSettings/git",
+        "path": "/cxrestapi/projects/:id/sourceCode/remoteSettings/git",
         "origin": "https://${CHECKMARX}"
       },
       {
         "//": "Get All Scans for Project",
         "method": "GET",
-        "path": "/sast/scans",
+        "path": "/cxrestapi/sast/scans",
         "origin": "https://${CHECKMARX}"
       },
       {
         "//": "Get Statistic Results by Scan Id",
         "method": "GET",
-        "path": "/sast/scans/:id/resultsStatistics",
+        "path": "/cxrestapi/sast/scans/:id/resultsStatistics",
         "origin": "https://${CHECKMARX}"
       }
     ]

--- a/lib/common/relay/prepareRequest.ts
+++ b/lib/common/relay/prepareRequest.ts
@@ -96,6 +96,8 @@ export const prepareRequestFromFilterResult = async (
         ); // replace the variables
         undefsafe(parsedBody, path, source); // put it back in
       }
+      //Remove the BROKER_VAR_SUB for the request body
+      delete parsedBody.BROKER_VAR_SUB;
       payload.body = JSON.stringify(parsedBody);
     }
   }
@@ -210,7 +212,7 @@ export const prepareRequestFromFilterResult = async (
     payload.headers['x-broker-content-type'] ===
       'application/x-www-form-urlencoded'
   ) {
-    payload.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+    payload.headers['content-type'] = 'application/x-www-form-urlencoded';
     if (payload.body) {
       const jsonBody = JSON.parse(payload.body) as Record<string, any>;
       const params = new URLSearchParams();

--- a/test/functional/server-client.test.ts
+++ b/test/functional/server-client.test.ts
@@ -150,7 +150,6 @@ describe('proxy requests originating from behind the broker server', () => {
 
     expect(response.status).toEqual(200);
     expect(response.data).toStrictEqual({
-      BROKER_VAR_SUB: ['swap.me'],
       swap: { me: 'client:broker-token-12345' },
     });
   });

--- a/test/unit/relay-response-body-form-url-encoded.test.ts
+++ b/test/unit/relay-response-body-form-url-encoded.test.ts
@@ -110,7 +110,7 @@ describe('body relay', () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
         const arg = mockedFn.mock.calls[0][0];
         expect(arg.body).toEqual(
-          `BROKER_VAR_SUB=url&url=${config.HOST}%3A${config.PORT}%2Fwebhook`,
+          `url=${config.HOST}%3A${config.PORT}%2Fwebhook`,
         );
 
         done();

--- a/test/unit/relay-response-body-universal-form-url-encoded.test.ts
+++ b/test/unit/relay-response-body-universal-form-url-encoded.test.ts
@@ -116,11 +116,11 @@ describe('body relay', () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
         const arg = mockedFn.mock.calls[0][0];
 
-        expect(arg.headers['Content-Type']).toEqual(
+        expect(arg.headers['content-type']).toEqual(
           'application/x-www-form-urlencoded',
         );
         expect(arg.body).toEqual(
-          `BROKER_VAR_SUB=url&url=${config.connections.myconn.HOST}%3A${config.connections.myconn.PORT}%2Fwebhook`,
+          `url=${config.connections.myconn.HOST}%3A${config.connections.myconn.PORT}%2Fwebhook`,
         );
 
         done();

--- a/test/unit/relay-response-headers-form-url-headers.test.ts
+++ b/test/unit/relay-response-headers-form-url-headers.test.ts
@@ -102,7 +102,7 @@ describe('header relay', () => {
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
         const arg = mockedFn.mock.calls[0][0];
-        expect(arg.headers['Content-Type']).toEqual(
+        expect(arg.headers['content-type']).toEqual(
           'application/x-www-form-urlencoded',
         );
         expect(arg.headers['private-token']).toEqual(

--- a/test/unit/relay-response-headers-universal-form-url-headers.test.ts
+++ b/test/unit/relay-response-headers-universal-form-url-headers.test.ts
@@ -93,6 +93,7 @@ describe('header relay', () => {
 
     const headers = {
       'x-broker-content-type': 'application/x-www-form-urlencoded',
+      'Content-Type': 'application/json',
       'x-broker-var-sub': 'private-token,replaceme',
       donttouch: 'not to be changed ${VALUE}',
       'private-token': 'Bearer ${SECRET_TOKEN}',
@@ -108,6 +109,7 @@ describe('header relay', () => {
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
         const arg = mockedFn.mock.calls[0][0];
+        expect(arg.headers['Content-Type']).toBeUndefined();
         expect(arg.headers['content-type']).toEqual(
           'application/x-www-form-urlencoded',
         );

--- a/test/unit/relay-response-headers-universal-form-url-headers.test.ts
+++ b/test/unit/relay-response-headers-universal-form-url-headers.test.ts
@@ -108,7 +108,7 @@ describe('header relay', () => {
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
         const arg = mockedFn.mock.calls[0][0];
-        expect(arg.headers['Content-Type']).toEqual(
+        expect(arg.headers['content-type']).toEqual(
           'application/x-www-form-urlencoded',
         );
         expect(arg.headers['private-token']).toEqual(
@@ -174,7 +174,7 @@ describe('header relay', () => {
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
         const arg = mockedFn.mock.calls[0][0];
-        expect(arg.headers['Content-Type']).toEqual(
+        expect(arg.headers['content-type']).toEqual(
           'application/x-www-form-urlencoded',
         );
         expect(arg.headers['private-token']).toEqual('Bearer ${SECRET_TOKEN}');


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
1. fixing content-type header ducplications
2. remove BROKER_VAR_SUB from the request 
after the broker is replacing the variables we dont need the BROKER_VAR_SUB anymore
3. fixing Content length calculation after converting body to query search params

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
