### PR TITLE
fix: pass body unmodified to primary from secondary srv [HYB-532]

### DIFF
--- a/lib/server/routesHandlers/httpRequestHandler.ts
+++ b/lib/server/routesHandlers/httpRequestHandler.ts
@@ -31,15 +31,23 @@ export const overloadHttpRequestWithConnectionDetailsMiddleware = async (
       const url = new URL(`http://${req.hostname}${req.url}`);
       url.hostname = req.hostname.replace(/-[0-9]{1,2}\./, '.');
       url.searchParams.append('connection_role', 'primary');
-      logger.debug({}, 'Making request to primary');
+
       const postFilterPreparedRequest: PostFilterPreparedRequest = {
         url: url.toString(),
         headers: req.headers,
         method: req.method,
       };
-      if (req.body) {
-        postFilterPreparedRequest.body = JSON.stringify(req.body);
+      if (
+        req.method == 'POST' ||
+        req.method == 'PUT' ||
+        req.method == 'PATCH'
+      ) {
+        postFilterPreparedRequest.body = req.body;
       }
+      logger.debug(
+        { url: req.url, method: req.method },
+        'Making request to primary',
+      );
       try {
         const httpResponse = await makeStreamingRequestToDownstream(
           postFilterPreparedRequest,

--- a/test/unit/old-client-redirect.test.ts
+++ b/test/unit/old-client-redirect.test.ts
@@ -48,7 +48,14 @@ describe('Testing older clients specific logic', () => {
         return [200, { test: 'value' }];
       });
     const app = express();
-    app.use(bodyParser.json());
+    app.use(
+      bodyParser.raw({
+        type: (req) =>
+          req.headers['content-type'] !==
+          'application/vnd.broker.stream+octet-stream',
+        limit: '10mb',
+      }),
+    );
     app.all(
       '/broker/:token/*',
       overloadHttpRequestWithConnectionDetailsMiddleware,
@@ -71,7 +78,14 @@ describe('Testing older clients specific logic', () => {
         return [200, requestBody];
       });
     const app = express();
-    app.use(bodyParser.json());
+    app.use(
+      bodyParser.raw({
+        type: (req) =>
+          req.headers['content-type'] !==
+          'application/vnd.broker.stream+octet-stream',
+        limit: '10mb',
+      }),
+    );
     app.all(
       '/broker/:token/*',
       overloadHttpRequestWithConnectionDetailsMiddleware,
@@ -98,7 +112,14 @@ describe('Testing older clients specific logic', () => {
         return [200, fileJson];
       });
     const app = express();
-    app.use(bodyParser.json());
+    app.use(
+      bodyParser.raw({
+        type: (req) =>
+          req.headers['content-type'] !==
+          'application/vnd.broker.stream+octet-stream',
+        limit: '10mb',
+      }),
+    );
     app.all(
       '/broker/:token/*',
       overloadHttpRequestWithConnectionDetailsMiddleware,


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
[Server only] For older client with a single tunnel, the secondary server will forward the request to the primary, which has the ws connection. This fixes the body forwarding to be unmodified, ensuring a clean passthrough from secondary to primary.