### PR TITLE
feat: allow GitHub native PR experience calls through the Broker

### DIFF
--- a/client-templates/github-com/accept.json.sample
+++ b/client-templates/github-com/accept.json.sample
@@ -2118,6 +2118,24 @@
       "method": "POST",
       "path": "/graphql",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_GRAPHQL}"
+    },
+    {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "create a pull request review",
+      "method": "POST",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     }
   ]
 }

--- a/client-templates/github-enterprise/accept.json.sample
+++ b/client-templates/github-enterprise/accept.json.sample
@@ -1398,6 +1398,24 @@
       "method": "POST",
       "path": "/graphql",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_GRAPHQL}"
+    },
+    {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "create a pull request review",
+      "method": "POST",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     }
   ]
 }

--- a/client-templates/github-server-app/accept.json.sample
+++ b/client-templates/github-server-app/accept.json.sample
@@ -1398,6 +1398,24 @@
       "method": "POST",
       "path": "/graphql",
       "origin": "https://${GITHUB_GRAPHQL}"
+    },
+    {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+      "origin": "https://${GITHUB_API}"
+    },
+    {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+      "origin": "https://${GITHUB_API}"
+    },
+    {
+      "//": "create a pull request review",
+      "method": "POST",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+      "origin": "https://${GITHUB_API}"
     }
   ]
 }

--- a/defaultFilters/github-enterprise.json
+++ b/defaultFilters/github-enterprise.json
@@ -1398,6 +1398,24 @@
         "method": "POST",
         "path": "/graphql",
         "origin": "https://${GITHUB_TOKEN}@${GITHUB_GRAPHQL}"
+      },
+      {
+        "//": "create a general pull request comment",
+        "method": "POST",
+        "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+        "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+      },
+      {
+        "//": "update a general pull request comment",
+        "method": "PATCH",
+        "path": "/repos/:name/:repo/issues/comments/:commentId",
+        "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+      },
+      {
+        "//": "create a pull request review",
+        "method": "POST",
+        "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+        "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
       }
     ]
   }

--- a/defaultFilters/github-server-app.json
+++ b/defaultFilters/github-server-app.json
@@ -1992,6 +1992,36 @@
           "scheme": "bearer",
           "token": "${ACCESS_TOKEN}"
         }
+      },
+      {
+        "//": "create a general pull request comment",
+        "method": "POST",
+        "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+        "origin": "https://${GITHUB_API}",
+        "auth": {
+          "scheme": "bearer",
+          "token": "${ACCESS_TOKEN}"
+        }
+      },
+      {
+        "//": "update a general pull request comment",
+        "method": "PATCH",
+        "path": "/repos/:name/:repo/issues/comments/:commentId",
+        "origin": "https://${GITHUB_API}",
+        "auth": {
+          "scheme": "bearer",
+          "token": "${ACCESS_TOKEN}"
+        }
+      },
+      {
+        "//": "create a pull request review",
+        "method": "POST",
+        "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+        "origin": "https://${GITHUB_API}",
+        "auth": {
+          "scheme": "bearer",
+          "token": "${ACCESS_TOKEN}"
+        }
       }
     ]
   }

--- a/defaultFilters/github.json
+++ b/defaultFilters/github.json
@@ -2118,6 +2118,24 @@
         "method": "POST",
         "path": "/graphql",
         "origin": "https://${GITHUB_TOKEN}@${GITHUB_GRAPHQL}"
+      },
+      {
+        "//": "create a general pull request comment",
+        "method": "POST",
+        "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+        "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+      },
+      {
+        "//": "update a general pull request comment",
+        "method": "PATCH",
+        "path": "/repos/:name/:repo/issues/comments/:commentId",
+        "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+      },
+      {
+        "//": "create a pull request review",
+        "method": "POST",
+        "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+        "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
       }
     ]
   }

--- a/test/fixtures/accept/github.json
+++ b/test/fixtures/accept/github.json
@@ -26,6 +26,24 @@
           "values": ["application/vnd.github.v4.sha"]
         }
       ]
+    },
+    {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "create a pull request review",
+      "method": "POST",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     }
   ]
 }

--- a/test/fixtures/client/github/graphql/find-pull-request-threads.txt
+++ b/test/fixtures/client/github/graphql/find-pull-request-threads.txt
@@ -1,0 +1,25 @@
+{
+    repository(owner: "test-org", name: "test-repo") {
+        pullRequest(number: 1) {
+        reviewThreads(first: 10) {
+            nodes {
+            id,
+            comments(first:1) {
+                nodes {
+                    id,
+                    pullRequestReview {
+                        id
+                    }
+                }
+            }
+            },
+            pageInfo {
+                hasNextPage,
+                hasPreviousPage,
+                endCursor,
+                startCursor
+            }
+        }
+        }
+    }
+}

--- a/test/fixtures/client/github/graphql/resolve-pull-request-thread.txt
+++ b/test/fixtures/client/github/graphql/resolve-pull-request-thread.txt
@@ -1,0 +1,12 @@
+mutation
+    {
+        resolveReviewThread(input: { threadId: "thread_id" }) {
+        thread {
+            comments(first: 1) {
+            nodes {
+                id
+            }
+            }
+        }
+        }
+    }

