### PR TITLE
fix: [server only] stop secondary to primary fwd flow on err [HYB-512]

### DIFF
--- a/lib/server/routesHandlers/httpRequestHandler.ts
+++ b/lib/server/routesHandlers/httpRequestHandler.ts
@@ -56,7 +56,7 @@ export const overloadHttpRequestWithConnectionDetailsMiddleware = async (
         return httpResponse.pipe(res);
       } catch (err) {
         logger.error({ err }, `Error in HTTP middleware: ${err}`);
-        res.status(500).send('Error forwarding request to primary');
+        return res.status(500).send('Error forwarding request to primary.');
       }
     } else {
       logger.warn({ desensitizedToken }, 'no matching connection found');


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
[Server only] Interrupts code flow upon error in secondary to primary request forwarding instead of continuing after having returned 500 error code.

#### Any background context you want to provide?
Server side only. No impact or change required on deployed broker clients.