### PR TITLE
fix: add accept cfg preflight checks signaling codeagent deprec [HYB-437]

### DIFF
--- a/lib/client/checks/config/customAcceptFile.ts
+++ b/lib/client/checks/config/customAcceptFile.ts
@@ -1,0 +1,30 @@
+import { Config } from '../../types/config';
+import { CheckOptions, CheckResult } from '../types';
+
+export const validateAcceptFlagsConfig = (
+  checkOptions: CheckOptions,
+  config: Config,
+): CheckResult => {
+  const acceptFlagKeys = Object.keys(config).filter((x) =>
+    x.startsWith('ACCEPT_'),
+  );
+  if (
+    config.ACCEPT &&
+    config.ACCEPT != 'accept.json' &&
+    acceptFlagKeys.length > 0
+  ) {
+    return {
+      id: checkOptions.id,
+      name: checkOptions.name,
+      status: 'error',
+      output: `ACCEPT_ flags are not compatible with custom accept.json files. Please refrain from using custom accept json (Code Agent is deprecated, see documentation).`,
+    } satisfies CheckResult;
+  }
+
+  return {
+    id: checkOptions.id,
+    name: checkOptions.name,
+    status: 'passing',
+    output: 'ACCEPT flags configuration OK.',
+  } satisfies CheckResult;
+};

--- a/lib/client/checks/config/index.ts
+++ b/lib/client/checks/config/index.ts
@@ -1,12 +1,14 @@
 import type { Config } from '../../types/config';
 import type { Check, CheckResult } from '../types';
 import { validateBrokerClientUrl } from './brokerClientUrlCheck';
+import { validateAcceptFlagsConfig } from './customAcceptFile';
 import { validateUniversalConnectionsConfig } from './universalConnectionConfigCheck';
 
 export function getConfigChecks(config: Config): Check[] {
   return [
     brokerClientUrlCheck(config),
     universalBrokerConnectionsCheck(config),
+    acceptFlagsConfigurationCheck(config),
   ];
 }
 
@@ -32,6 +34,20 @@ const universalBrokerConnectionsCheck = (config: Config): Check => {
     enabled: config.universalBrokerEnabled,
     check: function (): CheckResult {
       return validateUniversalConnectionsConfig(
+        { id: this.id, name: this.name },
+        config,
+      );
+    },
+  } satisfies Check;
+};
+
+const acceptFlagsConfigurationCheck = (config: Config): Check => {
+  return {
+    id: 'accept-flags-config-validation',
+    name: 'Accept flags Configuration Check',
+    enabled: true,
+    check: function (): CheckResult {
+      return validateAcceptFlagsConfig(
         { id: this.id, name: this.name },
         config,
       );

--- a/test/unit/client/checks/config/acceptFlagsConfigCheck.test.ts
+++ b/test/unit/client/checks/config/acceptFlagsConfigCheck.test.ts
@@ -1,0 +1,70 @@
+import { validateAcceptFlagsConfig } from '../../../../../lib/client/checks/config/customAcceptFile';
+import { aConfig } from '../../../../helpers/test-factories';
+
+describe('client/checks/config', () => {
+  describe('validateAcceptFlagsConfig()', () => {
+    it('should return error check result if incompatible ACCEPT flags', async () => {
+      const id = `check_${Date.now()}`;
+      const config = aConfig({
+        ACCEPT_CODE: true,
+        ACCEPT: '/path/to/custom/accept/file',
+      });
+
+      const checkResult = validateAcceptFlagsConfig(
+        { id: id, name: id },
+        config,
+      );
+      expect(checkResult.status).toEqual('error');
+      expect(checkResult.output).toContain(
+        'ACCEPT_ flags are not compatible with custom accept.json files. Please refrain from using custom accept json (Code Agent is deprecated, see documentation).',
+      );
+    });
+
+    it('should return error check result if incompatible ACCEPT numerous flags', async () => {
+      const id = `check_${Date.now()}`;
+      const config = aConfig({
+        ACCEPT_GIT: true,
+        ACCEPT_IAC: true,
+        ACCEPT_APPRISK: true,
+        ACCEPT: '/path/to/custom/accept/file',
+      });
+
+      const checkResult = validateAcceptFlagsConfig(
+        { id: id, name: id },
+        config,
+      );
+      expect(checkResult.status).toEqual('error');
+      expect(checkResult.output).toContain(
+        'ACCEPT_ flags are not compatible with custom accept.json files. Please refrain from using custom accept json (Code Agent is deprecated, see documentation).',
+      );
+    });
+
+    it('should return passing check result if only ACCEPT custom file configured', async () => {
+      const id = `check_${Date.now()}`;
+      const config = aConfig({
+        ACCEPT: '/path/to/custom/accept/file',
+      });
+
+      const checkResult = validateAcceptFlagsConfig(
+        { id: id, name: id },
+        config,
+      );
+      expect(checkResult.status).toEqual('passing');
+      expect(checkResult.output).toContain('ACCEPT flags configuration OK.');
+    });
+
+    it('should return passing check result if only ACCEPT_ flags configured', async () => {
+      const id = `check_${Date.now()}`;
+      const config = aConfig({
+        ACCEPT_CODE: true,
+      });
+
+      const checkResult = validateAcceptFlagsConfig(
+        { id: id, name: id },
+        config,
+      );
+      expect(checkResult.status).toEqual('passing');
+      expect(checkResult.output).toContain('ACCEPT flags configuration OK.');
+    });
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Signals ACCEPT flags incompatibility and report code agent deprecation as per our [Code Agent docs](https://docs.snyk.io/enterprise-configuration/snyk-broker/snyk-broker-code-agent)
