### PR TITLE
chore: rm expat from rhel image to reduce vuln FP

### DIFF
--- a/dockerfiles/base/Dockerfile.ubi
+++ b/dockerfiles/base/Dockerfile.ubi
@@ -65,6 +65,7 @@ RUN <<EOF
     rpm --erase --nodeps libtasn1
     rpm --erase --nodeps libxml2
     rpm --erase --nodeps libyaml
+    rpm --erase --nodeps expat
     rpm --erase --nodeps lz4-libs
     rpm --erase --nodeps ncurses-base
     rpm --erase --nodeps openldap


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Remove libexpat from expat package, unused by Broker, but reported as "vuln" (https://nvd.nist.gov/vuln/detail/CVE-2024-45490, https://nvd.nist.gov/vuln/detail/CVE-2024-45491, https://nvd.nist.gov/vuln/detail/CVE-2024-45492) in some scanners.
