### PR TITLE
feat: add url placeholder var swap for ghsa

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -287,6 +287,7 @@
         }
       ],
       "default": {
+        "enableUrlVarsSubstitution": true,
         "GITHUB_API": "$GITHUB/api/v3",
         "GITHUB_GRAPHQL": "$GITHUB/api",
         "BROKER_CLIENT_VALIDATION_URL": "https://$GITHUB_API/user",

--- a/lib/common/relay/prepareRequest.ts
+++ b/lib/common/relay/prepareRequest.ts
@@ -127,6 +127,23 @@ export const prepareRequestFromFilterResult = async (
     }
   }
 
+  const connectionConfig = options.config.universalBrokerEnabled
+    ? getConfigForIdentifier(brokerToken, options.config)
+    : options.config;
+  if (connectionConfig.enableUrlVarsSubstitution) {
+    const regexPattern = /\$[A-Za-z0-9_%]+/g;
+    const matches = result.url.match(regexPattern);
+    if (matches) {
+      for (const pathPart of matches) {
+        const source = replace(
+          `${pathPart.replace('$', '${')}}`,
+          connectionConfig,
+        ); // replace the variables
+        result.url = result.url.replace(pathPart, source);
+      }
+    }
+  }
+
   // remove headers that we don't want to relay
   // (because they corrupt the request)
   const headersToRemove = [

--- a/test/unit/relay-response-url-universal.test.ts
+++ b/test/unit/relay-response-url-universal.test.ts
@@ -1,0 +1,176 @@
+const PORT = 8001;
+process.env.BROKER_SERVER_URL = `http://localhost:${PORT}`;
+jest.mock('../../lib/common/http/request');
+import { Role, WebSocketConnection } from '../../lib/client/types/client';
+import { makeRequestToDownstream } from '../../lib/common/http/request';
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mockedFn = makeRequestToDownstream.mockImplementation((data) => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  return data;
+});
+
+import { forwardWebSocketRequest as relay } from '../../lib/common/relay/forwardWebsocketRequest';
+import {
+  LoadedClientOpts,
+  LoadedServerOpts,
+} from '../../lib/common/types/options';
+
+const dummyWebsocketHandler: WebSocketConnection = {
+  destroy: () => {
+    return;
+  },
+  latency: 0,
+  options: {
+    ping: 0,
+    pong: 0,
+    queueSize: Infinity,
+    reconnect: '',
+    stategy: '',
+    timeout: 100,
+    transport: '',
+  },
+  send: () => {},
+  serverId: '0',
+  socket: {},
+  supportedIntegrationType: 'github',
+  transport: '',
+  url: '',
+  on: () => {},
+  end: () => {},
+  role: Role.primary,
+  open: () => {},
+  emit: () => {},
+  readyState: 3,
+};
+
+// simulates the result from the loaded filters function
+const dummyLoadedFilters = {
+  private: () => {
+    return {
+      url: 'https://test/$INSTALLATION_ID/path/$OTHER',
+      auth: '',
+      stream: true,
+    };
+  },
+  public: () => {
+    return { url: '/', auth: '', stream: true };
+  },
+};
+
+describe('uri relay', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  afterAll(() => {
+    delete process.env.BROKER_SERVER_URL;
+    jest.clearAllMocks();
+  });
+  it('swaps uri placeholder values found in url', (done) => {
+    expect.hasAssertions();
+
+    const brokerToken = 'test-broker';
+
+    const config = {
+      universalBrokerEnabled: true,
+      plugins: new Map<string, any>(),
+      connections: {
+        myconn: {
+          identifier: brokerToken,
+          INSTALLATION_ID: '123',
+          OTHER: 'REPLACEDVALUE',
+          enableUrlVarsSubstitution: true,
+        },
+      },
+    };
+    const options: LoadedClientOpts | LoadedServerOpts = {
+      filters: {
+        private: [
+          {
+            method: 'any',
+            url: '/*',
+            origin: 'https://test',
+          },
+        ],
+        public: [],
+      },
+      config,
+      port: 8001,
+      loadedFilters: dummyLoadedFilters,
+    };
+    const route = relay(options, dummyWebsocketHandler)(brokerToken);
+
+    const headers = {
+      test: '1',
+    };
+
+    route(
+      {
+        url: '/INSTALLATION_ID/path/OTHER',
+        method: 'GET',
+        headers: headers,
+      },
+      () => {
+        expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
+        const arg = mockedFn.mock.calls[0][0];
+        expect(arg.url).toEqual(`https://test/123/path/REPLACEDVALUE`);
+        done();
+      },
+    );
+  });
+
+  it('does NOT swap uri placeholder values found in url if not enabled', (done) => {
+    expect.hasAssertions();
+
+    const brokerToken = 'test-broker';
+
+    const config = {
+      universalBrokerEnabled: true,
+      plugins: new Map<string, any>(),
+      connections: {
+        myconn: {
+          identifier: brokerToken,
+          INSTALLATION_ID: '123',
+          OTHER: 'REPLACEDVALUE',
+        },
+      },
+    };
+    const options: LoadedClientOpts | LoadedServerOpts = {
+      filters: {
+        private: [
+          {
+            method: 'any',
+            url: '/*',
+            origin: 'https://test',
+          },
+        ],
+        public: [],
+      },
+      config,
+      port: 8001,
+      loadedFilters: dummyLoadedFilters,
+    };
+    const route = relay(options, dummyWebsocketHandler)(brokerToken);
+
+    const headers = {
+      test: '1',
+    };
+
+    route(
+      {
+        url: '/INSTALLATION_ID/path/OTHER',
+        method: 'GET',
+        headers: headers,
+      },
+      () => {
+        expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
+        const arg = mockedFn.mock.calls[0][0];
+        expect(arg.url).toEqual('https://test/$INSTALLATION_ID/path/$OTHER');
+        done();
+      },
+    );
+  });
+});

