### PR TITLE
chore: scan broker images as part of cicd workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -469,11 +469,31 @@ workflows:
           nodejs_cycle: "20"
           project_name: broker
 
+      - scan-docker-image:
+          name: Scan base image (Ubuntu)
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
+          requires:
+            - Build base image (Ubuntu)
+          project: snyk/broker
+          project_name: broker
+
       - build-and-save-docker-ubi-image:
           name: Build base image (RHEL)
           requires:
             - Install NPM packages
           dockerfile: dockerfiles/base/Dockerfile.ubi
+          project_name: broker-rhel-ubi
+
+      - scan-docker-image:
+          name: Scan base image (RHEL)
+          context:
+            - snyk-bot-slack
+            - team-broker-snyk
+          requires:
+            - Build base image (RHEL)
+          project: snyk/broker-rhel-ubi
           project_name: broker-rhel-ubi
 
       - release:
@@ -483,8 +503,8 @@ workflows:
             - snyk-bot-slack
             - team-broker-snyk
           requires:
-            - Build base image (Ubuntu)
-            - Build base image (RHEL)
+            - Scan base image (Ubuntu)
+            - Scan base image (RHEL)
             - Test
           post-steps:
             - notify-slack-on-failure

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   prodsec: snyk/prodsec-orb@1.0
   slack: circleci/slack@4.12.5
-  snyk: snyk/snyk@1.7.2
+  snyk: snyk/snyk@2.2.0
 
 defaults: &defaults
   docker:
@@ -290,6 +290,9 @@ jobs:
   scan-docker-image:
     <<: *defaults
     parameters:
+      monitor_on_build:
+        type: boolean
+        default: true
       project:
         type: string
       project_name:
@@ -308,6 +311,7 @@ jobs:
           additional-arguments: --policy-path=.snyk
           docker-image-name: <<parameters.project_name>>:$CIRCLE_WORKFLOW_ID
           fail-on-issues: <<pipeline.parameters.fail_on_issues>>
+          monitor-on-build: <<parameters.monitor_on_build>>
           organization: platform-broker
           project: <<parameters.project>>
           severity-threshold: <<parameters.severity_threshold>>
@@ -439,6 +443,7 @@ workflows:
             - Build base image (Ubuntu)
           project: snyk/broker
           project_name: broker
+          monitor_on_build: false
 
       - build-and-save-docker-ubi-image:
           name: Build base image (RHEL)
@@ -456,9 +461,7 @@ workflows:
             - Build base image (RHEL)
           project: snyk/broker-rhel-ubi
           project_name: broker-rhel-ubi
-          post-steps:
-            - notify-slack-on-failure:
-                channel: broker-alerts-vulns
+          monitor_on_build: false
 
       - release:
           name: Release to GitHub and NPM

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,22 @@ commands:
           name: Load archived Docker image
           command: |
             docker load < "/tmp/workspace/images/<<parameters.project_name>>:$CIRCLE_WORKFLOW_ID.tar.gz"
+  load-slack-templates:
+    steps:
+      - run:
+          name: Load Slack message templates
+          command: |
+            echo 'export SLACK_FAIL_MESSAGE_TEMPLATE=$(cat .circleci/templates/slack_fail_message.json)' >> $BASH_ENV
+  notify-slack-on-failure:
+    parameters:
+      channel:
+        type: string
+        default: broker-alerts-cicd
+    steps:
+      - slack/notify:
+          channel: <<parameters.channel>>
+          event: fail
+          template: SLACK_FAIL_MESSAGE_TEMPLATE
   tag-and-push-docker-image:
     description: "Tag and push Docker image to registry"
     parameters:
@@ -166,72 +182,17 @@ commands:
             export COSIGN_KEY=$(echo $COSIGN_ENCODED_KEY | base64 -d)
             cosign sign --yes --key env://COSIGN_KEY --annotations tag=$IMAGE_TAG $IMAGE_WITH_DIGEST
             unset COSIGN_KEY
+  prepare:
+    description: "Checkout repository source code and load all Slack templates"
+    steps:
+      - checkout
+      - load-slack-templates
   prepare-dev-package-metadata:
     steps:
       - run:
           name: Prepare package.json and metadata.json for dev images
           command: |
             cd dockerfiles/.scripts && source prepare.sh
-  notify-slack-on-failure:
-    parameters:
-      channel:
-        type: string
-        default: broker-alerts-cicd
-    steps:
-      - slack/notify:
-          channel: <<parameters.channel>>
-          event: fail
-          custom: |
-            {
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "CICD pipeline failed :circleci-fail:",
-                    "emoji": true
-                  }
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Project*: ${CIRCLE_PROJECT_REPONAME}"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Job*: ${CIRCLE_JOB}"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Branch*: ${CIRCLE_BRANCH}"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Author*: ${CIRCLE_USERNAME}"
-                    }
-                  ]
-                },
-                {
-                  "type": "actions",
-                  "elements": [
-                    {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "emoji": true,
-                        "text": "View Job"
-                      },
-                      "url": "${CIRCLE_BUILD_URL}"
-                    }
-                  ]
-                }
-              ]
-            }
 
 jobs:
   install-npm-packages:
