### PR TITLE
fix: handle non ascii chars in headers [HYB-778]

### DIFF
--- a/test/fixtures/client/filters.json
+++ b/test/fixtures/client/filters.json
@@ -63,6 +63,12 @@
     },
 
     {
+      "path": "/echo-with-unicode",
+      "method": "POST",
+      "origin": "http://localhost:9000"
+    },
+
+    {
       "path": "/echo-body/filtered",
       "method": "POST",
       "origin": "http://localhost:9000",

--- a/test/functional/server-client.test.ts
+++ b/test/functional/server-client.test.ts
@@ -164,6 +164,22 @@ describe('proxy requests originating from behind the broker server', () => {
     expect(Buffer.from(response.data)).toEqual(body);
     expect(response.headers['x-broker-ws-response']).not.toBeNull();
   });
+
+  it('successfully broker POST with unicode body and header values', async () => {
+    const response = await axiosClient.post(
+      `http://localhost:${bs.port}/broker/${brokerToken}/echo-with-unicode`,
+      { some: { example: 'json' } },
+    );
+    expect(decodeURIComponent(response.headers.test)).toEqual(
+      'Special-Char-碰撞.proj',
+    );
+    expect(response.status).toEqual(200);
+    expect(response.data).toStrictEqual({
+      some: { example: 'json' },
+      test: 'Special-Char-碰撞.proj',
+    });
+  });
+
   it('successfully broker GET', async () => {
     const response = await axiosClient.get(
       `http://localhost:${bs.port}/broker/${brokerToken}/echo-param/xyz`,

--- a/test/setup/test-web-server.ts
+++ b/test/setup/test-web-server.ts
@@ -240,6 +240,21 @@ const applyEchoRoutes = (app: Express) => {
     },
   );
 
+  echoRouter.post(
+    '/echo-with-unicode/:param?',
+    (req: express.Request, resp: express.Response) => {
+      const unicodeValue = 'Special-Char-碰撞.proj';
+      const body = JSON.parse(req.body);
+      body.test = unicodeValue;
+      const contentType = req.get('Content-Type');
+      if (contentType) {
+        resp.type(contentType);
+      }
+      resp.setHeader('test', encodeURIComponent(unicodeValue));
+      resp.send(JSON.stringify(body));
+    },
+  );
+
   // mimics functionality of https://httpbin.org/headers
   echoRouter.get(
     '/echo-headers/httpbin',


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Handles non ascii characters in headers gracefully by calculating the length appropriately instead of relying on .length.