### PR TITLE
fix: add missing bitbucket server git env var for bearer auth connections

### DIFF
--- a/client-templates/bitbucket-server-bearer-auth/.env.sample
+++ b/client-templates/bitbucket-server-bearer-auth/.env.sample
@@ -15,6 +15,9 @@ BITBUCKET=bitbucket.yourdomain.com
 # changed to "bitbucket.yourdomain.com/rest/api/1.0"
 BITBUCKET_API=$BITBUCKET/rest/api/1.0
 
+# GIT Endpoint to override if necessary
+BITBUCKET_GIT=$BITBUCKET
+
 # the url of your broker client (including scheme and port)
 # BROKER_CLIENT_URL=
 

--- a/config.default.json
+++ b/config.default.json
@@ -187,6 +187,7 @@
         }
       ],
       "default": {
+        "BITBUCKET_GIT": "$BITBUCKET",
         "BITBUCKET_API": "$BITBUCKET/rest/api/1.0",
         "BROKER_CLIENT_VALIDATION_URL": "https://$BITBUCKET/rest/api/1.0/projects",
         "BROKER_CLIENT_VALIDATION_AUTHORIZATION_HEADER": "Bearer $BITBUCKET_PAT",


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adds BITBUCKET_GIT, recently added as a way to possibly override the git endpoint if a custom one is used. This addition made it into the filters but we missed adding the default value in the bearer auth .env file.

