### PR TITLE
fix: version retrieval in preflight check

### DIFF
--- a/lib/client/checks/config/brokerClientVersionCheck.ts
+++ b/lib/client/checks/config/brokerClientVersionCheck.ts
@@ -7,7 +7,7 @@ export const validateBrokerClientVersionAgainstServer = async (
   checkOptions: CheckOptions,
   config,
 ) => {
-  const clientVersion = version();
+  const clientVersion = `${version}`;
   if (clientVersion != 'local') {
     const req: PostFilterPreparedRequest = {
       url: `${config.BROKER_SERVER_URL}/healthcheck`,

--- a/test/unit/client/checks/config/brokerClientVersionCheck.test.ts
+++ b/test/unit/client/checks/config/brokerClientVersionCheck.test.ts
@@ -14,9 +14,7 @@ jest.mock('../../../../../lib/common/utils/version', () => {
   return {
     __esModule: true,
     ...originalModule,
-    default: () => {
-      return '4.180.0';
-    },
+    default: '4.180.0',
   };
 });
 

--- a/test/unit/client/checks/config/brokerClientVersionSkipDevLocalVersionCheck.test.ts
+++ b/test/unit/client/checks/config/brokerClientVersionSkipDevLocalVersionCheck.test.ts
@@ -12,9 +12,7 @@ jest.mock('../../../../../lib/common/utils/version', () => {
   return {
     __esModule: true,
     ...originalModule,
-    default: () => {
-      return 'local';
-    },
+    default: 'local',
   };
 });
 


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Fixes the way we retrieve version.