### PR TITLE
feat: add bitbucket server general comment rules [SCM-516]

### DIFF
--- a/client-templates/bitbucket-server-bearer-auth/accept.json.sample
+++ b/client-templates/bitbucket-server-bearer-auth/accept.json.sample
@@ -1022,6 +1022,36 @@
         "scheme": "bearer",
         "token": "${BITBUCKET_PAT}"
       }
+    },
+    {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
+    },
+    {
+      "//": "update a general pull request comment",
+      "method": "PUT",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
+    },
+    {
+      "//": "get a general pull request comment",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
     }
   ]
 }

--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -1123,6 +1123,39 @@
         "username": "${BITBUCKET_USERNAME}",
         "password": "${BITBUCKET_PASSWORD}"
       }
+    },
+    {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "update a general pull request comment",
+      "method": "PUT",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "get a general pull request comment",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
     }
   ]
 }

--- a/defaultFilters/bitbucket-server-bearer-auth.json
+++ b/defaultFilters/bitbucket-server-bearer-auth.json
@@ -1022,6 +1022,36 @@
         "scheme": "bearer",
         "token": "${BITBUCKET_PAT}"
       }
+    },
+    {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
+    },
+    {
+      "//": "update a general pull request comment",
+      "method": "PUT",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
+    },
+    {
+      "//": "get a general pull request comment",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
     }
   ]
 }

--- a/defaultFilters/bitbucket-server.json
+++ b/defaultFilters/bitbucket-server.json
@@ -1123,6 +1123,39 @@
           "username": "${BITBUCKET_USERNAME}",
           "password": "${BITBUCKET_PASSWORD}"
         }
+      },
+      {
+        "//": "create a general pull request comment",
+        "method": "POST",
+        "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+        "origin": "https://${BITBUCKET_API}",
+        "auth": {
+          "scheme": "basic",
+          "username": "${BITBUCKET_USERNAME}",
+          "password": "${BITBUCKET_PASSWORD}"
+        }
+      },
+      {
+        "//": "update a general pull request comment",
+        "method": "PUT",
+        "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+        "origin": "https://${BITBUCKET_API}",
+        "auth": {
+          "scheme": "basic",
+          "username": "${BITBUCKET_USERNAME}",
+          "password": "${BITBUCKET_PASSWORD}"
+        }
+      },
+      {
+        "//": "get a general pull request comment",
+        "method": "GET",
+        "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+        "origin": "https://${BITBUCKET_API}",
+        "auth": {
+          "scheme": "basic",
+          "username": "${BITBUCKET_USERNAME}",
+          "password": "${BITBUCKET_PASSWORD}"
+        }
       }
     ]
   }

--- a/test/fixtures/accept/bitbucket-server-bearer-auth.json
+++ b/test/fixtures/accept/bitbucket-server-bearer-auth.json
@@ -1,0 +1,36 @@
+{
+  "//": "Cut down example accept.json for bitbucket-server-bearer-auth to test filter logic",
+  "public": [],
+  "private": [
+    {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
+    },
+    {
+      "//": "update a general pull request comment",
+      "method": "PUT",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
+    },
+    {
+      "//": "get a general pull request comment",
+      "method": "GET",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
+    }
+  ]
+}

--- a/test/fixtures/accept/bitbucket-server.json
+++ b/test/fixtures/accept/bitbucket-server.json
@@ -1,0 +1,39 @@
+{
+    "//": "Cut down example accept.json for bitbucket-server to test filter logic",
+    "public": [],
+    "private": [
+      {
+        "//": "create a general pull request comment",
+        "method": "POST",
+        "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+        "origin": "https://${BITBUCKET_API}",
+        "auth": {
+          "scheme": "basic",
+          "username": "${BITBUCKET_USERNAME}",
+          "password": "${BITBUCKET_PASSWORD}"
+        }
+      },
+      {
+        "//": "update a general pull request comment",
+        "method": "PUT",
+        "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+        "origin": "https://${BITBUCKET_API}",
+        "auth": {
+          "scheme": "basic",
+          "username": "${BITBUCKET_USERNAME}",
+          "password": "${BITBUCKET_PASSWORD}"
+        }
+      },
+      {
+        "//": "get a general pull request comment",
+        "method": "GET",
+        "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+        "origin": "https://${BITBUCKET_API}",
+        "auth": {
+          "scheme": "basic",
+          "username": "${BITBUCKET_USERNAME}",
+          "password": "${BITBUCKET_PASSWORD}"
+        }
+      }
+    ]
+  }

