### PR TITLE
fix: align info log client vs server

### DIFF
--- a/lib/common/relay/forwardWebsocketRequest.ts
+++ b/lib/common/relay/forwardWebsocketRequest.ts
@@ -161,7 +161,7 @@ export const forwardWebSocketRequest = (
     logger.info(
       simplifiedContext,
       `[Websocket Flow] Received request from ${
-        process.env.BROKER_TYPE == 'client' ? 'server' : 'client'
+        process.env.BROKER_TYPE == 'client' ? 'client' : 'server'
       }`,
     );
 


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Fix wrong conditional order for log info.