### PR TITLE
fix: dynamic gids for openshift for rhel-ubi

### DIFF
--- a/dockerfiles/Dockerfile.ubi
+++ b/dockerfiles/Dockerfile.ubi
@@ -10,6 +10,9 @@ ENV BROKER_TYPE=${BROKER_TYPE}
 # Generate default accept filter
 RUN broker init $BROKER_TYPE
 
+# Ensure OpenShift compatibility
+USER root
+RUN chgrp -R 0 /home/snyk && chmod -R 755 /home/snyk
 USER snyk
 
 CMD ["broker", "--verbose"]

--- a/dockerfiles/base/Dockerfile.ubi
+++ b/dockerfiles/base/Dockerfile.ubi
@@ -11,8 +11,6 @@ RUN mkdir -p /tmp/node && \
     curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" && \
     tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /tmp/node --strip-components=1
 
-
-
 FROM node-base as broker-builder
 
 ARG BROKER_VERSION
@@ -93,7 +91,6 @@ COPY --from=broker-builder /opt/app-root/src/.npm-global /opt/app-root/src/.npm-
 COPY --from=node-base /tmp/node/bin/node /usr/bin/node
 COPY --chown=snyk:root config.default.json /home/snyk/config.default.json
 COPY --chown=snyk:root defaultFilters /home/snyk/defaultFilters
-RUN chown -R snyk:root /home/snyk
+RUN chgrp -R 0 /home/snyk && chmod -R 775 /home/snyk
 
 WORKDIR /home/snyk
-USER snyk

--- a/dockerfiles/base/Dockerfile.ubi
+++ b/dockerfiles/base/Dockerfile.ubi
@@ -89,8 +89,8 @@ EOF
 
 COPY --from=broker-builder /opt/app-root/src/.npm-global /opt/app-root/src/.npm-global
 COPY --from=node-base /tmp/node/bin/node /usr/bin/node
-COPY --chown=snyk:root config.default.json /home/snyk/config.default.json
-COPY --chown=snyk:root defaultFilters /home/snyk/defaultFilters
-RUN chgrp -R 0 /home/snyk && chmod -R 775 /home/snyk
+COPY --chown=snyk:snyk config.default.json /home/snyk/config.default.json
+COPY --chown=snyk:snyk defaultFilters /home/snyk/defaultFilters
 
 WORKDIR /home/snyk
+USER snyk

--- a/dockerfiles/base/Dockerfile.ubi
+++ b/dockerfiles/base/Dockerfile.ubi
@@ -11,6 +11,8 @@ RUN mkdir -p /tmp/node && \
     curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" && \
     tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /tmp/node --strip-components=1
 
+
+
 FROM node-base as broker-builder
 
 ARG BROKER_VERSION

--- a/dockerfiles/base/Dockerfile.ubi
+++ b/dockerfiles/base/Dockerfile.ubi
@@ -91,8 +91,9 @@ EOF
 
 COPY --from=broker-builder /opt/app-root/src/.npm-global /opt/app-root/src/.npm-global
 COPY --from=node-base /tmp/node/bin/node /usr/bin/node
-COPY --chown=snyk:snyk config.default.json /home/snyk/config.default.json
-COPY --chown=snyk:snyk defaultFilters /home/snyk/defaultFilters
+COPY --chown=snyk:root config.default.json /home/snyk/config.default.json
+COPY --chown=snyk:root defaultFilters /home/snyk/defaultFilters
+RUN chown -R snyk:root /home/snyk
 
 WORKDIR /home/snyk
 USER snyk


### PR DESCRIPTION
### What

- Sets directories `/home/snyk` and contents within to be owned by the `snyk` user and the `root` group