### PR TITLE
feat: upgrade nlatest base image to ubuntu:24.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1024,8 +1024,9 @@ workflows:
             - team-broker-snyk
           requires:
             - Scan repository for secrets
+          additional_arguments: "--build-arg BASE_IMAGE=ubuntu:24.04"
           dockerfile: dockerfiles/base/Dockerfile
-          nodejs_cycle: "21"
+          nodejs_cycle: "23"
           project_name: broker-nlatest
           post-steps:
             - notify-slack-on-failure

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1024,7 +1024,7 @@ workflows:
             - team-broker-snyk
           requires:
             - Scan repository for secrets
-          additional_arguments: "--build-arg BASE_IMAGE=ubuntu:24.04"
+          additional_arguments: "--build-arg BASE_IMAGE=ubuntu:24.04 --build-arg USER_UID=2000"
           dockerfile: dockerfiles/base/Dockerfile
           nodejs_cycle: "23"
           project_name: broker-nlatest

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -8,11 +8,13 @@ ARG NODE_VERSION
 ENV DEBIAN_FRONTEND=noninteractive
 ENV NODE_VERSION=${NODE_VERSION}
 ENV PATH=$PATH:/home/node/.npm-global/bin
+ARG USER_UID=1000
+ARG USER_GID=${USER_UID}
 
 RUN <<EOF
     set -ex
-    groupadd --gid 1000 node
-    useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+    groupadd --gid ${USER_GID} node
+    useradd --uid ${USER_UID} --gid node --shell /bin/bash --create-home node
     apt update
     apt upgrade --assume-yes
     # install packages needed for node installation

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=ubuntu:20.04
 ARG NODE_VERSION=20.11.0
 
 
-FROM ${BASE_IMAGE} as node-base
+FROM ${BASE_IMAGE} AS node-base
 
 ARG NODE_VERSION
 ENV DEBIAN_FRONTEND=noninteractive
@@ -76,7 +76,7 @@ EOF
 
 
 
-FROM node-base as broker-builder
+FROM node-base AS broker-builder
 
 ARG NODE_VERSION
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR upgrades base image to `ubuntu:24.04` for nlatest versions, so we can test it before upgrade for stable versions.

Additionally Node.js version for nlatest is bumped to 23.

Please note, that from `ubuntu:24.04` a ubuntu user with uid 1000 is already included in the image (https://bugs.launchpad.net/cloud-images/+bug/2005129). That's why we pass user uid and gid via build arguments and default value 1000 (as it was in ubuntu:20.04). 

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
