### PR TITLE
fix: release process ensuring sboms folder exists

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -24,17 +24,17 @@
     {
       "//": "generate Cyclone DX JSON SBOM",
       "path": "@semantic-release/exec",
-      "cmd": "npx snyk sbom --format cyclonedx1.4+json > sboms/broker.sbom.cyclonedx.json"
+      "cmd": "mkdir -p sboms && npx snyk sbom --format cyclonedx1.4+json > sboms/broker.sbom.cyclonedx.json"
     },
     {
       "//": "generate Cyclone DX XML SBOM",
       "path": "@semantic-release/exec",
-      "cmd": "npx snyk sbom --format cyclonedx1.4+xml > sboms/broker.sbom.cyclonedx.xml"
+      "cmd": "mkdir -p sboms && npx snyk sbom --format cyclonedx1.4+xml > sboms/broker.sbom.cyclonedx.xml"
     },
     {
       "//": "generate SPDX SBOM",
       "path": "@semantic-release/exec",
-      "cmd": "npx snyk sbom --format spdx2.3+json > sboms/broker.sbom.spdx.json"
+      "cmd": "mkdir -p sboms && npx snyk sbom --format spdx2.3+json > sboms/broker.sbom.spdx.json"
     }
   ],
   "publish": [


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Fixes release process to release following:
Adds missing apprisk flavor in classic broker (non universal broker).

#### Any background context you want to provide?
This apprisk flavor is different from the ACCEPT_APPRISK which enables apprisk over connections to SCM, possibly used for other Snyk flows.
This apprisk image supports specifically connectivity to third party system specifically for Snyk Apprisk products.
