### PR TITLE
fix: gnore glibc vuln for UBI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,6 +344,7 @@ jobs:
       - load-docker-image:
           project_name: <<parameters.project_name>>
       - snyk/scan:
+          additional-arguments: --policy-path=.snyk
           docker-image-name: <<parameters.project_name>>:$CIRCLE_WORKFLOW_ID
           fail-on-issues: <<pipeline.parameters.fail_on_issues>>
           organization: platform-broker
@@ -1112,7 +1113,7 @@ workflows:
           post-steps:
             - notify-slack-on-failure
           <<: *filter-tags-only
-      
+
       - build-and-save-docker-image:
           name: Build bitbucket-server-bearer-auth image
           context:
@@ -1518,7 +1519,7 @@ workflows:
           post-steps:
             - notify-slack-on-failure
           <<: *filter-tags-only
-      
+
       - build-and-save-docker-image:
           name: Build bitbucket-server-bearer-auth image (nlatest)
           context:

--- a/.snyk
+++ b/.snyk
@@ -1,13 +1,23 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.12.0
+version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   'npm:debug:20170905':
     - primus > setheader > debug:
         reason: Not vulnerable as `primus` doesn't run in debug mode
         expires: '2024-02-09T12:00:00.000Z'
-  'SNYK-JS-PREDEFINE-1054935':
+  SNYK-JS-PREDEFINE-1054935:
     - primus > fusing > predefine:
-        reason: Fixed in https://github.com/snyk/broker/pull/336
+        reason: 'Fixed in https://github.com/snyk/broker/pull/336'
         expires: '2023-07-06T09:47:29.283Z'
+  SNYK-RHEL8-GLIBC-6656573:
+    - '*':
+        reason: No fix from RHEL available
+        expires: 2024-05-14T11:13:02.169Z
+        created: 2024-05-07T11:13:02.174Z
+  SNYK-RHEL8-GLIBC-6684409:
+    - '*':
+        reason: No fix from RHEL available
+        expires: 2024-05-14T11:13:13.154Z
+        created: 2024-05-07T11:13:13.157Z
 patch: {}

--- a/.snyk
+++ b/.snyk
@@ -2,14 +2,6 @@
 version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  'npm:debug:20170905':
-    - primus > setheader > debug:
-        reason: Not vulnerable as `primus` doesn't run in debug mode
-        expires: '2024-02-09T12:00:00.000Z'
-  SNYK-JS-PREDEFINE-1054935:
-    - primus > fusing > predefine:
-        reason: 'Fixed in https://github.com/snyk/broker/pull/336'
-        expires: '2023-07-06T09:47:29.283Z'
   SNYK-RHEL8-GLIBC-6656573:
     - '*':
         reason: No fix from RHEL available

--- a/dockerfiles/base/Dockerfile.ubi
+++ b/dockerfiles/base/Dockerfile.ubi
@@ -2,7 +2,7 @@ ARG BROKER_VERSION=latest
 ARG NODE_VERSION=20.11.0
 
 
-FROM registry.access.redhat.com/ubi8/nodejs-18 as node-base
+FROM registry.access.redhat.com/ubi8/nodejs-20 as node-base
 
 ARG NODE_VERSION
 ENV NODE_VERSION=${NODE_VERSION}


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR ignores `SNYK-RHEL8-GLIBC-6656573` and `SNYK-RHEL8-GLIBC-6684409` for one week (until 2024-05-14) and unblocks failed workflow for releasing RHEL UBI images.

Additionally old ignores from `.snyk` policy file are cleaned up.