--- a/test/unit/relay-response-url.test.ts
+++ b/test/unit/relay-response-url.test.ts
@@ -1,0 +1,162 @@
+const PORT = 8001;
+process.env.BROKER_SERVER_URL = `http://localhost:${PORT}`;
+jest.mock('../../lib/common/http/request');
+import { Role, WebSocketConnection } from '../../lib/client/types/client';
+import { makeRequestToDownstream } from '../../lib/common/http/request';
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mockedFn = makeRequestToDownstream.mockImplementation((data) => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  return data;
+});
+
+import { forwardWebSocketRequest as relay } from '../../lib/common/relay/forwardWebsocketRequest';
+import {
+  LoadedClientOpts,
+  LoadedServerOpts,
+} from '../../lib/common/types/options';
+
+const dummyWebsocketHandler: WebSocketConnection = {
+  destroy: () => {
+    return;
+  },
+  latency: 0,
+  options: {
+    ping: 0,
+    pong: 0,
+    queueSize: Infinity,
+    reconnect: '',
+    stategy: '',
+    timeout: 100,
+    transport: '',
+  },
+  send: () => {},
+  serverId: '0',
+  socket: {},
+  supportedIntegrationType: 'github',
+  transport: '',
+  url: '',
+  on: () => {},
+  end: () => {},
+  role: Role.primary,
+  open: () => {},
+  emit: () => {},
+  readyState: 3,
+};
+
+// simulates the result from the loaded filters function
+const dummyLoadedFilters = {
+  private: () => {
+    return {
+      url: 'https://test/$INSTALLATION_ID/path/$OTHER',
+      auth: '',
+      stream: true,
+    };
+  },
+  public: () => {
+    return { url: '/', auth: '', stream: true };
+  },
+};
+
+describe('uri relay', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  afterAll(() => {
+    delete process.env.BROKER_SERVER_URL;
+    jest.clearAllMocks();
+  });
+  it('swaps uri placeholder values found in url', (done) => {
+    expect.hasAssertions();
+
+    const brokerToken = 'test-broker';
+
+    const config = {
+      INSTALLATION_ID: '123',
+      OTHER: 'REPLACEDVALUE',
+      enableUrlVarsSubstitution: true,
+    };
+    const options: LoadedClientOpts | LoadedServerOpts = {
+      filters: {
+        private: [
+          {
+            method: 'any',
+            url: '/*',
+            origin: 'https://test',
+          },
+        ],
+        public: [],
+      },
+      config,
+      port: 8001,
+      loadedFilters: dummyLoadedFilters,
+    };
+    const route = relay(options, dummyWebsocketHandler)(brokerToken);
+
+    const headers = {
+      test: '1',
+    };
+
+    route(
+      {
+        url: '/$INSTALLATION_ID/path/$OTHER',
+        method: 'GET',
+        headers: headers,
+      },
+      () => {
+        expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
+        const arg = mockedFn.mock.calls[0][0];
+        expect(arg.url).toEqual(`https://test/123/path/REPLACEDVALUE`);
+        done();
+      },
+    );
+  });
+
+  it('does NOT swaps uri placeholder values found in url if not enabled in config', (done) => {
+    expect.hasAssertions();
+
+    const brokerToken = 'test-broker';
+
+    const config = {
+      INSTALLATION_ID: '123',
+      OTHER: 'REPLACEDVALUE',
+    };
+    const options: LoadedClientOpts | LoadedServerOpts = {
+      filters: {
+        private: [
+          {
+            method: 'any',
+            url: '/*',
+            origin: 'https://test',
+          },
+        ],
+        public: [],
+      },
+      config,
+      port: 8001,
+      loadedFilters: dummyLoadedFilters,
+    };
+    const route = relay(options, dummyWebsocketHandler)(brokerToken);
+
+    const headers = {
+      test: '1',
+    };
+
+    route(
+      {
+        url: '/INSTALLATION_ID/path/OTHER',
+        method: 'GET',
+        headers: headers,
+      },
+      () => {
+        expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
+        const arg = mockedFn.mock.calls[0][0];
+        expect(arg.url).toEqual('https://test/$INSTALLATION_ID/path/$OTHER');
+        done();
+      },
+    );
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adds opt-in logic at connection level to enable variable interpolation in urls.
For the cases where a url must contain a value that is only available in the broker client, it is now possible to inject this value simply by having a placeholder value in the filters uris, in addition to the header and body value injections, long time part of the broker client.
This additional capability is required for upcoming integration(s) and will not apply to any current connection without explicit configuration value to opt into this behavior. Cases where needed will be apparent in the filters.