### PR TITLE
chore: add graceful client shutdown with signaling to server [HYB-866]

### DIFF
--- a/lib/hybrid-sdk/client/connectionsManager/manager.ts
+++ b/lib/hybrid-sdk/client/connectionsManager/manager.ts
@@ -52,6 +52,10 @@ export const manageWebsocketConnections = async (
       );
 
       handleTerminationSignal(cleanUpUniversalFile);
+    } else {
+      handleTerminationSignal(() => {
+        logger.debug({}, 'Received process termination signal.');
+      });
     }
 
     await reloadConfig(clientOpts);

--- a/lib/hybrid-sdk/client/index.ts
+++ b/lib/hybrid-sdk/client/index.ts
@@ -47,6 +47,10 @@ process.on('uncaughtException', (error) => {
     process.exit(1);
   }
 });
+export let websocketConnections: WebSocketConnection[];
+export const getWebsocketConnections = () => {
+  return websocketConnections;
+};
 
 export const main = async (clientOpts: ClientOpts) => {
   try {
@@ -55,6 +59,7 @@ export const main = async (clientOpts: ClientOpts) => {
     clientOpts.config.brokerClientId = uuidv4();
     clientOpts.config.logEnableBody = 'false';
     clientOpts.config.LOG_ENABLE_BODY = 'false';
+    websocketConnections = [];
     logger.info(
       { brokerClientId: clientOpts.config.brokerClientId },
       'Generated broker client id.',
@@ -117,7 +122,6 @@ export const main = async (clientOpts: ClientOpts) => {
       isDisabled: false,
     };
 
-    let websocketConnections: WebSocketConnection[] = [];
     if (clientOpts.config.universalBrokerEnabled) {
       websocketConnections = await manageWebsocketConnections(
         clientOpts,

--- a/lib/hybrid-sdk/common/utils/signals.ts
+++ b/lib/hybrid-sdk/common/utils/signals.ts
@@ -1,19 +1,42 @@
-const timers: NodeJS.Timeout[] = [];
+import { getWebsocketConnections } from '../../client';
+import { log as logger } from '../../../logs/logger';
 
+const timers: NodeJS.Timeout[] = [];
+const GRACE_PERIOD_MS = 12000;
 export const handleTerminationSignal = (callback: () => void) => {
   process.on('SIGINT', () => {
     timers.forEach((timer) => clearInterval(timer));
     callback();
-    process.exit(0);
+    signalTerminationToServer('SIGINT');
+    setTimeout(() => {
+      process.exit(0);
+    }, GRACE_PERIOD_MS);
   });
 
-  process.on('SIGTERM', () => {
+  process.on('SIGTERM', async () => {
     timers.forEach((timer) => clearInterval(timer));
     callback();
-    process.exit(0);
+    signalTerminationToServer('SIGTERM');
+    setTimeout(() => {
+      process.exit(0);
+    }, GRACE_PERIOD_MS);
   });
 };
 
 export const addTimerToTerminalHandlers = (timerId: NodeJS.Timeout) => {
   timers.push(timerId);
+};
+
+const signalTerminationToServer = (signal) => {
+  const [websocket] = getWebsocketConnections();
+  if (websocket) {
+    websocket.send('terminate', {
+      signal,
+    });
+  } else {
+    logger.error(
+      {},
+      'Unable to find websocket to signal termination to server.',
+    );
+  }
 };

--- a/lib/hybrid-sdk/server/socketHandlers/closeHandler.ts
+++ b/lib/hybrid-sdk/server/socketHandlers/closeHandler.ts
@@ -3,6 +3,7 @@ import { log as logger } from '../../../logs/logger';
 import { clientDisconnected } from '../infra/dispatcher';
 import { getSocketConnections } from '../socket';
 import { getDesensitizedToken } from '../utils/token';
+import { rmClientIdFromTerminationMap } from './identifyHandler';
 
 export const handleConnectionCloseOnSocket = (
   closeReason,
@@ -42,6 +43,7 @@ export const handleConnectionCloseOnSocket = (
         'Client disconnected before identifying itself.',
       );
     }
+    rmClientIdFromTerminationMap(token, clientId);
     setImmediate(async () => await clientDisconnected(token, clientId));
   }
 };

--- a/lib/hybrid-sdk/server/socketHandlers/connectionHandler.ts
+++ b/lib/hybrid-sdk/server/socketHandlers/connectionHandler.ts
@@ -3,6 +3,7 @@ import { getDesensitizedToken } from '../utils/token';
 import { handleIdentifyOnSocket } from './identifyHandler';
 import { handleConnectionCloseOnSocket } from './closeHandler';
 import { handleSocketError } from './errorHandler';
+import { handleTerminationSignalOnSocket } from './terminateHandler';
 
 export const handleSocketConnection = (socket) => {
   let clientId = null;
@@ -28,6 +29,14 @@ export const handleSocketConnection = (socket) => {
       handleConnectionCloseOnSocket(e, socket, token, clientId, identified),
     ),
   );
+
+  socket.on('terminate', (data) => {
+    logger.info(
+      { token, clientId, signal: data.signal },
+      'Socket termination signal received',
+    );
+    handleTerminationSignalOnSocket(token, clientId);
+  });
 
   socket.on('error', (error) => handleSocketError(error));
 };

--- a/lib/hybrid-sdk/server/socketHandlers/terminateHandler.ts
+++ b/lib/hybrid-sdk/server/socketHandlers/terminateHandler.ts
@@ -1,0 +1,7 @@
+import { clientDisconnected } from '../infra/dispatcher';
+import { addClientIdToTerminationMap } from './identifyHandler';
+
+export const handleTerminationSignalOnSocket = (token, clientId) => {
+  addClientIdToTerminationMap(token, clientId);
+  setImmediate(async () => await clientDisconnected(token, clientId));
+};

--- a/test/functional/server-client-universal-termination-signal.test.ts
+++ b/test/functional/server-client-universal-termination-signal.test.ts
@@ -1,0 +1,112 @@
+import path from 'path';
+import { axiosClient } from '../setup/axios-client';
+import { BrokerClient, closeBrokerClient } from '../setup/broker-client';
+import {
+  BrokerServer,
+  closeBrokerServer,
+  createBrokerServer,
+  waitForUniversalBrokerClientsConnection,
+} from '../setup/broker-server';
+import { TestWebServer, createTestWebServer } from '../setup/test-web-server';
+import { createUniversalBrokerClient } from '../setup/broker-universal-client';
+
+import * as dispatcher from '../../lib/hybrid-sdk/server/infra/dispatcher';
+import * as identifyHandler from '../../lib/hybrid-sdk/server/socketHandlers/identifyHandler';
+import { delay } from '../helpers/utils';
+
+const fixtures = path.resolve(__dirname, '..', 'fixtures');
+const serverAccept = path.join(fixtures, 'server', 'filters.json');
+const clientAccept = path.join(fixtures, 'client', 'filters.json');
+
+describe('client send termination signal to broker server', () => {
+  let tws: TestWebServer;
+  let bs: BrokerServer;
+  let bc: BrokerClient;
+  const spyClientDisconnected = jest.spyOn(dispatcher, 'clientDisconnected');
+
+  const spyAddClientIdToTerminationMap = jest.spyOn(
+    identifyHandler,
+    'addClientIdToTerminationMap',
+  );
+  const spyProcessExit = jest
+    .spyOn(process, 'exit')
+    // Disabling es-lint, complains of unused "code" otherwise
+    // eslint-disable-next-line
+    .mockImplementation((code?: number) => undefined as never);
+  beforeAll(async () => {
+    const PORT = 9999;
+    tws = await createTestWebServer();
+    process.env.RESPONSE_DATA_HIDDEN_ENABLED = 'true';
+    bs = await createBrokerServer({ filters: serverAccept, port: PORT });
+
+    process.env.SNYK_BROKER_SERVER_UNIVERSAL_CONFIG_ENABLED = 'true';
+    process.env.API_BASE_URL = `http://localhost:${bs.port}`;
+    process.env.UNIVERSAL_BROKER_ENABLED = 'true';
+    process.env.SERVICE_ENV = 'universaltest';
+    process.env.BROKER_TOKEN_1 = 'brokertoken1';
+    process.env.BROKER_TOKEN_2 = 'brokertoken2';
+    process.env.BROKER_TOKEN_3 = 'brokertoken3';
+    process.env.BROKER_TOKEN_4 = 'brokertoken4';
+    process.env.GITHUB_TOKEN = 'ghtoken';
+    process.env.GITLAB_TOKEN = 'gltoken';
+    process.env.AZURE_REPOS_TOKEN = '123';
+    process.env.AZURE_REPOS_HOST = 'hostname';
+    process.env.AZURE_REPOS_ORG = 'org';
+    process.env.JIRA_PAT = 'jirapat';
+    process.env.RAW_AUTH = 'CustomScheme CustomToken';
+    process.env.JIRA_HOSTNAME = 'hostname';
+    process.env.SNYK_BROKER_CLIENT_CONFIGURATION__common__default__BROKER_SERVER_URL = `http://localhost:${bs.port}`;
+    process.env.SNYK_FILTER_RULES_PATHS__github = clientAccept;
+    process.env.SNYK_FILTER_RULES_PATHS__gitlab = clientAccept;
+    process.env['SNYK_FILTER_RULES_PATHS__azure-repos'] = clientAccept;
+    process.env['SNYK_FILTER_RULES_PATHS__jira-bearer-auth'] = clientAccept;
+    process.env.CLIENT_ID = 'clienid';
+    process.env.CLIENT_SECRET = 'clientsecret';
+    process.env.SKIP_REMOTE_CONFIG = 'true';
+
+    bc = await createUniversalBrokerClient();
+    await waitForUniversalBrokerClientsConnection(bs, 2);
+  });
+
+  afterEach(async () => {
+    spyClientDisconnected.mockReset();
+    spyAddClientIdToTerminationMap.mockReset();
+    spyProcessExit.mockReset();
+  });
+  afterAll(async () => {
+    spyClientDisconnected.mockReset();
+    spyAddClientIdToTerminationMap.mockReset();
+    spyProcessExit.mockReset();
+    await tws.server.close();
+    await closeBrokerClient(bc);
+    await closeBrokerServer(bs);
+    delete process.env.BROKER_SERVER_URL;
+    delete process.env.SNYK_BROKER_SERVER_UNIVERSAL_CONFIG_ENABLED;
+    delete process.env
+      .SNYK_BROKER_CLIENT_CONFIGURATION__common__default__BROKER_SERVER_URL;
+    delete process.env.CLIENT_ID;
+    delete process.env.CLIENT_SECRET;
+    delete process.env.SKIP_REMOTE_CONFIG;
+  });
+
+  it('successfully send termination signal across tunnel and notify dispatcher of disconnection', async () => {
+    const response = await axiosClient.get(
+      `http://localhost:${bs.port}/broker/${process.env.BROKER_TOKEN_1}/echo-param/xyz`,
+    );
+
+    expect(response.status).toEqual(200);
+    expect(response.data).toEqual('xyz');
+    process.emit('SIGINT');
+    await delay(1000);
+    expect(spyAddClientIdToTerminationMap).toHaveBeenCalledWith(
+      process.env.BROKER_TOKEN_1,
+      expect.any(String),
+    );
+    expect(spyClientDisconnected).toHaveBeenCalledWith(
+      process.env.BROKER_TOKEN_1,
+      expect.any(String),
+    );
+    await delay(13000); // LET THE GRACE PERIOD PASS
+    expect(process.exit).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adds graceful client shutdown with advanced shutdown signaling to the server which can then signal upcoming client connection shutdown to the load balancing system.

#### How should this be manually tested?
It's a no-op for normal broker behavior. The rest requires the entire stack.