### PR TITLE
fix: logs Snyk's correlation headers

### DIFF
--- a/lib/common/http/downstream-post-stream-to-server.ts
+++ b/lib/common/http/downstream-post-stream-to-server.ts
@@ -80,6 +80,10 @@ class BrokerServerPostResponseHandler {
         method: 'post',
         headers: {
           'Snyk-Request-Id': `${this.#requestId}`,
+          'Snyk-acting-org-public-id': `${this.#logContext.actingOrgPublicId}`,
+          'Snyk-acting-group-public-id': `${this.#logContext.actingGroupPublicId}`,
+          'Snyk-product-line': `${this.#logContext.productLine}`,
+          'Snyk-flow-name':  `${this.#logContext.flow}`,
           'Content-Type': BROKER_CONTENT_TYPE,
           Connection: 'close',
           'user-agent': 'Snyk Broker client ' + version,

--- a/lib/common/http/downstream-post-stream-to-server.ts
+++ b/lib/common/http/downstream-post-stream-to-server.ts
@@ -81,9 +81,11 @@ class BrokerServerPostResponseHandler {
         headers: {
           'Snyk-Request-Id': `${this.#requestId}`,
           'Snyk-acting-org-public-id': `${this.#logContext.actingOrgPublicId}`,
-          'Snyk-acting-group-public-id': `${this.#logContext.actingGroupPublicId}`,
+          'Snyk-acting-group-public-id': `${
+            this.#logContext.actingGroupPublicId
+          }`,
           'Snyk-product-line': `${this.#logContext.productLine}`,
-          'Snyk-flow-name':  `${this.#logContext.flow}`,
+          'Snyk-flow-name': `${this.#logContext.flow}`,
           'Content-Type': BROKER_CONTENT_TYPE,
           Connection: 'close',
           'user-agent': 'Snyk Broker client ' + version,

--- a/lib/common/relay/forwardHttpRequest.ts
+++ b/lib/common/relay/forwardHttpRequest.ts
@@ -45,6 +45,10 @@ export const forwardHttpRequest = (
           : req.headers['snyk-request-id'] || '',
       maskedToken: req['maskedToken'],
       hashedToken: req['hashedToken'],
+      actingOrgPublicId: req.headers['snyk-acting-org-public-id'] as string,
+      actingGroupPublicId: req.headers['snyk-acting-group-public-id'] as string,
+      productLine: req.headers['snyk-product-line'] as string,
+      flow: req.headers['snyk-flow-name'] as string,
     };
 
     const simplifiedContext = logContext;

--- a/lib/common/relay/forwardWebsocketRequest.ts
+++ b/lib/common/relay/forwardWebsocketRequest.ts
@@ -57,7 +57,7 @@ export const forwardWebSocketRequest = (
       actingGroupPublicId,
       actingOrgPublicId,
       flow,
-      productLine
+      productLine,
     };
 
     if (!requestId) {

--- a/lib/common/relay/forwardWebsocketRequest.ts
+++ b/lib/common/relay/forwardWebsocketRequest.ts
@@ -35,6 +35,11 @@ export const forwardWebSocketRequest = (
       payload.connectionIdentifier = connectionIdentifier;
     }
     const requestId = payload.headers['snyk-request-id'];
+    const actingOrgPublicId = payload.headers['snyk-acting-org-public-id'];
+    const actingGroupPublicId = payload.headers['snyk-acting-group-public-id'];
+    const productLine = payload.headers['snyk-product-line'];
+    const flow = payload.headers['snyk-flow-name'];
+
     const logContext: ExtendedLogContext = {
       url: payload.url,
       connectionName: websocketConnectionHandler.friendlyName ?? '',
@@ -49,6 +54,10 @@ export const forwardWebSocketRequest = (
       responseMedium: payload.headers['x-broker-ws-response']
         ? 'websocket'
         : 'http',
+      actingGroupPublicId,
+      actingOrgPublicId,
+      flow,
+      productLine
     };
 
     if (!requestId) {

--- a/lib/common/types/log.ts
+++ b/lib/common/types/log.ts
@@ -25,4 +25,8 @@ export interface ExtendedLogContext extends LogContext {
   ioErrorType?: string;
   ioOriginalBodySize?: string;
   responseMedium?: string;
+  actingOrgPublicId?: string;
+  actingGroupPublicId?: string;
+  productLine?: string;
+  flow?: string;
 }

--- a/lib/server/routesHandlers/postResponseHandler.ts
+++ b/lib/server/routesHandlers/postResponseHandler.ts
@@ -14,6 +14,10 @@ export const handlePostResponse = (req: Request, res: Response) => {
     maskedToken: desensitizedToken.maskedToken,
     streamingID,
     requestId: req.headers['snyk-request-id'],
+    actingOrgPublicId: req.headers['snyk-acting-org-public-id'],
+    actingGroupPublicId: req.headers['snyk-acting-group-public-id'],
+    productLine: req.headers['snyk-product-line'],
+    flow: req.headers['snyk-flow-name'],
   };
   logger.info(logContext, 'Handling response-data request');
   req['maskedToken'] = desensitizedToken.maskedToken;

--- a/test/functional/systemcheck-universal.test.ts
+++ b/test/functional/systemcheck-universal.test.ts
@@ -9,6 +9,7 @@ import {
 } from '../setup/broker-server';
 import { TestWebServer, createTestWebServer } from '../setup/test-web-server';
 import { createUniversalBrokerClient } from '../setup/broker-universal-client';
+import nock from 'nock';
 
 const fixtures = path.resolve(__dirname, '..', 'fixtures');
 const serverAccept = path.join(fixtures, 'server', 'filters.json');
@@ -23,6 +24,12 @@ describe('broker client systemcheck endpoint', () => {
     tws = await createTestWebServer();
     bs = await createBrokerServer({ filters: serverAccept });
     process.env.SKIP_REMOTE_CONFIG = 'true';
+    nock(`https://snyk.io`)
+      .persist()
+      .get('/no-such-url-ever')
+      .reply(() => {
+        return [308, '/no-such-url-ever/'];
+      });
   });
 
   afterAll(async () => {


### PR DESCRIPTION
Logs Snyk's correlation headers.

Before:
<img width="1056" alt="image" src="https://github.com/user-attachments/assets/1d73b309-99ff-45a4-8807-85b7d2d5f332">


Now: (server/client)
<img width="1894" alt="image" src="https://github.com/user-attachments/assets/fe1c47e3-8bb8-4460-9ac8-221dcc7a7e7c">

