### PR TITLE
fix: update remote cfg url for unibroker

### DIFF
--- a/lib/client/config/remoteConfig.ts
+++ b/lib/client/config/remoteConfig.ts
@@ -9,12 +9,10 @@ export const retrieveConnectionsForDeployment = async (
   clientOpts: ClientOpts,
   universalFilePath: string,
 ) => {
-  const tenantId = clientOpts.config.tenantId;
-  const installId = clientOpts.config.installId;
   const deploymentId = clientOpts.config.deploymentId;
   const apiVersion = clientOpts.config.apiVersion;
   const request: PostFilterPreparedRequest = {
-    url: `${clientOpts.config.API_BASE_URL}/rest/tenants/${tenantId}/brokers/installs/${installId}/deployments/${deploymentId}/connections?version=${apiVersion}`,
+    url: `${clientOpts.config.API_BASE_URL}/hidden/brokers/deployments/${deploymentId}/connections?version=${apiVersion}`,
     headers: {
       'Content-Type': 'application/vnd.api+json',
       Authorization: `${clientOpts.accessToken?.authHeader}`,
@@ -25,7 +23,7 @@ export const retrieveConnectionsForDeployment = async (
   if (connectionsResponse.statusCode != 200) {
     if (connectionsResponse.statusCode == 404) {
       throw new Error(
-        `No deployment found for tenant ${tenantId} install ${installId}. You must create a deployment first.`,
+        `No deployment found. You must create a deployment first.`,
       );
     } else {
       const errorBody = JSON.parse(connectionsResponse.body);

--- a/test/unit/remoteConfig.test.ts
+++ b/test/unit/remoteConfig.test.ts
@@ -11,7 +11,7 @@ describe('Remote config helpers', () => {
     nock('http://restapihostname')
       .persist()
       .get(
-        `/rest/tenants/12345/brokers/installs/12345/deployments/67890/connections?version=2024-04-02~experimental`,
+        `/hidden/brokers/deployments/67890/connections?version=2024-04-02~experimental`,
       )
       .reply(() => {
         return [
@@ -39,7 +39,7 @@ describe('Remote config helpers', () => {
         ];
       })
       .get(
-        `/rest/tenants/12345/brokers/installs/12345/deployments/67891/connections?version=2024-04-02~experimental`,
+        `/hidden/brokers/deployments/67891/connections?version=2024-04-02~experimental`,
       )
       .reply(() => {
         return [
@@ -75,17 +75,13 @@ describe('Remote config helpers', () => {
     delete process.env.CLIENT_ID;
     delete process.env.CLIENT_SECRET;
   });
-  it('Retrieve connections from install ID and deployment ID', async () => {
+  it('Retrieve connections from deployment ID', async () => {
     await loadBrokerConfig();
     let config = getConfig();
 
-    const installId = '12345';
-    const tenantId = '12345';
     const deploymentId = '67890';
     const apiVersion = '2024-04-02~experimental';
     const apiBaseUrl = 'http://restapihostname';
-    config.tenantId = tenantId;
-    config.installId = installId;
     config.deploymentId = deploymentId;
     config.apiVersion = apiVersion;
     config.API_BASE_URL = apiBaseUrl;
@@ -120,13 +116,9 @@ describe('Remote config helpers', () => {
     await loadBrokerConfig();
     let config = getConfig();
 
-    const installId = '12345';
-    const tenantId = '12345';
     const deploymentId = '67891';
     const apiVersion = '2024-04-02~experimental';
     const apiBaseUrl = 'http://restapihostname';
-    config.tenantId = tenantId;
-    config.installId = installId;
     config.deploymentId = deploymentId;
     config.apiVersion = apiVersion;
     config.API_BASE_URL = apiBaseUrl;


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Updates the endpoint from which the universal broker retrieves the connections details. Simplifies the parameters to pass to the broker client in the deployment/container.