### PR TITLE
fix: apply old clients fwding to primary for conn status routes [HYB-535]

### DIFF
--- a/lib/server/routesHandlers/connectionStatusHandler.ts
+++ b/lib/server/routesHandlers/connectionStatusHandler.ts
@@ -2,8 +2,11 @@ import { Request, Response } from 'express';
 import { getDesensitizedToken } from '../utils/token';
 import { getSocketConnections } from '../socket';
 import { log as logger } from '../../logs/logger';
+import { hostname } from 'node:os';
+import { PostFilterPreparedRequest } from '../../common/relay/prepareRequest';
+import { makeStreamingRequestToDownstream } from '../../common/http/request';
 
-export const connectionStatusHandler = (req: Request, res: Response) => {
+export const connectionStatusHandler = async (req: Request, res: Response) => {
   const token = req.params.token;
   const desensitizedToken = getDesensitizedToken(token);
   const connections = getSocketConnections();
@@ -13,7 +16,47 @@ export const connectionStatusHandler = (req: Request, res: Response) => {
       filters: conn.metadata && conn.metadata.filters,
     }));
     return res.status(200).json({ ok: true, clients: clientsMetadata });
+  } else {
+    const localHostname = hostname();
+    const regex = new RegExp(/-[0-9]{1,2}-[0-1]/);
+    if (
+      localHostname &&
+      localHostname.endsWith('-1') &&
+      localHostname.match(regex)
+    ) {
+      const url = new URL(`http://${req.hostname}${req.url}`);
+      url.hostname = req.hostname.replace(/-[0-9]{1,2}\./, '.');
+      url.searchParams.append('connection_role', 'primary');
+
+      const postFilterPreparedRequest: PostFilterPreparedRequest = {
+        url: url.toString(),
+        headers: req.headers,
+        method: req.method,
+      };
+      if (
+        req.method == 'POST' ||
+        req.method == 'PUT' ||
+        req.method == 'PATCH'
+      ) {
+        postFilterPreparedRequest.body = req.body;
+      }
+      logger.debug(
+        { url: req.url, method: req.method },
+        'Making request to primary',
+      );
+      try {
+        const httpResponse = await makeStreamingRequestToDownstream(
+          postFilterPreparedRequest,
+        );
+        res.writeHead(httpResponse.statusCode ?? 500, httpResponse.headers);
+        return httpResponse.pipe(res);
+      } catch (err) {
+        logger.error({ err }, `Error in HTTP middleware: ${err}`);
+        res.status(500).send('Error forwarding request to primary');
+      }
+    } else {
+      logger.warn({ desensitizedToken }, 'no matching connection found');
+      return res.status(404).json({ ok: false });
+    }
   }
-  logger.warn({ desensitizedToken }, 'no matching connection found');
-  return res.status(404).json({ ok: false });
 };


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Forwards request for connection-status routes from secondary to primary broker server for older client without double tunnels primary and secondary.