### PR TITLE
fix: ensure content length uses bytes

### DIFF
--- a/lib/common/relay/prepareRequest.ts
+++ b/lib/common/relay/prepareRequest.ts
@@ -211,7 +211,7 @@ export const prepareRequestFromFilterResult = async (
   if (!payload.body || payload.body.length === 0) {
     payload.headers['Content-Length'] = '0';
   } else {
-    payload.headers['Content-length'] = payload.body.length;
+    payload.headers['Content-Length'] = Buffer.byteLength(payload.body, 'utf8');
   }
 
   payload.headers['connection'] = 'Keep-Alive';
@@ -241,7 +241,7 @@ export const prepareRequestFromFilterResult = async (
       //updating the content length after converting the body
       const encoder = new TextEncoder();
       const byteArray = encoder.encode(payload.body);
-      payload.headers['Content-length'] = byteArray.length;
+      payload.headers['Content-Length'] = byteArray.length;
     }
   }
 

--- a/lib/common/relay/prepareRequest.ts
+++ b/lib/common/relay/prepareRequest.ts
@@ -123,7 +123,7 @@ export const prepareRequestFromFilterResult = async (
 
   // remove headers that we don't want to relay
   // (because they corrupt the request)
-  [
+  const headersToRemove = [
     'x-forwarded-for',
     'x-forwarded-proto',
     'content-length',
@@ -139,7 +139,12 @@ export const prepareRequestFromFilterResult = async (
     'snyk-product-line',
     'snyk-project-type',
     'snyk-integration-type',
-  ].map((_) => delete payload.headers[_]);
+  ];
+  Object.keys(payload.headers).map((header) => {
+    if (headersToRemove.includes(header.toLowerCase())) {
+      delete payload.headers[header];
+    }
+  });
 
   if (options.config.removeXForwardedHeaders === 'true') {
     for (const key in payload.headers) {

--- a/test/unit/relay-response-body-universal-form-url-encoded.test.ts
+++ b/test/unit/relay-response-body-universal-form-url-encoded.test.ts
@@ -246,7 +246,7 @@ describe('body relay', () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
         const arg = mockedFn.mock.calls[0][0];
 
-        expect(arg.headers['Content-length']).toEqual(arg.body.length);
+        expect(arg.headers['Content-Length']).toEqual(arg.body.length);
 
         done();
       },


### PR DESCRIPTION
### What

- Ensures the `Content-Length` header uses bytes
- Ensures `Content-Length` format is standardised to `Content-Length`