### PR TITLE
feat: add url placeholder var swap for ghsa in plugin

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -297,6 +297,7 @@
       },
       "required": {
         "GITHUB": "ghe.yourdomain.com",
+        "GITHUB_API": "$GITHUB/api/v3",
         "GITHUB_APP_ID": "APP_ID",
         "GITHUB_APP_PRIVATE_PEM_PATH": "abc",
         "GITHUB_APP_CLIENT_ID": "123",

--- a/lib/client/brokerClientPlugins/plugins/githubServerAppAuth.ts
+++ b/lib/client/brokerClientPlugins/plugins/githubServerAppAuth.ts
@@ -7,6 +7,7 @@ import { PostFilterPreparedRequest } from '../../../common/relay/prepareRequest'
 import { makeRequestToDownstream } from '../../../common/http/request';
 import { maskSCMToken } from '../../../common/utils/token';
 import { getConfig } from '../../../common/config/config';
+import { replace } from '../../../common/utils/replace-vars';
 
 export class Plugin extends BrokerPlugin {
   // Plugin Code and Name must be unique across all plugins.
@@ -288,14 +289,30 @@ export class Plugin extends BrokerPlugin {
   }
 
   // Hook to run pre requests operations - Optional. Uncomment to enable
-  // async preRequest(
-  //   connectionConfiguration: Record<string, any>,
-  //   postFilterPreparedRequest: PostFilterPreparedRequest,
-  // ) {
-  //   this.logger.debug(
-  //     { plugin: this.pluginName, connection: connectionConfiguration },
-  //     'Running prerequest plugin',
-  //   );
-  //   return postFilterPreparedRequest;
-  // }
+  async preRequest(
+    connectionConfiguration: Record<string, any>,
+    postFilterPreparedRequest: PostFilterPreparedRequest,
+  ) {
+    this.logger.debug(
+      { plugin: this.pluginName, connection: connectionConfiguration },
+      'Running prerequest plugin',
+    );
+
+    const regexPattern = /\$[A-Za-z0-9_%]+/g;
+    const matches = postFilterPreparedRequest.url.match(regexPattern);
+    if (matches) {
+      for (const pathPart of matches) {
+        const source = replace(
+          `${pathPart.replace('$', '${')}}`,
+          connectionConfiguration,
+        ); // replace the variables
+        postFilterPreparedRequest.url = postFilterPreparedRequest.url.replace(
+          pathPart,
+          source,
+        );
+      }
+    }
+
+    return postFilterPreparedRequest;
+  }
 }

--- a/test/unit/plugins/brokerPlugins/github-server-app.test.ts
+++ b/test/unit/plugins/brokerPlugins/github-server-app.test.ts
@@ -3,6 +3,7 @@ import { findProjectRoot } from '../../../../lib/common/config/config';
 import nock from 'nock';
 import { delay } from '../../../helpers/utils';
 import { getConfig } from '../../../../lib/common/config/config';
+import { PostFilterPreparedRequest } from '../../../../lib/common/relay/prepareRequest';
 
 describe('Github Server App Plugin', () => {
   const pluginsFixturesFolderPath = `${findProjectRoot(
@@ -179,5 +180,25 @@ describe('Github Server App Plugin', () => {
     await delay(100);
     expect(JSON.parse(config.accessToken)).toEqual(renewedDummyAccessToken);
     clearTimeout(config['accessTokenTimeoutHandlerId']);
+  });
+
+  it('Test Prerequest url var interpolation', async () => {
+    const config = {};
+    const plugin = new Plugin(config);
+    const postFilterPreparedRequest: PostFilterPreparedRequest = {
+      url: 'https://hostname/path/test/with/installationid/$GITHUB_INSTALLATION_ID/rest/of/path',
+      headers: {},
+      method: '',
+    };
+
+    const preequest = await plugin.preRequest(
+      { GITHUB_INSTALLATION_ID: '123' },
+      postFilterPreparedRequest,
+    );
+    expect(preequest).toStrictEqual({
+      url: 'https://hostname/path/test/with/installationid/123/rest/of/path',
+      headers: {},
+      method: '',
+    });
   });
 });


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adds opt-in logic in github server app plugin at connection level to enable variable interpolation in urls.
For the cases where a url must contain a value that is only available in the broker client, it is now possible to inject this value simply by having a placeholder value in the filters uris, in addition to the header and body value injections, long time part of the broker client.
Keeping it in the plugin isolates this logic to only relevant type(s).

This approach is favored over the global logic in https://github.com/snyk/broker/pull/800.
