### PR TITLE
fix: allow one or more matching connection types for plugin enablement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,10 @@ repos:
     hooks:
       - id: gitleaks
         stages: [ commit ]
+  - repo: local
+    language: system
+    stages: [pre-commit]
+    pass_filenames: true
+    name: npm lint
+    id: npm-lint
+    entry: prettier --check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,9 +5,24 @@ repos:
       - id: gitleaks
         stages: [ commit ]
   - repo: local
-    language: system
-    stages: [pre-commit]
-    pass_filenames: true
-    name: npm lint
-    id: npm-lint
-    entry: prettier --check
+    hooks:
+      - id: prettier-lint
+        language: system
+        stages: [pre-commit]
+        pass_filenames: true
+        name: prettier lint
+        entry: prettier --check
+        types_or:
+          - "javascript"
+          - "ts"
+        files: ^(lib|test|cli)/
+      - id: eslint
+        language: system
+        stages: [pre-commit]
+        pass_filenames: true
+        name: eslint
+        entry: npx eslint --color --cache
+        types_or:
+          - "javascript"
+          - "ts"
+        files: ^(lib|test|cli)/

--- a/lib/client/brokerClientPlugins/abstractBrokerPlugin.ts
+++ b/lib/client/brokerClientPlugins/abstractBrokerPlugin.ts
@@ -30,15 +30,9 @@ export default abstract class BrokerPlugin {
   }
 
   getApplicableTypes(): Array<string> {
-    const applicableTypes: Array<string> = [];
-    if (
-      this.applicableBrokerTypes.every((type) =>
-        this.brokerClientConfiguration.supportedBrokerTypes.includes(type),
-      )
-    ) {
-      applicableTypes.push(...this.applicableBrokerTypes);
-    }
-    return applicableTypes;
+    return this.applicableBrokerTypes.filter((type) =>
+      this.brokerClientConfiguration.supportedBrokerTypes.includes(type),
+    );
   }
   isDisabled(config): boolean {
     let isDisabled = false;

--- a/test/fixtures/plugins/dummy-multi.js
+++ b/test/fixtures/plugins/dummy-multi.js
@@ -1,0 +1,35 @@
+import BrokerPlugin from '../../../lib/client/brokerClientPlugins/abstractBrokerPlugin';
+
+export class Plugin extends BrokerPlugin {
+  pluginCode = 'DUMMYMULTI';
+  pluginName = 'Dummy Plugin Multi';
+  description = `
+    dummy plugin multi 1 2
+    `;
+  version = '0.1';
+  applicableBrokerTypes = ['dummy-multi-1', 'dummy-multi-2'];
+
+  isPluginActive() {
+    if (this.brokerClientConfiguration.DISABLE_DUMMY_PLUGIN) {
+      this.logger.debug({ plugin: this.pluginName }, 'Disabling plugin');
+      return false;
+    }
+    return true;
+  }
+  async startUp(connectionConfig) {
+    this.logger.info({ plugin: this.pluginName }, 'Running Startup');
+    this.logger.info(
+      { config: connectionConfig },
+      'Connection Config passed to the plugin',
+    );
+    connectionConfig['NEW_VAR_ADDED_TO_CONNECTION'] = 'access-token';
+  }
+
+  async preRequest(connectionConfiguration, postFilterPreparedRequest) {
+    this.logger.info({ plugin: this.pluginName }, 'Running prerequest plugin');
+    const customizedRequest = postFilterPreparedRequest;
+    customizedRequest.body['NEW_VAR_ADDED_TO_CONNECTION'] =
+      connectionConfiguration['NEW_VAR_ADDED_TO_CONNECTION'];
+    return customizedRequest;
+  }
+}

--- a/test/unit/plugins/pluginManager.test.ts
+++ b/test/unit/plugins/pluginManager.test.ts
@@ -34,7 +34,9 @@ describe('Plugin Manager', () => {
     };
     const plugins = await loadPlugins(pluginsFolderPath, clientOpts);
     expect(plugins.get('dummy-multi-1').length).toBeGreaterThanOrEqual(1);
-    expect(plugins.get('dummy-multi-1')[0].pluginName).toEqual('Dummy Plugin Multi');
+    expect(plugins.get('dummy-multi-1')[0].pluginName).toEqual(
+      'Dummy Plugin Multi',
+    );
   });
 
   it('should load plugins no plugin successfully', async () => {

--- a/test/unit/plugins/pluginManager.test.ts
+++ b/test/unit/plugins/pluginManager.test.ts
@@ -24,6 +24,19 @@ describe('Plugin Manager', () => {
     expect(plugins.get('dummy')[0].pluginName).toEqual('Dummy Plugin');
   });
 
+  it('should load plugins if at least one supported broker type is present', async () => {
+    const clientOpts = {
+      config: {
+        universalBrokerEnabled: true,
+        supportedBrokerTypes: ['dummy-multi-1'],
+        connections: { 'my connection': { type: 'dummy-multi-1' } },
+      },
+    };
+    const plugins = await loadPlugins(pluginsFolderPath, clientOpts);
+    expect(plugins.get('dummy-multi-1').length).toBeGreaterThanOrEqual(1);
+    expect(plugins.get('dummy-multi-1')[0].pluginName).toEqual('Dummy Plugin Multi');
+  });
+
   it('should load plugins no plugin successfully', async () => {
     const clientOpts = {
       config: {


### PR DESCRIPTION
### What

- Adjusts the enablement mechanism for plugins to load if one or more of the defined `applicableBrokerTypes` are present in config

### Why

- Previously _all_ matching broker types must be present