--- a/test/fixtures/relay.json
+++ b/test/fixtures/relay.json
@@ -101,6 +101,16 @@
         "//": "query to find open snyk pull requests, allowing auto dependency upgrade pull requests to open no more than a limited amount of pull requests",
         "path": "query",
         "regex": "{\\s*search\\(\\s*query: \"repo:[a-zA-Z0-9-_.]+\\/[a-zA-Z0-9-_.]+ is:pr state:[a-zA-Z]+ head:snyk-\\s*(is:[a-zA-Z]+)?\", type: ISSUE, last: [0-9]+\\s*\\)\\s*{\\s*edges {\\s*node {\\s*\\.\\.\\. on PullRequest {\\s*url\\s*title\\s*createdAt\\s*headRefName\\s*state\\s*mergeable\\s*body\\s*repository\\s*{\\s*name\\s*}\\s*}\\s*}\\s*}\\s*}\\s*rateLimit\\s*{\\s*limit\\s*cost\\s*remaining\\s*resetAt\\s*}\\s*}\\s*"
+      },
+      {
+        "//": "query for pull request review threads",
+        "path": "query",
+        "regex": ".*{\\s*reviewThreads\\(first:\\s*\\d+\\)\\s*{.*"
+      },
+      {
+        "//": "resolve pull request review thread",
+        "path": "query",
+        "regex": "mutation\\s*{\\s*resolveReviewThread\\(input:\\s*{\\s*threadId:\\s*\"[a-zA-Z0-9-_.]+\"\\s*}\\)\\s*{.*"
       }
     ]
   },

--- a/test/unit/__snapshots__/runtime-rules-hotloading.test.ts.snap
+++ b/test/unit/__snapshots__/runtime-rules-hotloading.test.ts.snap
@@ -4212,6 +4212,24 @@ Object {
       "path": "/graphql",
     },
     Object {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+    },
