### PR TITLE
feat: add local override for separate bitbucket-server git endpt

### DIFF
--- a/client-templates/bitbucket-server/.env.sample
+++ b/client-templates/bitbucket-server/.env.sample
@@ -18,6 +18,9 @@ BITBUCKET=bitbucket.yourdomain.com
 # changed to "bitbucket.yourdomain.com/rest/api/1.0"
 BITBUCKET_API=$BITBUCKET/rest/api/1.0
 
+# GIT Endpoint to override if necessary
+BITBUCKET_GIT=$BITBUCKET
+
 # the url of your broker client (including scheme and port)
 # BROKER_CLIENT_URL=
 

--- a/config.default.json
+++ b/config.default.json
@@ -154,6 +154,7 @@
         }
       ],
       "default": {
+        "BITBUCKET_GIT": "$BITBUCKET",
         "BITBUCKET_API": "$BITBUCKET/rest/api/1.0",
         "BROKER_CLIENT_VALIDATION_URL": "https://$BITBUCKET/rest/api/1.0/projects",
         "BROKER_CLIENT_VALIDATION_BASIC_AUTH": "$BITBUCKET_USERNAME:$BITBUCKET_PASSWORD",

--- a/lib/common/filter/filter-rules-loading.ts
+++ b/lib/common/filter/filter-rules-loading.ts
@@ -219,6 +219,8 @@ function injectRulesAtRuntime(
           templateGETForSnippets.path =
             '/projects/:project/repos/:repo/browse*/:file';
           templatePOST.path = '*/git-upload-pack';
+          templateGET.origin = 'https://${BITBUCKET_GIT}';
+          templatePOST.origin = 'https://${BITBUCKET_GIT}';
           break;
         default:
           logger.error(

--- a/test/unit/__snapshots__/runtime-rules-hotloading.test.ts.snap
+++ b/test/unit/__snapshots__/runtime-rules-hotloading.test.ts.snap
@@ -25948,7 +25948,7 @@ Object {
         "username": "\${BITBUCKET_USERNAME}",
       },
       "method": "GET",
-      "origin": "https://\${BITBUCKET}",
+      "origin": "https://\${BITBUCKET_GIT}",
       "path": "*/info/refs*",
     },
     Object {
@@ -25959,7 +25959,7 @@ Object {
         "username": "\${BITBUCKET_USERNAME}",
       },
       "method": "POST",
-      "origin": "https://\${BITBUCKET}",
+      "origin": "https://\${BITBUCKET_GIT}",
       "path": "*/git-upload-pack",
     },
     Object {
@@ -27080,7 +27080,7 @@ Object {
         "token": "\${BITBUCKET_PAT}",
       },
       "method": "GET",
-      "origin": "https://\${BITBUCKET}",
+      "origin": "https://\${BITBUCKET_GIT}",
       "path": "*/info/refs*",
     },
     Object {
@@ -27090,7 +27090,7 @@ Object {
         "token": "\${BITBUCKET_PAT}",
       },
       "method": "POST",
-      "origin": "https://\${BITBUCKET}",
+      "origin": "https://\${BITBUCKET_GIT}",
       "path": "*/git-upload-pack",
     },
     Object {
@@ -34019,7 +34019,7 @@ Object {
         "username": "\${BITBUCKET_USERNAME}",
       },
       "method": "GET",
-      "origin": "https://\${BITBUCKET}",
+      "origin": "https://\${BITBUCKET_GIT}",
       "path": "*/info/refs*",
     },
     Object {
@@ -34030,7 +34030,7 @@ Object {
         "username": "\${BITBUCKET_USERNAME}",
       },
       "method": "POST",
-      "origin": "https://\${BITBUCKET}",
+      "origin": "https://\${BITBUCKET_GIT}",
       "path": "*/git-upload-pack",
     },
     Object {
@@ -35171,7 +35171,7 @@ Object {
         "token": "\${BITBUCKET_PAT}",
       },
       "method": "GET",
-      "origin": "https://\${BITBUCKET}",
+      "origin": "https://\${BITBUCKET_GIT}",
       "path": "*/info/refs*",
     },
     Object {
@@ -35181,7 +35181,7 @@ Object {
         "token": "\${BITBUCKET_PAT}",
       },
       "method": "POST",
-      "origin": "https://\${BITBUCKET}",
+      "origin": "https://\${BITBUCKET_GIT}",
       "path": "*/git-upload-pack",
     },
     Object {
@@ -42120,7 +42120,7 @@ Object {
         "username": "\${BITBUCKET_USERNAME}",
       },
       "method": "GET",
-      "origin": "https://\${BITBUCKET}",
+      "origin": "https://\${BITBUCKET_GIT}",
       "path": "*/info/refs*",
     },
     Object {
@@ -42131,7 +42131,7 @@ Object {
         "username": "\${BITBUCKET_USERNAME}",
       },
       "method": "POST",
-      "origin": "https://\${BITBUCKET}",
+      "origin": "https://\${BITBUCKET_GIT}",
       "path": "*/git-upload-pack",
     },
     Object {
@@ -43252,7 +43252,7 @@ Object {
         "token": "\${BITBUCKET_PAT}",
       },
       "method": "GET",
-      "origin": "https://\${BITBUCKET}",
+      "origin": "https://\${BITBUCKET_GIT}",
       "path": "*/info/refs*",
     },
     Object {
@@ -43262,7 +43262,7 @@ Object {
         "token": "\${BITBUCKET_PAT}",
       },
       "method": "POST",
-      "origin": "https://\${BITBUCKET}",
+      "origin": "https://\${BITBUCKET_GIT}",
       "path": "*/git-upload-pack",
     },
     Object {


### PR DESCRIPTION
- [ ] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adds a local override to be able to use a separate git endpoint for custom bitbucket configurations that require it.