### PR TITLE
fix: add url pattern to the apprisk gitlab whitelist

### DIFF
--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -49,7 +49,6 @@
       "path": "/api/v4/projects/:project/repository/tree",
       "origin": "https://${GITLAB}"
     },
-
     {
       "//": "used to determine the full dependency tree",
       "method": "GET",

--- a/defaultFilters/apprisk/gitlab.json
+++ b/defaultFilters/apprisk/gitlab.json
@@ -24,6 +24,12 @@
     "origin": "https://${GITLAB}"
   },
   {
+    "//": "list of users in a project",
+    "method": "GET",
+    "path": "/api/v4/projects/:project/users",
+    "origin": "https://${GITLAB}"
+  },
+  {
     "//": "used to retrieve organization context from catalog-info.yaml",
     "method": "GET",
     "path": "/api/v4/projects/:project/repository/files/catalog-info.yaml/raw",


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR is to solve errors that gitlab clients are getting.  Example of these clients are [here](https://snyksec.atlassian.net/browse/IA-872). The issue is related to the fact that a step in sanity checks in apprisk are failing with the following error:

`{
  "message": "blocked",
  "reason": "[Websocket Flow][Blocked Request] Does not match any accept rule",
  "url": "/api/v4/projects/20263346/users"
}`
