### PR TITLE
chore: add workload preflight check and error handling

### DIFF
--- a/lib/hybrid-sdk/client/checks/config/index.ts
+++ b/lib/hybrid-sdk/client/checks/config/index.ts
@@ -6,6 +6,7 @@ import { validateCodeAgentDeprecation } from './codeAgentDeprecation';
 import { validateUniversalConnectionsConfig } from './universalConnectionConfigCheck';
 import { validateBrokerClientVersionAgainstServer } from './brokerClientVersionCheck';
 import { validateBrokerToken } from './brokerTokenCheck';
+import { validateWorkloadConfig } from './workloadConfiguration';
 
 export function getConfigChecks(config: Config): Check[] {
   return [
@@ -15,6 +16,7 @@ export function getConfigChecks(config: Config): Check[] {
     codeAgentDeprecationCheck(config),
     brokerClientVersionCheck(config),
     brokerTokenCheck(config),
+    workloadConfigurationCheck(config),
   ];
 }
 
@@ -57,6 +59,17 @@ const acceptFlagsConfigurationCheck = (config: Config): Check => {
         { id: this.id, name: this.name },
         config,
       );
+    },
+  } satisfies Check;
+};
+
+const workloadConfigurationCheck = (config: Config): Check => {
+  return {
+    id: 'workload-config-validation',
+    name: 'Workload Configuration Check',
+    enabled: true,
+    check: function (): CheckResult {
+      return validateWorkloadConfig({ id: this.id, name: this.name }, config);
     },
   } satisfies Check;
 };

--- a/lib/hybrid-sdk/client/checks/config/workloadConfiguration.ts
+++ b/lib/hybrid-sdk/client/checks/config/workloadConfiguration.ts
@@ -1,0 +1,75 @@
+import { Config } from '../../types/config';
+import { CheckOptions, CheckResult } from '../types';
+import { existsSync, readFileSync } from 'node:fs';
+import { findProjectRoot } from '../../../common/config/config';
+import { resolve } from 'node:path';
+export const validateWorkloadConfig = (
+  checkOptions: CheckOptions,
+  config: Config,
+): CheckResult => {
+  const workloadKeys = Object.keys(config).filter((x) =>
+    x.includes('_WORKLOAD_'),
+  );
+  if (workloadKeys.length < 4) {
+    return {
+      id: checkOptions.id,
+      name: checkOptions.name,
+      status: 'error',
+      output: `Workload configuration missing. Please use or update config from https://github.com/snyk/broker/blob/master/config.default.json.`,
+    } satisfies CheckResult;
+  }
+
+  const REMOTE_WORKLOAD_NAME = config.REMOTE_WORKLOAD_NAME;
+  const REMOTE_WORKLOAD_MODULE_PATH = config.REMOTE_WORKLOAD_MODULE_PATH;
+  const CLIENT_WORKLOAD_NAME = config.CLIENT_WORKLOAD_NAME;
+  const CLIENT_WORKLOAD_MODULE_PATH = config.CLIENT_WORKLOAD_MODULE_PATH;
+
+  if (
+    !verifyClassAndHandler(REMOTE_WORKLOAD_NAME, REMOTE_WORKLOAD_MODULE_PATH) ||
+    !verifyClassAndHandler(CLIENT_WORKLOAD_NAME, CLIENT_WORKLOAD_MODULE_PATH)
+  ) {
+    return {
+      id: checkOptions.id,
+      name: checkOptions.name,
+      status: 'error',
+      output: `Workload configuration invalid. The workload cannot be found or is not containing the expected method(s).`,
+    } satisfies CheckResult;
+  }
+
+  return {
+    id: checkOptions.id,
+    name: checkOptions.name,
+    status: 'passing',
+    output: 'Workload configuration OK.',
+  } satisfies CheckResult;
+};
+
+function verifyClassAndHandler(className, filePath) {
+  try {
+    const root = findProjectRoot(__dirname);
+    if (!root) {
+      return false;
+    }
+    const absolutePath =
+      resolve(`${root}/dist/lib/`, filePath.replace('../', '')) + '.js';
+    if (!existsSync(absolutePath)) {
+      return false;
+    }
+    const fileContent = readFileSync(absolutePath, 'utf-8');
+
+    if (!fileContent) {
+      return false;
+    }
+    const classRegex = new RegExp(`class\\s+${className}\\s*extends`);
+    const handlerRegex = /handler\s*\(/;
+
+    if (!classRegex.test(fileContent)) {
+      return false;
+    }
+
+    return handlerRegex.test(fileContent);
+  } catch (error) {
+    const errorMessage = `Error validating Workload configuration. ${error}`;
+    throw new Error(errorMessage);
+  }
+}

--- a/lib/hybrid-sdk/workloadFactory.ts
+++ b/lib/hybrid-sdk/workloadFactory.ts
@@ -88,6 +88,11 @@ export abstract class Workload<
   ): Promise<
     Workload<WorkloadType.localClient> | Workload<WorkloadType.remoteServer>
   > {
+    if (!path) {
+      throw new Error(
+        `Unable to instantiate workload, path is undefined. Please check config.default.json to contain workload directives. Refer to https://github.com/snyk/broker/blob/master/config.default.json.`,
+      );
+    }
     switch (type) {
       case WorkloadType.remoteServer:
         return await this.instantiateRemoteServerWorkload(name, path, params);


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Handles more clearly issues related to workload misconfiguration and missing workload config parameters.

#### Any background context you want to provide?
In some cases, custom config.default.json are used, with a drift from the one from the repo, causing issues since the introduction of the workload centric refactoring. While this is not a supported process, we're still adding some cleaner error handling with more explicit error messages.
Adding preflight check to also validate configuration upon startup.