### PR TITLE
feat: add gitlab and bitbucket server update hook rules

### DIFF
--- a/client-templates/bitbucket-server-bearer-auth/accept.json.sample
+++ b/client-templates/bitbucket-server-bearer-auth/accept.json.sample
@@ -808,6 +808,26 @@
       }
     },
     {
+      "//": "allow webhooks to be fetched",
+      "method": "GET",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/webhooks/:webhookId",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
+    },
+    {
+      "//": "allow webhooks to be updated",
+      "method": "PUT",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/webhooks/:webhookId",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
+    },
+    {
       "//": "used to create commit status messages",
       "method": "POST",
       "path": "/rest/build-status/1.0/commits/:sha",

--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -888,6 +888,28 @@
       }
     },
     {
+      "//": "allow webhooks to be fetched",
+      "method": "GET",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/webhooks/:webhookId",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
+      "//": "allow webhooks to be updated",
+      "method": "PUT",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/webhooks/:webhookId",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
+    },
+    {
       "//": "used to create commit status messages",
       "method": "POST",
       "path": "/rest/build-status/1.0/commits/:sha",

--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -1499,6 +1499,18 @@
       "origin": "https://${GITLAB}"
     },
     {
+      "//": "allow webhooks to be updated",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/hooks/:id",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "allow webhooks to be fetched, used to facilitate patch upgrades",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/hooks/:id",
+      "origin": "https://${GITLAB}"
+    },
+    {
       "//": "used to create commit status messages",
       "method": "POST",
       "path": "/api/v4/projects/:project/statuses/:sha",

--- a/defaultFilters/bitbucket-server-bearer-auth.json
+++ b/defaultFilters/bitbucket-server-bearer-auth.json
@@ -808,6 +808,26 @@
       }
     },
     {
+      "//": "allow webhooks to be fetched",
+      "method": "GET",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/webhooks/:webhookId",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}" 
+      }
+    },
+    {
+      "//": "allow webhooks to be updated",
+      "method": "PUT",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/webhooks/:webhookId",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
+    },
+    {
       "//": "used to create commit status messages",
       "method": "POST",
       "path": "/rest/build-status/1.0/commits/:sha",

--- a/defaultFilters/bitbucket-server.json
+++ b/defaultFilters/bitbucket-server.json
@@ -888,6 +888,28 @@
         }
       },
       {
+        "//": "allow webhooks to be fetched",
+        "method": "GET",
+        "path": "/rest/api/1.0/projects/:project/repos/:repo/webhooks/:webhookId",
+        "origin": "https://${BITBUCKET}",
+        "auth": {
+          "scheme": "basic",
+          "username": "${BITBUCKET_USERNAME}",
+          "password": "${BITBUCKET_PASSWORD}"
+        }
+      },
+      {
+        "//": "allow webhooks to be updated",
+        "method": "PUT",
+        "path": "/rest/api/1.0/projects/:project/repos/:repo/webhooks/:webhookId",
+        "origin": "https://${BITBUCKET}",
+        "auth": {
+          "scheme": "basic",
+          "username": "${BITBUCKET_USERNAME}",
+          "password": "${BITBUCKET_PASSWORD}"
+        }
+      },
+      {
         "//": "used to create commit status messages",
         "method": "POST",
         "path": "/rest/build-status/1.0/commits/:sha",

--- a/defaultFilters/gitlab.json
+++ b/defaultFilters/gitlab.json
@@ -1499,6 +1499,18 @@
         "origin": "https://${GITLAB}"
       },
       {
+        "//": "allow webhooks to be updated",
+        "method": "PUT",
+        "path": "/api/v4/projects/:project/hooks/:id",
+        "origin": "https://${GITLAB}"
+      },
+      {
+        "//": "allow webhooks to be fetched, used to facilitate patch upgrades",
+        "method": "GET",
+        "path": "/api/v4/projects/:project/hooks/:id",
+        "origin": "https://${GITLAB}"
+      },
+      {
         "//": "used to create commit status messages",
         "method": "POST",
         "path": "/api/v4/projects/:project/statuses/:sha",

--- a/test/unit/filters.test.ts
+++ b/test/unit/filters.test.ts
@@ -297,6 +297,33 @@ describe('filters', () => {
         const filterResponseUrl = filterResponse ? filterResponse.url : '';
         expect(filterResponseUrl).toMatch(url);
       });
+
+      it('should allow fetching webook info', () => {
+        const url =
+          '/rest/api/1.0/projects/:project/repos/:repo/webhooks/:webhookId';
+
+        const filterResponse = filter({
+          url,
+          method: 'GET',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseUrl = filterResponse ? filterResponse.url : '';
+        expect(filterResponseUrl).toMatch(url);
+      });
+
+      it('should allow updating webhook config', () => {
+        const url =
+          '/rest/api/1.0/projects/:project/repos/:repo/webhooks/:webhookId';
+
+        const filterResponse = filter({
+          url,
+          method: 'PUT',
+        });
+
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseUrl = filterResponse ? filterResponse.url : '';
+        expect(filterResponseUrl).toMatch(url);
+      });
     });
 
     describe('for azure repos', () => {
@@ -394,6 +421,30 @@ describe('filters', () => {
         const filterResponse = filter({
           url,
           method: 'GET',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseUrl = filterResponse ? filterResponse.url : '';
+        expect(filterResponseUrl).toMatch(url);
+      });
+
+      it('should allow fetching webhook info', () => {
+        const url = '/api/v4/projects/test-project/hooks/1';
+
+        const filterResponse = filter({
+          url,
+          method: 'GET',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseUrl = filterResponse ? filterResponse.url : '';
+        expect(filterResponseUrl).toMatch(url);
+      });
+
+      it('should allow updating webhook info', () => {
+        const url = '/api/v4/projects/test-project/hooks/1';
+
+        const filterResponse = filter({
+          url,
+          method: 'PUT',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseUrl = filterResponse ? filterResponse.url : '';


### PR DESCRIPTION
#### What does this PR do?

Adds rules for Gitlab and Bitbucket Server to facilitate updating webhooks.

#### Any background context you want to provide?

https://github.com/snyk/bitbucket-server-agent/pull/686
https://github.com/snyk/gitlab-agent/pull/764
