### PR TITLE
fix: add code agent deprecation preflight check [HYB-437]

### DIFF
--- a/lib/client/checks/config/codeAgentDeprecation.ts
+++ b/lib/client/checks/config/codeAgentDeprecation.ts
@@ -1,0 +1,25 @@
+import { Config } from '../../types/config';
+import { CheckOptions, CheckResult } from '../types';
+
+export const validateCodeAgentDeprecation = (
+  checkOptions: CheckOptions,
+  config: Config,
+): CheckResult => {
+  if (config.GIT_CLIENT_URL && !config.DISABLE_CODE_AGENT_PREFLIGHT_CHECK) {
+    return {
+      id: checkOptions.id,
+      name: checkOptions.name,
+      status: 'warning',
+      output: `Code Agent is deprecated. Please move to broker only Snyk Code support.`,
+    } satisfies CheckResult;
+  }
+
+  return {
+    id: checkOptions.id,
+    name: checkOptions.name,
+    status: 'passing',
+    output: config.DISABLE_CODE_AGENT_PREFLIGHT_CHECK
+      ? 'Code Agent Preflight Check disabled.'
+      : 'Code Agent not in use.',
+  } satisfies CheckResult;
+};

--- a/lib/client/checks/config/index.ts
+++ b/lib/client/checks/config/index.ts
@@ -2,6 +2,7 @@ import type { Config } from '../../types/config';
 import type { Check, CheckResult } from '../types';
 import { validateBrokerClientUrl } from './brokerClientUrlCheck';
 import { validateAcceptFlagsConfig } from './customAcceptFile';
+import { validateCodeAgentDeprecation } from './codeAgentDeprecation';
 import { validateUniversalConnectionsConfig } from './universalConnectionConfigCheck';
 
 export function getConfigChecks(config: Config): Check[] {
@@ -9,6 +10,7 @@ export function getConfigChecks(config: Config): Check[] {
     brokerClientUrlCheck(config),
     universalBrokerConnectionsCheck(config),
     acceptFlagsConfigurationCheck(config),
+    codeAgentDeprecationCheck(config),
   ];
 }
 
@@ -48,6 +50,20 @@ const acceptFlagsConfigurationCheck = (config: Config): Check => {
     enabled: true,
     check: function (): CheckResult {
       return validateAcceptFlagsConfig(
+        { id: this.id, name: this.name },
+        config,
+      );
+    },
+  } satisfies Check;
+};
+
+const codeAgentDeprecationCheck = (config: Config): Check => {
+  return {
+    id: 'code-agent-deprecation-validation',
+    name: 'Code Agent Deprecation Check',
+    enabled: !config.DISABLE_CODE_AGENT_PREFLIGHT_CHECK,
+    check: function (): CheckResult {
+      return validateCodeAgentDeprecation(
         { id: this.id, name: this.name },
         config,
       );

--- a/test/unit/client/checks/config/codeAgentDeprecation.test.ts
+++ b/test/unit/client/checks/config/codeAgentDeprecation.test.ts
@@ -1,0 +1,51 @@
+import { validateCodeAgentDeprecation } from '../../../../../lib/client/checks/config/codeAgentDeprecation';
+import { aConfig } from '../../../../helpers/test-factories';
+
+describe('client/checks/config', () => {
+  describe('validateCodeAgentDeprecation()', () => {
+    it('should return pasing check result if code agent config is not detected', async () => {
+      const id = `check_${Date.now()}`;
+      const config = aConfig({});
+
+      const checkResult = validateCodeAgentDeprecation(
+        { id: id, name: id },
+        config,
+      );
+      expect(checkResult.status).toEqual('passing');
+      expect(checkResult.output).toContain('Code Agent not in use.');
+    });
+
+    it('should return warning check result if code agent config is detected', async () => {
+      const id = `check_${Date.now()}`;
+      const config = aConfig({
+        GIT_CLIENT_URL: 'http://codeagent',
+      });
+
+      const checkResult = validateCodeAgentDeprecation(
+        { id: id, name: id },
+        config,
+      );
+      expect(checkResult.status).toEqual('warning');
+      expect(checkResult.output).toContain(
+        'Code Agent is deprecated. Please move to broker only Snyk Code support.',
+      );
+    });
+
+    it('should return passing check result if code agent config is detected but preflight check is disabled', async () => {
+      const id = `check_${Date.now()}`;
+      const config = aConfig({
+        GIT_CLIENT_URL: 'http://codeagent',
+        DISABLE_CODE_AGENT_PREFLIGHT_CHECK: 'any value',
+      });
+
+      const checkResult = validateCodeAgentDeprecation(
+        { id: id, name: id },
+        config,
+      );
+      expect(checkResult.status).toEqual('passing');
+      expect(checkResult.output).toContain(
+        'Code Agent Preflight Check disabled.',
+      );
+    });
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Officially deprecate code agent usage in clients.