--- a/test/unit/__snapshots__/runtime-rules-hotloading.test.ts.snap
+++ b/test/unit/__snapshots__/runtime-rules-hotloading.test.ts.snap
@@ -1306,6 +1306,39 @@ Object {
       "path": "/rest/default-reviewers/1.0/projects/:projectKey/repos/:repo/reviewers",
     },
     Object {
+      "//": "create a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "POST",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "PUT",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
+      "//": "get a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
       "//": "used to get custom pull request template",
       "auth": Object {
         "password": "\${BITBUCKET_PASSWORD}",
@@ -2356,6 +2389,36 @@ Object {
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/default-reviewers/1.0/projects/:projectKey/repos/:repo/reviewers",
+    },
+    Object {
+      "//": "create a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "POST",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "PUT",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
+      "//": "get a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
     },
     Object {
       "//": "used to get custom pull request template",
@@ -9077,6 +9140,39 @@ Object {
       "path": "/rest/default-reviewers/1.0/projects/:projectKey/repos/:repo/reviewers",
     },
     Object {
+      "//": "create a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "POST",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "PUT",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
+      "//": "get a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
       "//": "used to get repo's commits",
       "auth": Object {
         "password": "\${BITBUCKET_PASSWORD}",
@@ -10249,6 +10345,36 @@ Object {
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/default-reviewers/1.0/projects/:projectKey/repos/:repo/reviewers",
+    },
+    Object {
+      "//": "create a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "POST",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "PUT",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
+      "//": "get a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
     },
     Object {
       "//": "used to get repo's commits",
@@ -17204,6 +17330,39 @@ Object {
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/default-reviewers/1.0/projects/:projectKey/repos/:repo/reviewers",
     },
+    Object {
+      "//": "create a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "POST",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "PUT",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
+      "//": "get a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
   ],
   "public": Array [
     Object {
@@ -18233,6 +18392,36 @@ Object {
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/default-reviewers/1.0/projects/:projectKey/repos/:repo/reviewers",
+    },
+    Object {
+      "//": "create a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "POST",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "PUT",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
+      "//": "get a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
     },
   ],
   "public": Array [
@@ -24947,6 +25136,39 @@ Object {
       "path": "/rest/default-reviewers/1.0/projects/:projectKey/repos/:repo/reviewers",
     },
     Object {
+      "//": "create a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "POST",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "PUT",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
+      "//": "get a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
       "//": "allow info refs (for git clone)",
       "auth": Object {
         "password": "\${BITBUCKET_PASSWORD}",
@@ -26008,6 +26230,36 @@ Object {
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/default-reviewers/1.0/projects/:projectKey/repos/:repo/reviewers",
+    },
+    Object {
+      "//": "create a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "POST",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "PUT",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
+      "//": "get a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
     },
     Object {
       "//": "allow info refs (for git clone)",
@@ -32798,6 +33050,39 @@ Object {
       "path": "/rest/default-reviewers/1.0/projects/:projectKey/repos/:repo/reviewers",
     },
     Object {
+      "//": "create a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "POST",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "PUT",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
+      "//": "get a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
       "//": "used to scan IAC files",
       "auth": Object {
         "password": "\${BITBUCKET_PASSWORD}",
@@ -33881,6 +34166,36 @@ Object {
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/default-reviewers/1.0/projects/:projectKey/repos/:repo/reviewers",
+    },
+    Object {
+      "//": "create a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "POST",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "PUT",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
+      "//": "get a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
     },
     Object {
       "//": "used to scan IAC files",
@@ -40723,6 +41038,39 @@ Object {
       "path": "/rest/default-reviewers/1.0/projects/:projectKey/repos/:repo/reviewers",
     },
     Object {
+      "//": "create a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "POST",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "PUT",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
+      "//": "get a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
       "//": "allow info refs (for git clone)",
       "auth": Object {
         "password": "\${BITBUCKET_PASSWORD}",
@@ -41784,6 +42132,36 @@ Object {
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/default-reviewers/1.0/projects/:projectKey/repos/:repo/reviewers",
+    },
+    Object {
+      "//": "create a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "POST",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "PUT",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
+      "//": "get a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
     },
     Object {
       "//": "allow info refs (for git clone)",
@@ -48976,6 +49354,39 @@ Object {
       "path": "/rest/default-reviewers/1.0/projects/:projectKey/repos/:repo/reviewers",
     },
     Object {
+      "//": "create a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "POST",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "PUT",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
+      "//": "get a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
       "//": "used to scan IAC files",
       "auth": Object {
         "password": "\${BITBUCKET_PASSWORD}",
@@ -50217,6 +50628,39 @@ Object {
       "path": "/rest/default-reviewers/1.0/projects/:projectKey/repos/:repo/reviewers",
     },
     Object {
+      "//": "create a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "POST",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "PUT",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
+      "//": "get a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
       "//": "used to scan IAC files",
       "auth": Object {
         "password": "\${BITBUCKET_PASSWORD}",
@@ -51289,6 +51733,36 @@ Object {
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/default-reviewers/1.0/projects/:projectKey/repos/:repo/reviewers",
+    },
+    Object {
+      "//": "create a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "POST",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "PUT",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
+      "//": "get a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
     },
     Object {
       "//": "used to scan IAC files",
@@ -52419,6 +52893,36 @@ Object {
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/default-reviewers/1.0/projects/:projectKey/repos/:repo/reviewers",
+    },
+    Object {
+      "//": "create a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "POST",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "PUT",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
+      "//": "get a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
     },
     Object {
       "//": "used to scan IAC files",
@@ -64529,6 +65033,39 @@ Object {
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/default-reviewers/1.0/projects/:projectKey/repos/:repo/reviewers",
     },
+    Object {
+      "//": "create a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "POST",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "PUT",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
+      "//": "get a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
   ],
   "public": Array [
     Object {
@@ -65558,6 +66095,36 @@ Object {
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/default-reviewers/1.0/projects/:projectKey/repos/:repo/reviewers",
+    },
+    Object {
+      "//": "create a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "POST",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "PUT",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
+      "//": "get a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
     },
   ],
   "public": Array [
@@ -72229,6 +72796,39 @@ Object {
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/default-reviewers/1.0/projects/:projectKey/repos/:repo/reviewers",
     },
+    Object {
+      "//": "create a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "POST",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "PUT",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
+      "//": "get a general pull request comment",
+      "auth": Object {
+        "password": "\${BITBUCKET_PASSWORD}",
+        "scheme": "basic",
+        "username": "\${BITBUCKET_USERNAME}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
   ],
   "public": Array [
     Object {
@@ -73258,6 +73858,36 @@ Object {
       "method": "GET",
       "origin": "https://\${BITBUCKET}",
       "path": "/rest/default-reviewers/1.0/projects/:projectKey/repos/:repo/reviewers",
+    },
+    Object {
+      "//": "create a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "POST",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+    },
+    Object {
+      "//": "update a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "PUT",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+    },
+    Object {
+      "//": "get a general pull request comment",
+      "auth": Object {
+        "scheme": "bearer",
+        "token": "\${BITBUCKET_PAT}",
+      },
+      "method": "GET",
+      "origin": "https://\${BITBUCKET_API}",
+      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
     },
   ],
   "public": Array [

--- a/test/unit/filters.test.ts
+++ b/test/unit/filters.test.ts
@@ -82,6 +82,98 @@ describe('filters', () => {
         expect(filterResponseUrl).toMatch(url);
       });
     });
+
+    describe('for bitbucket server private filters', () => {
+      const rules = JSON.parse(
+        loadFixture(path.join('accept', 'bitbucket-server.json')),
+      );
+      const filter = loadFilters(rules.private, 'default', {});
+
+      it('should allow creating a general pull request comment', () => {
+        const url =
+          '/projects/test-org/repos/test-repo/pull-requests/1/comments';
+
+        const filterResponse = filter({
+          url,
+          method: 'POST',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseUrl = filterResponse ? filterResponse.url : '';
+        expect(filterResponseUrl).toMatch(url);
+      });
+
+      it('should allow updating a general pull request comment', () => {
+        const url =
+          '/projects/test-org/repos/test-repo/pull-requests/1/comments/12345';
+
+        const filterResponse = filter({
+          url,
+          method: 'PUT',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseUrl = filterResponse ? filterResponse.url : '';
+        expect(filterResponseUrl).toMatch(url);
+      });
+
+      it('should allow getting a general pull request comment', () => {
+        const url =
+          '/projects/test-org/repos/test-repo/pull-requests/1/comments/12345';
+
+        const filterResponse = filter({
+          url,
+          method: 'GET',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseUrl = filterResponse ? filterResponse.url : '';
+        expect(filterResponseUrl).toMatch(url);
+      });
+    });
+
+    describe('for bitbucket server bearer auth private filters', () => {
+      const rules = JSON.parse(
+        loadFixture(path.join('accept', 'bitbucket-server-bearer-auth.json')),
+      );
+      const filter = loadFilters(rules.private, 'default', {});
+
+      it('should allow creating a general pull request comment', () => {
+        const url =
+          '/projects/test-org/repos/test-repo/pull-requests/1/comments';
+
+        const filterResponse = filter({
+          url,
+          method: 'POST',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseUrl = filterResponse ? filterResponse.url : '';
+        expect(filterResponseUrl).toMatch(url);
+      });
+
+      it('should allow updating a general pull request comment', () => {
+        const url =
+          '/projects/test-org/repos/test-repo/pull-requests/1/comments/12345';
+
+        const filterResponse = filter({
+          url,
+          method: 'PUT',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseUrl = filterResponse ? filterResponse.url : '';
+        expect(filterResponseUrl).toMatch(url);
+      });
+
+      it('should allow getting a general pull request comment', () => {
+        const url =
+          '/projects/test-org/repos/test-repo/pull-requests/1/comments/12345';
+
+        const filterResponse = filter({
+          url,
+          method: 'GET',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseUrl = filterResponse ? filterResponse.url : '';
+        expect(filterResponseUrl).toMatch(url);
+      });
+    });
   });
 
   describe('on body', () => {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adds rules for bitbucket server general comments

#### Any background context you want to provide?

- https://github.com/snyk/bitbucket-server-agent/pull/616
- https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html#idm8288072528
