### PR TITLE
chore: undo webhook path update for github-server-app - use github in path

### DIFF
--- a/defaultFilters/github-server-app.json
+++ b/defaultFilters/github-server-app.json
@@ -3,7 +3,7 @@
       {
         "//": "used for pushing up webhooks from github",
         "method": "POST",
-        "path": "/webhook/github-server-app",
+        "path": "/webhook/github",
         "valid": [
           {
             "//": "accept all pull request state changes (these don't have files in them)",
@@ -295,7 +295,7 @@
       {
         "//": "used for pushing up webhooks from github",
         "method": "POST",
-        "path": "/webhook/github-server-app/:webhookId"
+        "path": "/webhook/github/:webhookId"
       }
     ],
     "private": [


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Undo #807 for backwards compatibility.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
