### PR TITLE
fix: universal brk webhooks support for ghsa-ghca

### DIFF
--- a/config.universaltest5.json
+++ b/config.universaltest5.json
@@ -1,0 +1,27 @@
+{
+    "BROKER_CLIENT_CONFIGURATION": {
+      "common": {
+        "default": {
+          "BROKER_SERVER_URL": "https://broker2.dev.snyk.io",
+          "BROKER_HA_MODE_ENABLED": "false",
+          "BROKER_DISPATCHER_BASE_URL": "https://api.dev.snyk.io"
+        }
+      },
+      "github": {
+        "validations":[{
+          "url": "https://notexists.notexists/no-such-url-ever"
+        }]
+      },
+      "gitlab": {
+        "validations":[{
+          "url": "https://notexists.notexists/no-such-url-ever"
+        }]
+      }
+    },
+    "CONNECTIONS": {
+      "my github connection": {
+        "type": "github-server-app",
+        "identifier": "${BROKER_TOKEN_1}"
+      }
+    }
+  }

--- a/config.universaltest6.json
+++ b/config.universaltest6.json
@@ -1,0 +1,27 @@
+{
+    "BROKER_CLIENT_CONFIGURATION": {
+      "common": {
+        "default": {
+          "BROKER_SERVER_URL": "https://broker2.dev.snyk.io",
+          "BROKER_HA_MODE_ENABLED": "false",
+          "BROKER_DISPATCHER_BASE_URL": "https://api.dev.snyk.io"
+        }
+      },
+      "github": {
+        "validations":[{
+          "url": "https://notexists.notexists/no-such-url-ever"
+        }]
+      },
+      "gitlab": {
+        "validations":[{
+          "url": "https://notexists.notexists/no-such-url-ever"
+        }]
+      }
+    },
+    "CONNECTIONS": {
+      "my github connection": {
+        "type": "github-cloud-app",
+        "identifier": "${BROKER_TOKEN_1}"
+      }
+    }
+  }

