### PR TITLE
feat: add catalog-info.yaml paths for azure, github, gitlab

### DIFF
--- a/defaultFilters/apprisk/azure-repos.json
+++ b/defaultFilters/apprisk/azure-repos.json
@@ -130,6 +130,24 @@
     }
   },
   {
+    "//": "used to retrieve organization context from catalog-info.yaml",
+    "method": "GET",
+    "path": "/:org/:project/_apis/git/repositories/:repo/files",
+    "origin": "https://${AZURE_REPOS_HOST}",
+    "auth": {
+      "scheme": "basic",
+      "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+    },
+    "valid": [
+      {
+        "queryParam": "path",
+        "values": [
+          "catalog-info.yaml"
+        ]
+      }
+    ]
+  },
+  {
     "//": "get list of team's members",
     "method": "GET",
     "path": "/:org/_apis/projects/:project/teams/:team/members",

--- a/defaultFilters/apprisk/github.json
+++ b/defaultFilters/apprisk/github.json
@@ -36,6 +36,12 @@
     "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
   },
   {
+    "//": "used to retrieve organization context from catalog-info.yaml",
+    "method": "GET",
+    "path": "/repos/:name/:repo/contents/catalog-info.yaml",
+    "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+  },
+  {
     "//": "used to get repo's languages",
     "method": "GET",
     "path": "/repos/:owner/:repo/languages",

--- a/defaultFilters/apprisk/gitlab.json
+++ b/defaultFilters/apprisk/gitlab.json
@@ -18,9 +18,15 @@
     "origin": "https://${GITLAB}"
   },
   {
+    "//": "used to retrieve organization context from catalog-info.yaml",
+    "method": "GET",
+    "path": "/api/v4/projects/:project/repository/files/catalog-info.yaml/raw",
+    "origin": "https://${GITLAB}"
+  },
+  {
     "//": "get metadata",
     "method": "GET",
     "path": "/api/v4/metadata",
     "origin": "https://${GITLAB}"
-  }
+  },
 ]

--- a/defaultFilters/apprisk/gitlab.json
+++ b/defaultFilters/apprisk/gitlab.json
@@ -28,5 +28,5 @@
     "method": "GET",
     "path": "/api/v4/metadata",
     "origin": "https://${GITLAB}"
-  },
+  }
 ]

--- a/test/unit/__snapshots__/runtime-rules-hotloading.test.ts.snap
+++ b/test/unit/__snapshots__/runtime-rules-hotloading.test.ts.snap
@@ -512,6 +512,24 @@ Object {
       "path": "/:org/:project/_apis/git/repositories/:repo/commits",
     },
     Object {
+      "//": "used to retrieve organization context from catalog-info.yaml",
+      "auth": Object {
+        "scheme": "basic",
+        "token": "\${BROKER_CLIENT_VALIDATION_BASIC_AUTH}",
+      },
+      "method": "GET",
+      "origin": "https://\${AZURE_REPOS_HOST}",
+      "path": "/:org/:project/_apis/git/repositories/:repo/files",
+      "valid": Array [
+        Object {
+          "queryParam": "path",
+          "values": Array [
+            "catalog-info.yaml",
+          ],
+        },
+      ],
+    },
+    Object {
       "//": "get list of team's members",
       "auth": Object {
         "scheme": "basic",
@@ -3698,6 +3716,12 @@ Object {
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
       "path": "/repos/:owner/:repo/contributors",
+    },
+    Object {
+      "//": "used to retrieve organization context from catalog-info.yaml",
+      "method": "GET",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/contents/catalog-info.yaml",
     },
     Object {
       "//": "used to get repo's languages",
@@ -7071,6 +7095,12 @@ Object {
       "method": "GET",
       "origin": "https://\${GITLAB}",
       "path": "/api/v4/projects/:project/groups",
+    },
+    Object {
+      "//": "used to retrieve organization context from catalog-info.yaml",
+      "method": "GET",
+      "origin": "https://\${GITLAB}",
+      "path": "/api/v4/projects/:project/repository/files/catalog-info.yaml/raw",
     },
     Object {
       "//": "get metadata",


### PR DESCRIPTION
#### What does this PR do?

This is a follow-up to https://github.com/snyk/broker/pull/748, which adds the `catalog-info.yaml` file for other SCMs.

#### Where should the reviewer start?

N/A

#### How should this be manually tested?

N/A

#### Any background context you want to provide?

N/A

#### Screenshots

N/A

#### Additional questions

N/A