### PR TITLE
chore: add github apprisk endpoint to whitelist

### DIFF
--- a/defaultFilters/apprisk/github.json
+++ b/defaultFilters/apprisk/github.json
@@ -48,6 +48,12 @@
     "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
   },
   {
+    "//": "used to get repo's custom properties",
+    "method": "GET",
+    "path": "/repos/:owner/:repo/properties/values",
+    "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+  },
+  {
     "//": "used to get repo's topics list",
     "method": "GET",
     "path": "/repos/:owner/:repo/topics",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Whitelist github url for custom properties that are attached to repos.
Jira: https://snyksec.atlassian.net/browse/IA-809