### PR TITLE
chore: add broker-server-url preflight check

### DIFF
--- a/lib/client/checks/config/brokerClientUrlCheck.ts
+++ b/lib/client/checks/config/brokerClientUrlCheck.ts
@@ -1,7 +1,10 @@
 import { log as logger } from '../../../logs/logger';
 import type { CheckOptions, CheckResult } from '../types';
 import type { Config } from '../../types/config';
-import { urlContainsProtocol } from '../../../common/utils/urlValidator';
+import {
+  urlContainsProtocol,
+  isHttpUrl,
+} from '../../../common/utils/urlValidator';
 import {
   HttpResponse,
   makeSingleRawRequestToDownstream,
@@ -57,22 +60,6 @@ export async function validateBrokerClientUrl(
     const errorMessage = `Error executing check with checkId ${checkOptions.id}`;
     logger.debug({ error }, errorMessage);
     throw new Error(errorMessage);
-  }
-}
-
-function isHttpUrl(brokerClientUrl: string): boolean {
-  logger.trace(
-    { url: brokerClientUrl },
-    'checking if URL is correctly configured',
-  );
-  try {
-    return (
-      urlContainsProtocol(brokerClientUrl, 'http:') ||
-      urlContainsProtocol(brokerClientUrl, 'https:')
-    );
-  } catch (error) {
-    logger.error({ error }, 'Error checking URL HTTP protocol');
-    return false;
   }
 }
 

--- a/lib/client/checks/config/brokerServerUrlCheck.ts
+++ b/lib/client/checks/config/brokerServerUrlCheck.ts
@@ -1,0 +1,32 @@
+import { log as logger } from '../../../logs/logger';
+import type { CheckOptions, CheckResult } from '../types';
+import type { Config } from '../../types/config';
+import { isHttpUrl } from '../../../common/utils/urlValidator';
+
+export async function validateBrokerServerUrl(
+  checkOptions: CheckOptions,
+  config: Config,
+): Promise<CheckResult> {
+  logger.debug({ checkId: checkOptions.id }, 'executing config check');
+  const brokerServerUrl = config.BROKER_SERVER_URL;
+  try {
+    if (brokerServerUrl && !isHttpUrl(brokerServerUrl)) {
+      return {
+        id: checkOptions.id,
+        name: checkOptions.name,
+        status: 'error',
+        output: `Broker Server URL must use the HTTP or HTTPS protocols. Configured URL: ${brokerServerUrl}`,
+      } satisfies CheckResult;
+    }
+    return {
+      id: checkOptions.id,
+      name: checkOptions.name,
+      status: 'passing',
+      output: 'config check: ok',
+    } satisfies CheckResult;
+  } catch (error) {
+    const errorMessage = `Error executing check with checkId ${checkOptions.id}`;
+    logger.debug({ error }, errorMessage);
+    throw new Error(errorMessage);
+  }
+}

--- a/lib/common/utils/urlValidator.ts
+++ b/lib/common/utils/urlValidator.ts
@@ -14,3 +14,19 @@ export function urlContainsProtocol(url: string, protocol: string): boolean {
     return false;
   }
 }
+
+export function isHttpUrl(brokerClientUrl: string): boolean {
+  logger.trace(
+    { url: brokerClientUrl },
+    'checking if URL is correctly configured',
+  );
+  try {
+    return (
+      urlContainsProtocol(brokerClientUrl, 'http:') ||
+      urlContainsProtocol(brokerClientUrl, 'https:')
+    );
+  } catch (error) {
+    logger.error({ error }, 'Error checking URL HTTP protocol');
+    return false;
+  }
+}

--- a/test/unit/client/checks/config/brokerServerUrlCheck.test.ts
+++ b/test/unit/client/checks/config/brokerServerUrlCheck.test.ts
@@ -1,0 +1,53 @@
+import { aConfig } from '../../../../helpers/test-factories';
+import { validateBrokerServerUrl } from '../../../../../lib/client/checks/config/brokerServerUrlCheck';
+
+describe('client/checks/config', () => {
+  describe('validateBrokerClientUrl()', () => {
+    it('should return error check result if protocol is missing', async () => {
+      const id = `check_${Date.now()}`;
+      const config = aConfig({
+        BROKER_SERVER_URL: 'broker.snyk.io',
+      });
+
+      const checkResult = await validateBrokerServerUrl(
+        { id: id, name: id },
+        config,
+      );
+
+      expect(checkResult.status).toEqual('error');
+      expect(checkResult.output).toContain('Configured URL: broker.snyk.io');
+    });
+
+    it('should return error check result for non http(s) protocol', async () => {
+      const id = `check_${Date.now()}`;
+      const config = aConfig({
+        BROKER_SERVER_URL: 'ftp://broker.snyk.io',
+      });
+
+      const checkResult = await validateBrokerServerUrl(
+        { id: id, name: id },
+        config,
+      );
+
+      expect(checkResult.status).toEqual('error');
+      expect(checkResult.output).toContain(
+        'Configured URL: ftp://broker.snyk.io',
+      );
+    });
+
+    it('should return passing check result for http protocol', async () => {
+      const id = `check_${Date.now()}`;
+      const config = aConfig({
+        BROKER_SERVER_URL: 'http://broker.snyk.io:8000',
+      });
+
+      const checkResult = await validateBrokerServerUrl(
+        { id: id, name: id },
+        config,
+      );
+
+      expect(checkResult.status).toEqual('passing');
+      expect(checkResult.output).toContain('config check: ok');
+    });
+  });
+});


### PR DESCRIPTION
### What

- Adds a preflight check for BROKER_SERVER_URL

### Why

- Ensure the URL contains a schema (`http[s]://`)
