### PR TITLE
fix: strip connection_role qs in http req into server

### DIFF
--- a/test/functional/server-client.test.ts
+++ b/test/functional/server-client.test.ts
@@ -582,4 +582,12 @@ describe('proxy requests originating from behind the broker server', () => {
     expect(response.status).toEqual(200);
     expect(response.data).toStrictEqual({ proxyMe: 'please' });
   });
+
+  it('successfully broker POST removing connection_role QS', async () => {
+    const response = await axiosClient.get(
+      `http://localhost:${bs.port}/broker/${brokerToken}/echo-query?connection_role=primary&test=value&test2=value2`,
+    );
+    expect(response.status).toEqual(200);
+    expect(response.data).toStrictEqual({ test: 'value', test2: 'value2' });
+  });
 });

--- a/test/unit/old-client-redirect.test.ts
+++ b/test/unit/old-client-redirect.test.ts
@@ -15,7 +15,12 @@ jest.mock('../../lib/server/socket', () => {
     __esModule: true,
     ...originalModule,
     getSocketConnections: () => {
-      return new Map();
+      const map = new Map();
+
+      map.set('7fe7a57b-aa0d-416a-97fc-472061737e24', [
+        { socket: {}, socketVersion: '1', metadata: { capabilities: {} } },
+      ]);
+      return map;
     },
   };
 });


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
[Server only] Strips connection_role query string on inbound request from backend systems to not forward it to downstream services.