### PR TITLE
chore: increase max listeners default

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -26,6 +26,8 @@ process.on('unhandledRejection', (reason: any) => {
 });
 
 export const app = async ({ port = 7341, client = false, config }) => {
+  const events = require('events');
+  events.EventEmitter.defaultMaxListeners = 30;
   try {
     // note: the config is loaded in the main function to allow us to mock in tests
     if (process.env.JEST_WORKER_ID) {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Increases the default number to hide memory leak warning.

#### Any background context you want to provide?
The different activities carried out by the broker require at time a larger than default amount of event listeners. While there is no memory leak, the warning shows up as the default number, set to 10, is too low. Bumping this up to limit log noise. The default number being still low (30 is not 100s or 1000s), this protection remains useful nonetheless.