+    Object {
+      "//": "create a pull request review",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+    },
+    Object {
       "//": "used to get custom pull request template",
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
@@ -5628,6 +5646,24 @@ Object {
       "method": "POST",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_GRAPHQL}",
       "path": "/graphql",
+    },
+    Object {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+    },
+    Object {
+      "//": "create a pull request review",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
     },
     Object {
       "//": "used to get custom pull request template",
@@ -12183,6 +12219,24 @@ Object {
       "path": "/graphql",
     },
     Object {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+    },
+    Object {
+      "//": "create a pull request review",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+    },
+    Object {
       "//": "used to get repo's teams list",
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
@@ -13647,6 +13701,24 @@ Object {
       "method": "POST",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_GRAPHQL}",
       "path": "/graphql",
+    },
+    Object {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+    },
+    Object {
+      "//": "create a pull request review",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
     },
     Object {
       "//": "used to get repo's teams list",
@@ -19997,6 +20069,24 @@ Object {
       "path": "/graphql",
     },
     Object {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+    },
+    Object {
+      "//": "create a pull request review",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+    },
+    Object {
       "//": "used to get given manifest file",
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
@@ -21407,6 +21497,24 @@ Object {
       "method": "POST",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_GRAPHQL}",
       "path": "/graphql",
+    },
+    Object {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+    },
+    Object {
+      "//": "create a pull request review",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
     },
     Object {
       "//": "used to get given manifest file",
@@ -27766,6 +27874,24 @@ Object {
       "path": "/graphql",
     },
     Object {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+    },
+    Object {
+      "//": "create a pull request review",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+    },
+    Object {
       "//": "allow info refs (for git clone)",
       "method": "GET",
       "origin": "https://pat:\${GITHUB_TOKEN}@\${GITHUB}",
@@ -29188,6 +29314,24 @@ Object {
       "method": "POST",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_GRAPHQL}",
       "path": "/graphql",
+    },
+    Object {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+    },
+    Object {
+      "//": "create a pull request review",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
     },
     Object {
       "//": "allow info refs (for git clone)",
@@ -35623,6 +35767,24 @@ Object {
       "path": "/graphql",
     },
     Object {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+    },
+    Object {
+      "//": "create a pull request review",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+    },
+    Object {
       "//": "used to scan IAC files",
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
@@ -37057,6 +37219,24 @@ Object {
       "method": "POST",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_GRAPHQL}",
       "path": "/graphql",
+    },
+    Object {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+    },
+    Object {
+      "//": "create a pull request review",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
     },
     Object {
       "//": "used to scan IAC files",
@@ -43470,6 +43650,24 @@ Object {
       "path": "/graphql",
     },
     Object {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+    },
+    Object {
+      "//": "create a pull request review",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+    },
+    Object {
       "//": "allow info refs (for git clone)",
       "method": "GET",
       "origin": "https://pat:\${GITHUB_TOKEN}@\${GITHUB}",
@@ -44892,6 +45090,24 @@ Object {
       "method": "POST",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_GRAPHQL}",
       "path": "/graphql",
+    },
+    Object {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+    },
+    Object {
+      "//": "create a pull request review",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
     },
     Object {
       "//": "allow info refs (for git clone)",
@@ -54077,6 +54293,24 @@ Object {
       "path": "/graphql",
     },
     Object {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+    },
+    Object {
+      "//": "create a pull request review",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+    },
+    Object {
       "//": "used to scan IAC files",
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
@@ -56263,6 +56497,24 @@ Object {
       "path": "/graphql",
     },
     Object {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+    },
+    Object {
+      "//": "create a pull request review",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+    },
+    Object {
       "//": "used to scan IAC files",
       "method": "GET",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
@@ -57691,6 +57943,24 @@ Object {
       "method": "POST",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_GRAPHQL}",
       "path": "/graphql",
+    },
+    Object {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+    },
+    Object {
+      "//": "create a pull request review",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
     },
     Object {
       "//": "used to scan IAC files",
@@ -59157,6 +59427,24 @@ Object {
       "method": "POST",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_GRAPHQL}",
       "path": "/graphql",
+    },
+    Object {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+    },
+    Object {
+      "//": "create a pull request review",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
     },
     Object {
       "//": "used to scan IAC files",
@@ -67103,6 +67391,24 @@ Object {
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_GRAPHQL}",
       "path": "/graphql",
     },
+    Object {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+    },
+    Object {
+      "//": "create a pull request review",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+    },
   ],
   "public": Array [
     Object {
@@ -68508,6 +68814,24 @@ Object {
       "method": "POST",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_GRAPHQL}",
       "path": "/graphql",
+    },
+    Object {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+    },
+    Object {
+      "//": "create a pull request review",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
     },
   ],
   "public": Array [
@@ -74767,6 +75091,24 @@ Object {
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_GRAPHQL}",
       "path": "/graphql",
     },
+    Object {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+    },
+    Object {
+      "//": "create a pull request review",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+    },
   ],
   "public": Array [
     Object {
@@ -76172,6 +76514,24 @@ Object {
       "method": "POST",
       "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_GRAPHQL}",
       "path": "/graphql",
+    },
+    Object {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/:issueNumber/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/issues/comments/:commentId",
+    },
+    Object {
+      "//": "create a pull request review",
+      "method": "POST",
+      "origin": "https://\${GITHUB_TOKEN}@\${GITHUB_API}",
+      "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
     },
   ],
   "public": Array [

--- a/test/unit/filters.test.ts
+++ b/test/unit/filters.test.ts
@@ -45,6 +45,42 @@ describe('filters', () => {
         });
         expect(filterResponse).toBeFalsy();
       });
+
+      it('should allow creating a general pull request comment', () => {
+        const url = '/repos/test-org/test-repo/issues/1/comments';
+
+        const filterResponse = filter({
+          url,
+          method: 'POST',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseUrl = filterResponse ? filterResponse.url : '';
+        expect(filterResponseUrl).toMatch(url);
+      });
+
+      it('should allow updating a general pull request comment', () => {
+        const url = '/repos/test-org/test-repo/issues/comments/12345';
+
+        const filterResponse = filter({
+          url,
+          method: 'PATCH',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseUrl = filterResponse ? filterResponse.url : '';
+        expect(filterResponseUrl).toMatch(url);
+      });
+
+      it('should allow creating a pull request review', () => {
+        const url = '/repos/test-org/test-repo/pulls/:pullRef/reviews';
+
+        const filterResponse = filter({
+          url,
+          method: 'POST',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseUrl = filterResponse ? filterResponse.url : '';
+        expect(filterResponseUrl).toMatch(url);
+      });
     });
   });
 
@@ -237,6 +273,36 @@ describe('filters', () => {
             query: readFileSync(
               __dirname +
                 '/../fixtures/client/github/graphql/find-pull-requests-closed.txt',
+            ).toString('utf-8'),
+          }),
+        });
+        const filterResponseUrl = filterResponse ? filterResponse.url : '';
+        expect(filterResponseUrl).toEqual('/graphql');
+      });
+
+      it('find pull request threads', () => {
+        const filterResponse = filter({
+          url: '/graphql',
+          method: 'POST',
+          body: jsonBuffer({
+            query: readFileSync(
+              __dirname +
+                '/../fixtures/client/github/graphql/find-pull-request-threads.txt',
+            ).toString('utf-8'),
+          }),
+        });
+        const filterResponseUrl = filterResponse ? filterResponse.url : '';
+        expect(filterResponseUrl).toEqual('/graphql');
+      });
+
+      it('resolve pull request thread', () => {
+        const filterResponse = filter({
+          url: '/graphql',
+          method: 'POST',
+          body: jsonBuffer({
+            query: readFileSync(
+              __dirname +
+                '/../fixtures/client/github/graphql/resolve-pull-request-thread.txt',
             ).toString('utf-8'),
           }),
         });


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adds the ability to allow native PR experience calls through the Broker, to manage general comments, create reviews and resolve review threads in GitHub.
