### PR TITLE
fix: allow with_shared query param for listing groups in a project in apprisk/gitlab

### DIFF
--- a/defaultFilters/apprisk/gitlab.json
+++ b/defaultFilters/apprisk/gitlab.json
@@ -15,7 +15,13 @@
     "//": "list of groups in a project",
     "method": "GET",
     "path": "/api/v4/projects/:project/groups",
-    "origin": "https://${GITLAB}"
+    "origin": "https://${GITLAB}",
+    "valid": [
+      {
+        "queryParam": "with_shared",
+        "values": ["true", "false"]
+      }
+    ]
   },
   {
     "//": "list of members in a project",

--- a/test/unit/__snapshots__/runtime-rules-hotloading.test.ts.snap
+++ b/test/unit/__snapshots__/runtime-rules-hotloading.test.ts.snap
@@ -16342,6 +16342,15 @@ Object {
       "method": "GET",
       "origin": "https://\${GITLAB}",
       "path": "/api/v4/projects/:project/groups",
+      "valid": Array [
+        Object {
+          "queryParam": "with_shared",
+          "values": Array [
+            "true",
+            "false",
+          ],
+        },
+      ],
     },
     Object {
       "//": "list of members in a project",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
- on the default apprisk/gitlab adds with_shared query param with possible values as true or false
-  apprisk makes requests to "/api/v4/projects/:projectId/groups?with_shared=true" to gather groups
- we received in one instance a blocked error message with "[Websocket Flow][Blocked Request] Does not match any accept rule"

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?
https://snyk.slack.com/archives/C05KD7HA1K3/p1736411022022439?thread_ts=1733864353.415129&cid=C05KD7HA1K3

#### Screenshots


#### Additional questions
- is queryParam required for all endpoints to be set ?