### PR TITLE
fix: do not install weak deps

### DIFF
--- a/dockerfiles/base/Dockerfile.ubi
+++ b/dockerfiles/base/Dockerfile.ubi
@@ -41,9 +41,9 @@ ENV PATH="/opt/app-root/src/node_modules/.bin/:/opt/app-root/src/.npm-global/bin
 
 RUN <<EOF
     set -ex
-    yum upgrade --assumeyes
-    yum clean all
-    rm -rf /var/cache/yum
+    dnf upgrade --assumeyes --best --setopt=install_weak_deps=False
+    dnf clean all
+    rm -rf /var/cache/dnf
     # create default user and group
     groupadd --gid 10001 snyk
     useradd --gid 10001 --shell /sbin/nologin --uid 10001 snyk


### PR DESCRIPTION
### What

- Move from `yum` to `dnf`
- Ignore weak dependencies when building base image

### Why

- Reduce additional packages, limiting surface for vulnerabilities
