### PR TITLE
fix: add missing node.js release gpg key

### DIFF
--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -48,6 +48,7 @@ RUN <<EOF
       C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
       108F52B48DB57BB0CC439B2997B01419BD92F80A \
       A363A499291CBBC940DD62E41F10027AF002F8B0 \
+      C0D6248439F1D5604AAFFB4021D900FFDB233756 \
     ; do \
       gpg --batch --keyserver hkp://keys.openpgp.org --recv-keys "$key" || \
       gpg --batch --keyserver hkp://pgp.mit.edu --recv-keys "$key" || \


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR adds a new Node.js release GPG key, so builds for Node.js 23 (nlatest) works as expected.

