### PR TITLE
feat: add apprisk docker images releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -528,6 +528,33 @@ workflows:
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
+          name: Build apprisk UBI image
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
+          requires:
+            - Push base UBI image
+          additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-rhel-ubi --build-arg BROKER_TYPE=apprisk"
+          dockerfile: dockerfiles/Dockerfile.ubi
+          project_name: rhel-ubi-apprisk
+          <<: *filter-tags-only
+      - tag-and-push-docker-image:
+          name: Push apprisk UBI image
+          context:
+            - snyk-bot-slack
+            - team-broker-cosign
+            - team-broker-docker-hub
+            - team-broker-snyk
+          requires:
+            - Build apprisk UBI image
+          image_name: snyk/broker
+          image_tag: rhel-ubi-apprisk
+          project_name: rhel-ubi-apprisk
+          post-steps:
+            - notify-slack-on-failure
+          <<: *filter-tags-only
+
+      - build-and-save-docker-image:
           name: Build artifactory UBI image
           context:
             - snyk-bot-slack
@@ -1029,6 +1056,35 @@ workflows:
           <<: *filter-tags-only
 
       - build-and-save-docker-image:
+          name: Build apprisk image
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
+          requires:
+            - Push base image
+          additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base --build-arg BROKER_TYPE=apprisk"
+          dockerfile: dockerfiles/Dockerfile
+          project_name: apprisk
+          post-steps:
+            - notify-slack-on-failure
+          <<: *filter-tags-only
+      - tag-and-push-docker-image:
+          name: Push apprisk image
+          context:
+            - snyk-bot-slack
+            - team-broker-cosign
+            - team-broker-docker-hub
+            - team-broker-snyk
+          requires:
+            - Build apprisk image
+          image_name: snyk/broker
+          image_tag: apprisk
+          project_name: apprisk
+          post-steps:
+            - notify-slack-on-failure
+          <<: *filter-tags-only
+
+      - build-and-save-docker-image:
           name: Build artifactory image
           context:
             - snyk-bot-slack
@@ -1430,6 +1486,35 @@ workflows:
           image_name: snyk/broker
           image_tag: universal
           project_name: universal
+          post-steps:
+            - notify-slack-on-failure
+          <<: *filter-tags-only
+
+      - build-and-save-docker-image:
+          name: Build apprisk image (nlatest)
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
+          requires:
+            - Push base image (nlatest)
+          additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-nlatest --build-arg BROKER_TYPE=apprisk"
+          dockerfile: dockerfiles/Dockerfile
+          project_name: apprisk-nlatest
+          post-steps:
+            - notify-slack-on-failure
+          <<: *filter-tags-only
+      - tag-and-push-docker-image:
+          name: Push apprisk image (nlatest)
+          context:
+            - snyk-bot-slack
+            - team-broker-cosign
+            - team-broker-docker-hub
+            - team-broker-snyk
+          requires:
+            - Build apprisk image (nlatest)
+          image_name: snyk/broker
+          image_tag: apprisk-nlatest
+          project_name: apprisk-nlatest
           post-steps:
             - notify-slack-on-failure
           <<: *filter-tags-only


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adds missing apprisk flavor in classic broker (non universal broker).

#### Any background context you want to provide?
This apprisk flavor is different from the ACCEPT_APPRISK which enables apprisk over connections to SCM, possibly used for other Snyk flows.
This apprisk image supports specifically connectivity to third party system specifically for Snyk Apprisk products.