### PR TITLE
fix: add github and azure-repos filter rules for webhook event upgrades

### DIFF
--- a/client-templates/azure-repos/accept.json.sample
+++ b/client-templates/azure-repos/accept.json.sample
@@ -414,6 +414,16 @@
         "scheme": "basic",
         "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
       }
+    },
+    {
+      "//": "get webhook",
+      "method": "GET",
+      "path": "/_apis/hooks/subscriptions/:subscriptionId",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
     }
   ]
 }

--- a/client-templates/github-com/accept.json.sample
+++ b/client-templates/github-com/accept.json.sample
@@ -2142,6 +2142,12 @@
       "method": "PATCH",
       "path": "/repos/:name/:repo/hooks/:id/config",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "allow webhooks to be updated, to allow for event upgrades",
+      "method": "PATCH",
+      "path": "/repos/:name/:repo/hooks/:id",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     }
   ]
 }

--- a/client-templates/github-enterprise/accept.json.sample
+++ b/client-templates/github-enterprise/accept.json.sample
@@ -1422,6 +1422,12 @@
       "method": "PATCH",
       "path": "/repos/:name/:repo/hooks/:id/config",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "allow webhooks to be updated, to allow for event upgrades",
+      "method": "PATCH",
+      "path": "/repos/:name/:repo/hooks/:id",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     }
   ]
 }

--- a/client-templates/github-server-app/accept.json.sample
+++ b/client-templates/github-server-app/accept.json.sample
@@ -1422,6 +1422,12 @@
       "method": "PATCH",
       "path": "/repos/:name/:repo/hooks/:id/config",
       "origin": "https://${GITHUB_API}"
+    },
+    {
+      "//": "allow webhooks to be updated, to allow for event upgrades",
+      "method": "PATCH",
+      "path": "/repos/:name/:repo/hooks/:id",
+      "origin": "https://${GITHUB_API}"
     }
   ]
 }

--- a/defaultFilters/azure-repos.json
+++ b/defaultFilters/azure-repos.json
@@ -422,6 +422,16 @@
           "scheme": "basic",
           "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
         }
+      },
+      {
+        "//": "get webhook",
+        "method": "GET",
+        "path": "/_apis/hooks/subscriptions/:subscriptionId",
+        "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+        "auth": {
+          "scheme": "basic",
+          "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+        }
       }
     ]
   }

--- a/defaultFilters/github-enterprise.json
+++ b/defaultFilters/github-enterprise.json
@@ -1422,6 +1422,12 @@
         "method": "PATCH",
         "path": "/repos/:name/:repo/hooks/:id/config",
         "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+      },
+      {
+        "//": "allow webhooks to be updated, to allow for event upgrades",
+        "method": "PATCH",
+        "path": "/repos/:name/:repo/hooks/:id",
+        "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
       }
     ]
   }

--- a/defaultFilters/github-server-app.json
+++ b/defaultFilters/github-server-app.json
@@ -2033,5 +2033,15 @@
           "token": "${GHA_ACCESS_TOKEN}"
         }
       },
+      {
+        "//": "allow webhooks to be updated, to allow for event upgrades",
+        "method": "PATCH",
+        "path": "/repos/:name/:repo/hooks/:id",
+        "origin": "https://${GITHUB_API}",
+        "auth": {
+          "scheme": "bearer",
+          "token": "${GHA_ACCESS_TOKEN}"
+        }
+      }
     ]
   }

--- a/defaultFilters/github.json
+++ b/defaultFilters/github.json
@@ -2140,6 +2140,12 @@
         "method": "PATCH",
         "path": "/repos/:name/:repo/hooks/:id/config",
         "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+      },
+      {
+        "//": "allow webhooks to be updated, to allow for event upgrades",
+        "method": "PATCH",
+        "path": "/repos/:name/:repo/hooks/:id",
+        "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
       }
     ]
   }

--- a/test/fixtures/accept/github.json
+++ b/test/fixtures/accept/github.json
@@ -50,6 +50,12 @@
       "method": "PATCH",
       "path": "/repos/:name/:repo/hooks/:id/config",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "allow webhooks to be updated, to allow for event upgrades",
+      "method": "PATCH",
+      "path": "/repos/:name/:repo/hooks/:id",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     }
   ]
 }


### PR DESCRIPTION
#### What does this PR do?

Adds filter rules to allow Github and Azure Repos API calls to enable upgrading subscribed webhook events.

#### Any background context you want to provide?

https://github.com/snyk/scm-agents/pull/647
https://github.com/snyk/azure-repos-agent/pull/627

