### PR TITLE
fix(docker): remove non-needed glibc-* packages

### DIFF
--- a/dockerfiles/base/Dockerfile.ubi
+++ b/dockerfiles/base/Dockerfile.ubi
@@ -54,6 +54,8 @@ RUN <<EOF
     rpm --erase --nodeps dnf-plugin-subscription-manager
     rpm --erase --nodeps gdb-gdbserver
     rpm --erase --nodeps glibc-common
+    rpm --erase --nodeps glibc-gconv-extra
+    rpm --erase --nodeps glibc-langpack-en
     rpm --erase --nodeps glibc-minimal-langpack
     rpm --erase --nodeps gnutls
     rpm --erase --nodeps libarchive


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR removes additional packages from RHEL UBI image (coming from latest ubi8 image)

- glibc-gconv-extra
- glibc-langpack-en