--- a/lib/client/routesHandler/websocketConnectionMiddlewares.ts
+++ b/lib/client/routesHandler/websocketConnectionMiddlewares.ts
@@ -40,6 +40,18 @@ export const websocketConnectionSelectorMiddleware = (
         availableConnectionsTypes.includes('github-enterprise')
       ) {
         inboundRequestType = 'github-enterprise';
+      } else if (
+        splitUrl.length > 2 &&
+        splitUrl[2] == 'github' &&
+        availableConnectionsTypes.includes('github-server-app')
+      ) {
+        inboundRequestType = 'github-server-app';
+      } else if (
+        splitUrl.length > 2 &&
+        splitUrl[2] == 'github' &&
+        availableConnectionsTypes.includes('github-cloud-app')
+      ) {
+        inboundRequestType = 'github-cloud-app';
       } else {
         logger.warn({ url: req.path }, 'Unexpected type in webhook request');
         res

--- a/test/functional/webhook-universal-ghca.test.ts
+++ b/test/functional/webhook-universal-ghca.test.ts
@@ -1,0 +1,101 @@
+const PORT = 9999;
+process.env.BROKER_SERVER_URL = `http://localhost:${PORT}`;
+import path from 'path';
+import { axiosClient } from '../setup/axios-client';
+import {
+  BrokerClient,
+  closeBrokerClient,
+  waitForBrokerServerConnections,
+} from '../setup/broker-client';
+import {
+  BrokerServer,
+  closeBrokerServer,
+  createBrokerServer,
+  waitForUniversalBrokerClientsConnection,
+} from '../setup/broker-server';
+import { TestWebServer, createTestWebServer } from '../setup/test-web-server';
+import { DEFAULT_TEST_WEB_SERVER_PORT } from '../setup/constants';
+import { createUniversalBrokerClient } from '../setup/broker-universal-client';
+
+const fixtures = path.resolve(__dirname, '..', 'fixtures');
+const serverAccept = path.join(fixtures, 'server', 'filters-webhook.json');
+const clientAccept = path.join(fixtures, 'client', 'filters-webhook.json');
+
+describe('proxy requests originating from behind the broker client', () => {
+  let tws: TestWebServer;
+  let bs: BrokerServer;
+  let bc: BrokerClient;
+  process.env.API_BASE_URL = `http://localhost:${DEFAULT_TEST_WEB_SERVER_PORT}`;
+
+  beforeAll(async () => {
+    process.env.SKIP_REMOTE_CONFIG = 'true';
+    tws = await createTestWebServer();
+
+    bs = await createBrokerServer({ port: PORT, filters: serverAccept });
+
+    process.env.SNYK_BROKER_SERVER_UNIVERSAL_CONFIG_ENABLED = 'true';
+    process.env.UNIVERSAL_BROKER_ENABLED = 'true';
+    process.env.SERVICE_ENV = 'universaltest6';
+    process.env.BROKER_TOKEN_1 = 'brokertoken1';
+    // process.env.BROKER_TOKEN_2 = 'brokertoken2';
+    process.env.SNYK_BROKER_CLIENT_CONFIGURATION__common__default__BROKER_SERVER_URL = `http://localhost:${bs.port}`;
+    process.env['SNYK_FILTER_RULES_PATHS__github-server-app'] = clientAccept;
+    // process.env['SNYK_FILTER_RULES_PATHS__github-cloud-app'] = clientAccept;
+
+    bc = await createUniversalBrokerClient();
+    await waitForUniversalBrokerClientsConnection(bs, 1);
+  });
+
+  afterAll(async () => {
+    await tws.server.close();
+    await closeBrokerClient(bc);
+    await closeBrokerServer(bs);
+    delete process.env.BROKER_SERVER_URL;
+  });
+
+  it('server identifies self to client', async () => {
+    const serverMetadata = await waitForBrokerServerConnections(bc);
+    expect(serverMetadata.map((x) => x.brokertoken)).toEqual(
+      expect.arrayContaining(['brokertoken1']),
+    );
+    expect(serverMetadata.map((x) => x.capabilities)).toEqual(
+      expect.arrayContaining([['receive-post-streams']]),
+    );
+  });
+
+  it('successfully broker GHSA Webhook call via tunnel without github conn', async () => {
+    const response = await axiosClient.post(
+      `http://localhost:${bc.port}/webhook/github/12345678-1234-1234-1234-123456789abc`,
+      { some: { example: 'json' } },
+    );
+
+    expect(response.status).toEqual(200);
+    expect(response.data).toStrictEqual('Received webhook via websocket');
+  });
+
+  it('successfully fails Webhook call without matching type', async () => {
+    const response = await axiosClient.post(
+      `http://localhost:${bc.port}/webhook/githubd/12345678-1234-1234-1234-000000000000`,
+      { some: { example: 'json' } },
+    );
+
+    expect(response.status).toEqual(401);
+    expect(response.data).toStrictEqual(
+      'Unexpected type in webhook request, unable to forward to server.',
+    );
+  });
+
+  it('successfully fails Webhook call via API without matching type', async () => {
+    await closeBrokerServer(bs);
+
+    const response = await axiosClient.post(
+      `http://localhost:${bc.port}/webhook/githubd/12345678-1234-1234-1234-000000000000`,
+      { some: { example: 'json' } },
+    );
+
+    expect(response.status).toEqual(401);
+    expect(response.data).toStrictEqual(
+      'Unexpected type in webhook request, unable to forward to server.',
+    );
+  });
+});

--- a/test/functional/webhook-universal-ghsa.test.ts
+++ b/test/functional/webhook-universal-ghsa.test.ts
@@ -1,0 +1,101 @@
+const PORT = 9999;
+process.env.BROKER_SERVER_URL = `http://localhost:${PORT}`;
+import path from 'path';
+import { axiosClient } from '../setup/axios-client';
+import {
+  BrokerClient,
+  closeBrokerClient,
+  waitForBrokerServerConnections,
+} from '../setup/broker-client';
+import {
+  BrokerServer,
+  closeBrokerServer,
+  createBrokerServer,
+  waitForUniversalBrokerClientsConnection,
+} from '../setup/broker-server';
+import { TestWebServer, createTestWebServer } from '../setup/test-web-server';
+import { DEFAULT_TEST_WEB_SERVER_PORT } from '../setup/constants';
+import { createUniversalBrokerClient } from '../setup/broker-universal-client';
+
+const fixtures = path.resolve(__dirname, '..', 'fixtures');
+const serverAccept = path.join(fixtures, 'server', 'filters-webhook.json');
+const clientAccept = path.join(fixtures, 'client', 'filters-webhook.json');
+
+describe('proxy requests originating from behind the broker client', () => {
+  let tws: TestWebServer;
+  let bs: BrokerServer;
+  let bc: BrokerClient;
+  process.env.API_BASE_URL = `http://localhost:${DEFAULT_TEST_WEB_SERVER_PORT}`;
+
+  beforeAll(async () => {
+    process.env.SKIP_REMOTE_CONFIG = 'true';
+    tws = await createTestWebServer();
+
+    bs = await createBrokerServer({ port: PORT, filters: serverAccept });
+
+    process.env.SNYK_BROKER_SERVER_UNIVERSAL_CONFIG_ENABLED = 'true';
+    process.env.UNIVERSAL_BROKER_ENABLED = 'true';
+    process.env.SERVICE_ENV = 'universaltest5';
+    process.env.BROKER_TOKEN_1 = 'brokertoken1';
+    // process.env.BROKER_TOKEN_2 = 'brokertoken2';
+    process.env.SNYK_BROKER_CLIENT_CONFIGURATION__common__default__BROKER_SERVER_URL = `http://localhost:${bs.port}`;
+    process.env['SNYK_FILTER_RULES_PATHS__github-server-app'] = clientAccept;
+    // process.env['SNYK_FILTER_RULES_PATHS__github-cloud-app'] = clientAccept;
+
+    bc = await createUniversalBrokerClient();
+    await waitForUniversalBrokerClientsConnection(bs, 1);
+  });
+
+  afterAll(async () => {
+    await tws.server.close();
+    await closeBrokerClient(bc);
+    await closeBrokerServer(bs);
+    delete process.env.BROKER_SERVER_URL;
+  });
+
+  it('server identifies self to client', async () => {
+    const serverMetadata = await waitForBrokerServerConnections(bc);
+    expect(serverMetadata.map((x) => x.brokertoken)).toEqual(
+      expect.arrayContaining(['brokertoken1']),
+    );
+    expect(serverMetadata.map((x) => x.capabilities)).toEqual(
+      expect.arrayContaining([['receive-post-streams']]),
+    );
+  });
+
+  it('successfully broker GHSA Webhook call via tunnel without github conn', async () => {
+    const response = await axiosClient.post(
+      `http://localhost:${bc.port}/webhook/github/12345678-1234-1234-1234-123456789abc`,
+      { some: { example: 'json' } },
+    );
+
+    expect(response.status).toEqual(200);
+    expect(response.data).toStrictEqual('Received webhook via websocket');
+  });
+
+  it('successfully fails Webhook call without matching type', async () => {
+    const response = await axiosClient.post(
+      `http://localhost:${bc.port}/webhook/githubd/12345678-1234-1234-1234-000000000000`,
+      { some: { example: 'json' } },
+    );
+
+    expect(response.status).toEqual(401);
+    expect(response.data).toStrictEqual(
+      'Unexpected type in webhook request, unable to forward to server.',
+    );
+  });
+
+  it('successfully fails Webhook call via API without matching type', async () => {
+    await closeBrokerServer(bs);
+
+    const response = await axiosClient.post(
+      `http://localhost:${bc.port}/webhook/githubd/12345678-1234-1234-1234-000000000000`,
+      { some: { example: 'json' } },
+    );
+
+    expect(response.status).toEqual(401);
+    expect(response.data).toStrictEqual(
+      'Unexpected type in webhook request, unable to forward to server.',
+    );
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
**Universal Broker Only**
Makes sure to forward wehook/github/.... url pattern to ghsa or ghca connections if they are the only one(s) available.