@@ -239,7 +200,7 @@ jobs:
     environment:
       NODE_ENV: development
     steps:
-      - checkout
+      - prepare
       - run:
           name: Install NPM packages
           command: npm clean-install
@@ -250,7 +211,7 @@ jobs:
   lint:
     <<: *defaults
     steps:
-      - checkout
+      - prepare
       - attach_workspace:
           at: ~/broker
       - run:
@@ -259,14 +220,14 @@ jobs:
   lint-json-samples:
     <<: *defaults
     steps:
-      - checkout
+      - prepare
       - run:
           name: Lint JSON templates
           command: ./lintVerifier.sh
   test:
     <<: *defaults
     steps:
-      - checkout
+      - prepare
       - attach_workspace:
           at: ~/broker
       - run:
@@ -292,7 +253,7 @@ jobs:
         type: string
         default: "broker"
     steps:
-      - checkout
+      - prepare
       - setup_remote_docker:
           docker_layer_caching: true
       - get-tagged-broker-version
@@ -317,7 +278,7 @@ jobs:
         type: string
         default: "broker"
     steps:
-      - checkout
+      - prepare
       - setup_remote_docker:
           docker_layer_caching: false
       - get-tagged-broker-version
@@ -338,7 +299,7 @@ jobs:
         type: string
         default: "high"
     steps:
-      - checkout
+      - prepare
       - setup_remote_docker:
           docker_layer_caching: false
       - load-docker-image:
@@ -361,7 +322,7 @@ jobs:
         type: string
         default: "broker"
     steps:
-      - checkout
+      - prepare
       - setup_remote_docker:
           docker_layer_caching: true
       - dockerhub-login
@@ -395,7 +356,7 @@ jobs:
         type: string
         default: "high"
     steps:
-      - checkout
+      - prepare
       - setup_remote_docker:
           docker_layer_caching: false
       - dockerhub-login
@@ -422,7 +383,7 @@ jobs:
   release:
     <<: *defaults
     steps:
-      - checkout
+      - prepare
       - attach_workspace:
           at: ~/broker
       - run:
@@ -495,6 +456,9 @@ workflows:
             - Build base image (RHEL)
           project: snyk/broker-rhel-ubi
           project_name: broker-rhel-ubi
+          post-steps:
+            - notify-slack-on-failure:
+                channel: broker-alerts-vulns
 
       - release:
           name: Release to GitHub and NPM

--- a/.circleci/templates/slack_fail_message.json
+++ b/.circleci/templates/slack_fail_message.json
@@ -1,0 +1,50 @@
+{
+  "blocks": [
+    {
+      "type": "header",
+      "text": {
+        "type": "plain_text",
+        "text": "Scans pipeline failed :circleci-fail:",
+        "emoji": true
+      }
+    },
+    {
+      "type": "divider"
+    },
+    {
+      "type": "section",
+      "fields": [
+        {
+          "type": "mrkdwn",
+          "text": "*Project*: ${CIRCLE_PROJECT_REPONAME}"
+        },
+        {
+          "type": "mrkdwn",
+          "text": "*Job*: ${CIRCLE_JOB}"
+        },
+        {
+          "type": "mrkdwn",
+          "text": "*Branch*: ${CIRCLE_BRANCH}"
+        },
+        {
+          "type": "mrkdwn",
+          "text": "*Author*: ${CIRCLE_USERNAME}"
+        }
+      ]
+    },
+    {
+      "type": "actions",
+      "elements": [
+        {
+          "type": "button",
+          "text": {
+            "type": "plain_text",
+            "emoji": true,
+            "text": "View Job"
+          },
+          "url": "${CIRCLE_BUILD_URL}"
+        }
+      ]
+    }
+  ]
+}

--- a/.snyk
+++ b/.snyk
@@ -22,4 +22,9 @@ ignore:
         reason: No upstream fix available
         expires: 2024-12-11T13:11:49.669Z
         created: 2024-11-11T13:11:49.674Z
+  SNYK-RHEL8-PAM-8350338:
+    - '*':
+        reason: No fix from RHEL available
+        expires: 2024-12-12T12:19:17.636Z
+        created: 2024-11-12T12:19:17.640Z
 patch: {}


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR adds "Scan base images" job for Ubuntu and RHEL images during CICD CircleCI workflow. This will allow to catch vulnerability issues before releasing to NPM.

Additionally
- CircleCI failed message template is moved under `.circleci/template/slack_fail_message.json` for better readability in config.yml
- Skip monitoring of broker project during Snyk scans in CICD workflow (otherwise we update project snapshot by each PR)
- ignore pam vulnerability in RHEL UBI image temporary (this unblocks releasing of UBI images)


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
