### PR TITLE
feat: add header to identify brokered webhooks [SCM-674]

### DIFF
--- a/lib/common/relay/forwardHttpRequest.ts
+++ b/lib/common/relay/forwardHttpRequest.ts
@@ -113,7 +113,10 @@ export const forwardHttpRequest = (
         url: req.url,
         method: req.method,
         body: req.body,
-        headers: req.headers,
+        headers: {
+          ...req.headers,
+          'x-snyk-brokered': 'true',
+        },
         streamingID,
       });
       incrementWebSocketRequestsTotal(false, 'outbound-request');
@@ -138,7 +141,10 @@ export const forwardHttpRequest = (
           url: req.url,
           method: req.method,
           body: req.body,
-          headers: req.headers,
+          headers: {
+            ...req.headers,
+            'x-snyk-brokered': 'true',
+          },
           streamingID: '',
         },
         (ioResponse) => {


### PR DESCRIPTION
#### What does this PR do?

We thought we could use `snyk-request-id` header to identify brokered scm webhooks but it seems something else is setting that header (perhaps the api gateway), so this PR adds an explicit header to identify brokered webhooks.


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
