### PR TITLE
fix: add injected rules to rule downloading logic [HYB-772]

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -528,6 +528,19 @@
     "digitalocean-cr":"defaultFilters/container-registry-agent.json",
     "gitlab-cr":"defaultFilters/container-registry-agent.json",
     "google-artifact-cr":"defaultFilters/container-registry-agent.json",
-    "workload":"defaultFilters/workload.json"
+    "workload":"defaultFilters/workload.json",
+    "apprisk-azure-repos":"defaultFilters/apprisk/azure-repos.json",
+    "apprisk-bitbucket-server-bearer-auth":"defaultFilters/apprisk/bitbucket-server-bearer-auth.json",
+    "apprisk-bitbucket-server":"defaultFilters/apprisk/bitbucket-server.json",
+    "apprisk-github-enterprise":"defaultFilters/apprisk/github-enterprise.json",
+    "apprisk-github":"defaultFilters/apprisk/github.json",
+    "apprisk-gitlab":"defaultFilters/apprisk/gitlab.json",
+    "custom-pr-templates-azure-repos":"defaultFilters/customPrTemplates/azure-repos.json",
+    "custom-pr-templates-bitbucket-server-bearer-auth":"defaultFilters/customPrTemplates/bitbucket-server-bearer-auth.json",
+    "custom-pr-templates-bitbucket-server":"defaultFilters/customPrTemplates/bitbucket-server.json",
+    "custom-pr-templates-github-enterprise":"defaultFilters/customPrTemplates/github-enterprise.json",
+    "custom-pr-templates-github":"defaultFilters/customPrTemplates/github.json",
+    "custom-pr-templates-gitlab":"defaultFilters/customPrTemplates/gitlab.json"
+
   }
 }

--- a/lib/common/filter/utils.ts
+++ b/lib/common/filter/utils.ts
@@ -4,6 +4,7 @@ import { makeSingleRawRequestToDownstream } from '../../hybrid-sdk/http/request'
 import { PostFilterPreparedRequest } from '../relay/prepareRequest';
 import version from '../utils/version';
 import { findProjectRoot } from '../config/config';
+import { log as logger } from '../../logs/logger';
 
 export const validateHeaders = (headerFilters, requestHeaders = []) => {
   for (const filter of headerFilters) {
@@ -30,7 +31,7 @@ export const isValidURI = (uri: string) => {
   }
 };
 
-/* Retrieve filters from list of uris 
+/* Retrieve filters from list of uris
    Can be uri or local path          */
 export const retrieveFilters = async (locations: Map<string, string>) => {
   const retrievedFiltersMap = new Map<string, any>();
@@ -45,6 +46,7 @@ export const retrieveFilters = async (locations: Map<string, string>) => {
         headers: { 'user-agent': `Snyk Broker Client ${version}` },
         method: 'GET',
       };
+      logger.debug({ location }, `Downloading ${key} filter`);
       const filter = await makeSingleRawRequestToDownstream(req);
       if (filter.statusCode && filter.statusCode > 299) {
         throw new Error(

--- a/lib/server/index.ts
+++ b/lib/server/index.ts
@@ -20,7 +20,7 @@ export const main = async (serverOpts: ServerOpts) => {
   const filters = await filterRulesLoader(serverOpts.config);
   if (!filters) {
     const error = new ReferenceError(
-      `No Filters found. A Broker requires filters to run. Shutting down.`,
+      `Server mode - No Filters found. A Broker requires filters to run. Review config.default.json or ACCEPT env var. Shutting down.`,
     );
     error['code'] = 'MISSING_FILTERS';
     logger.error({ error }, error.message);


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Includes runtime injected rulesets (apprisk, custom PRs) to the remote ruleset downloading logic.

#### Any background context you want to provide?
The rules still get pulled from the local filesystem currently, but adding the extra rulesets in the downloading logic.