### PR TITLE
chore: extend ignore for SNYK-JS-WS-7266574

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -15,6 +15,6 @@ ignore:
   SNYK-JS-WS-7266574:
     - '*':
         reason: Mitigated in code
-        expires: 2024-07-26T21:59:20.738Z
+        expires: 2024-08-26T21:59:20.738Z
         created: 2024-06-26T21:59:20.744Z
 patch: {}


### PR DESCRIPTION
### What

- Ignores [SNYK-JS-WS-7266574](https://security.snyk.io/vuln/SNYK-JS-WS-7266574) for an extra month