### PR TITLE
fix: rm CVE-2024-35325

### DIFF
--- a/dockerfiles/base/Dockerfile.ubi
+++ b/dockerfiles/base/Dockerfile.ubi
@@ -64,6 +64,7 @@ RUN <<EOF
     rpm --erase --nodeps libnghttp2
     rpm --erase --nodeps libtasn1
     rpm --erase --nodeps libxml2
+    rpm --erase --nodeps libyaml
     rpm --erase --nodeps lz4-libs
     rpm --erase --nodeps ncurses-base
     rpm --erase --nodeps openldap


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Removes unused libyaml in UBI image.

#### Any background context you want to provide?

 https://access.redhat.com/security/cve/CVE-2024-35325