### PR TITLE
chore: add server side broker header

### DIFF
--- a/lib/common/relay/forwardWebsocketRequest.ts
+++ b/lib/common/relay/forwardWebsocketRequest.ts
@@ -229,6 +229,11 @@ export const forwardWebSocketRequest = (
         );
         payload.headers[contentLengthHeader] = computeContentLength(payload);
       }
+      if (options.config.brokerType !== 'client') {
+        preparedRequest.req.headers['x-snyk-broker'] = `${maskToken(
+          connectionIdentifier,
+        )}`;
+      }
 
       incrementHttpRequestsTotal(false, 'outbound-request');
       payload.streamingID

--- a/test/functional/client-server.test.ts
+++ b/test/functional/client-server.test.ts
@@ -14,6 +14,7 @@ import {
   waitForBrokerClientConnections,
 } from '../setup/broker-server';
 import { TestWebServer, createTestWebServer } from '../setup/test-web-server';
+import { maskToken } from '../../lib/common/utils/token';
 
 const fixtures = path.resolve(__dirname, '..', 'fixtures');
 const serverAccept = path.join(fixtures, 'server', 'filters.json');
@@ -72,6 +73,18 @@ describe('proxy requests originating from behind the broker client', () => {
     expect(response.data).toStrictEqual({
       some: { example: 'json' },
     });
+  });
+
+  it('successfully broker POST with x-broker-server header', async () => {
+    const response = await axiosClient.post(
+      `http://localhost:${bc.port}/echo-headers`,
+      { some: { example: 'json' } },
+    );
+
+    expect(response.status).toEqual(200);
+    expect(response.data['x-snyk-broker']).toStrictEqual(
+      maskToken(brokerToken),
+    );
   });
 
   it('successfully broker exact bytes of POST body', async () => {

--- a/test/functional/webhook.test.ts
+++ b/test/functional/webhook.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../setup/broker-server';
 import { TestWebServer, createTestWebServer } from '../setup/test-web-server';
 import { DEFAULT_TEST_WEB_SERVER_PORT } from '../setup/constants';
+import { maskToken } from '../../lib/common/utils/token';
 
 const fixtures = path.resolve(__dirname, '..', 'fixtures');
 const serverAccept = path.join(fixtures, 'server', 'filters-webhook.json');
@@ -79,5 +80,18 @@ describe('proxy requests originating from behind the broker client', () => {
 
     expect(response.status).toEqual(200);
     expect(response.data).toStrictEqual('Received webhook via API');
+  });
+  it('successfully broker injects x-snyk-broker header to Webhook calls', async () => {
+    await closeBrokerServer(bs);
+
+    const response = await axiosClient.post(
+      `http://localhost:${bc.port}/webhook/github/return-req-headers`,
+      { some: { example: 'json' } },
+    );
+
+    expect(response.status).toEqual(200);
+    expect(response.data['x-snyk-broker']).toStrictEqual(
+      maskToken('broker-token-12345'),
+    );
   });
 });

--- a/test/setup/test-web-server.ts
+++ b/test/setup/test-web-server.ts
@@ -125,6 +125,14 @@ const applyEchoRoutes = (app: Express) => {
     },
   );
 
+  echoRouter.post(
+    '/webhook/github/return-req-headers',
+    (req: express.Request, resp: express.Response) => {
+      resp.status(200);
+      resp.send(req.headers);
+    },
+  );
+
   echoRouter.get('/test', (_: express.Request, resp: express.Response) => {
     resp.status(200);
     resp.send('All good');


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adds x-snyk-broker header in client->server side requests.
