### PR TITLE
chore: use correct circleci context for security scans

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,6 +244,7 @@ jobs:
       - prodsec/security_scans:
           mode: auto
           open-source-additional-arguments: --exclude=test
+          release-branch: master
   build-and-save-docker-image:
     <<: *defaults
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,7 +321,7 @@ jobs:
           docker-image-name: <<parameters.project_name>>:$CIRCLE_WORKFLOW_ID
           fail-on-issues: <<pipeline.parameters.fail_on_issues>>
           monitor-on-build: <<parameters.monitor_on_build>>
-          organization: platform-broker
+          organization: platformeng_hybrid
           project: <<parameters.project>>
           severity-threshold: <<parameters.severity_threshold>>
   tag-and-push-docker-image:
@@ -384,7 +384,7 @@ jobs:
           docker-image-name: <<parameters.project_name>>:$CIRCLE_WORKFLOW_ID
           fail-on-issues: false
           monitor-on-build: false
-          organization: platform-broker
+          organization: platformeng_hybrid
           project: <<parameters.project_name>>
           severity-threshold: <<parameters.severity_threshold>>
       - install-cosign
@@ -439,7 +439,7 @@ workflows:
           name: Snyk Security Scans
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Install NPM packages
 
@@ -455,7 +455,7 @@ workflows:
           name: Scan base image (Ubuntu)
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build base image (Ubuntu)
           project: snyk/broker
@@ -473,7 +473,7 @@ workflows:
           name: Scan base image (RHEL)
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build base image (RHEL)
           project: snyk/broker-rhel-ubi
@@ -485,7 +485,7 @@ workflows:
           context:
             - nodejs-lib-release
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Snyk Security Scans
             - Scan base image (Ubuntu)
@@ -512,7 +512,7 @@ workflows:
           name: Build base UBI image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Scan repository for secrets
           dockerfile: dockerfiles/base/Dockerfile.ubi
@@ -524,7 +524,7 @@ workflows:
           name: Scan base UBI image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build base UBI image
           project: snyk/broker-rhel-ubi
@@ -539,7 +539,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Scan base UBI image
           image_name: snyk/broker
@@ -553,7 +553,7 @@ workflows:
           name: Build apprisk UBI image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-rhel-ubi --build-arg BROKER_TYPE=apprisk"
@@ -566,7 +566,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build apprisk UBI image
           image_name: snyk/broker
@@ -580,7 +580,7 @@ workflows:
           name: Build artifactory UBI image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-rhel-ubi --build-arg BROKER_TYPE=artifactory"
@@ -593,7 +593,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build artifactory UBI image
           image_name: snyk/broker
@@ -607,7 +607,7 @@ workflows:
           name: Build azure-repos UBI image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-rhel-ubi --build-arg BROKER_TYPE=azure-repos"
@@ -622,7 +622,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build azure-repos UBI image
           image_name: snyk/broker
@@ -636,7 +636,7 @@ workflows:
           name: Build bitbucket-server UBI image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-rhel-ubi --build-arg BROKER_TYPE=bitbucket-server"
@@ -651,7 +651,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build bitbucket-server UBI image
           image_name: snyk/broker
@@ -664,7 +664,7 @@ workflows:
           name: Build bitbucket-server-bearer-auth UBI image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-rhel-ubi --build-arg BROKER_TYPE=bitbucket-server-bearer-auth"
@@ -679,7 +679,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build bitbucket-server-bearer-auth UBI image
           image_name: snyk/broker
@@ -693,7 +693,7 @@ workflows:
           name: Build container-registry-agent UBI image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-rhel-ubi --build-arg BROKER_TYPE=container-registry-agent"
@@ -708,7 +708,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build container-registry-agent UBI image
           image_name: snyk/broker
@@ -722,7 +722,7 @@ workflows:
           name: Build github-com UBI image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-rhel-ubi --build-arg BROKER_TYPE=github-com"
@@ -737,7 +737,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build github-com UBI image
           image_name: snyk/broker
@@ -751,7 +751,7 @@ workflows:
           name: Build github-enterprise UBI image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-rhel-ubi --build-arg BROKER_TYPE=github-enterprise"
@@ -766,7 +766,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build github-enterprise UBI image
           image_name: snyk/broker
@@ -780,7 +780,7 @@ workflows:
           name: Build github-server-app UBI image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-rhel-ubi --build-arg BROKER_TYPE=github-server-app"
@@ -795,7 +795,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build github-server-app UBI image
           image_name: snyk/broker
@@ -809,7 +809,7 @@ workflows:
           name: Build gitlab UBI image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-rhel-ubi --build-arg BROKER_TYPE=gitlab"
@@ -824,7 +824,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build gitlab UBI image
           image_name: snyk/broker
@@ -838,7 +838,7 @@ workflows:
           name: Build jira UBI image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-rhel-ubi --build-arg BROKER_TYPE=jira"
@@ -853,7 +853,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build jira UBI image
           image_name: snyk/broker
@@ -867,7 +867,7 @@ workflows:
           name: Build jira bearer auth UBI image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-rhel-ubi --build-arg BROKER_TYPE=jira-bearer-auth"
@@ -882,7 +882,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build jira bearer auth UBI image
           image_name: snyk/broker
@@ -896,7 +896,7 @@ workflows:
           name: Build nexus UBI image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-rhel-ubi --build-arg BROKER_TYPE=nexus"
@@ -911,7 +911,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build nexus UBI image
           image_name: snyk/broker
@@ -925,7 +925,7 @@ workflows:
           name: Build nexus2 UBI image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-rhel-ubi --build-arg BROKER_TYPE=nexus2"
@@ -940,7 +940,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build nexus2 UBI image
           image_name: snyk/broker
@@ -954,7 +954,7 @@ workflows:
           name: Build universal UBI image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base UBI image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-rhel-ubi"
@@ -969,7 +969,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build universal UBI image
           image_name: snyk/broker
@@ -997,7 +997,7 @@ workflows:
           name: Build base image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Scan repository for secrets
           dockerfile: dockerfiles/base/Dockerfile
@@ -1010,7 +1010,7 @@ workflows:
           name: Scan base image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build base image
           project: snyk/broker
@@ -1025,7 +1025,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Scan base image
           image_name: snyk/broker
@@ -1039,7 +1039,7 @@ workflows:
           name: Build base image (nlatest)
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Scan repository for secrets
           additional_arguments: "--build-arg BASE_IMAGE=ubuntu:24.04 --build-arg USER_UID=2000"
@@ -1053,7 +1053,7 @@ workflows:
           name: Scan base image (nlatest)
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build base image (nlatest)
           project: snyk/broker
@@ -1068,7 +1068,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Scan base image (nlatest)
           image_name: snyk/broker
@@ -1082,7 +1082,7 @@ workflows:
           name: Build apprisk image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base --build-arg BROKER_TYPE=apprisk"
@@ -1097,7 +1097,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build apprisk image
           image_name: snyk/broker
@@ -1111,7 +1111,7 @@ workflows:
           name: Build artifactory image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base --build-arg BROKER_TYPE=artifactory"
@@ -1126,7 +1126,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build artifactory image
           image_name: snyk/broker
@@ -1140,7 +1140,7 @@ workflows:
           name: Build azure-repos image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base --build-arg BROKER_TYPE=azure-repos"
@@ -1155,7 +1155,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build azure-repos image
           image_name: snyk/broker
@@ -1169,7 +1169,7 @@ workflows:
           name: Build bitbucket-server image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base --build-arg BROKER_TYPE=bitbucket-server"
@@ -1184,7 +1184,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build bitbucket-server image
           image_name: snyk/broker
@@ -1198,7 +1198,7 @@ workflows:
           name: Build bitbucket-server-bearer-auth image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base --build-arg BROKER_TYPE=bitbucket-server-bearer-auth"
@@ -1213,7 +1213,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build bitbucket-server-bearer-auth image
           image_name: snyk/broker
@@ -1227,7 +1227,7 @@ workflows:
           name: Build container-registry-agent image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base --build-arg BROKER_TYPE=container-registry-agent"
@@ -1242,7 +1242,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build container-registry-agent image
           image_name: snyk/broker
@@ -1256,7 +1256,7 @@ workflows:
           name: Build github-com image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base --build-arg BROKER_TYPE=github-com"
@@ -1271,7 +1271,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build github-com image
           image_name: snyk/broker
@@ -1285,7 +1285,7 @@ workflows:
           name: Build github-enterprise image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base --build-arg BROKER_TYPE=github-enterprise"
@@ -1300,7 +1300,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build github-enterprise image
           image_name: snyk/broker
@@ -1314,7 +1314,7 @@ workflows:
           name: Build github-server-app image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base --build-arg BROKER_TYPE=github-server-app"
@@ -1329,7 +1329,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build github-server-app image
           image_name: snyk/broker
@@ -1343,7 +1343,7 @@ workflows:
           name: Build gitlab image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base --build-arg BROKER_TYPE=gitlab"
@@ -1358,7 +1358,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build gitlab image
           image_name: snyk/broker
@@ -1372,7 +1372,7 @@ workflows:
           name: Build jira image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base --build-arg BROKER_TYPE=jira"
@@ -1387,7 +1387,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build jira image
           image_name: snyk/broker
@@ -1401,7 +1401,7 @@ workflows:
           name: Build jira bearer auth image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base --build-arg BROKER_TYPE=jira-bearer-auth"
@@ -1416,7 +1416,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build jira bearer auth image
           image_name: snyk/broker
@@ -1430,7 +1430,7 @@ workflows:
           name: Build nexus image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base --build-arg BROKER_TYPE=nexus"
@@ -1445,7 +1445,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build nexus image
           image_name: snyk/broker
@@ -1459,7 +1459,7 @@ workflows:
           name: Build nexus2 image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base --build-arg BROKER_TYPE=nexus2"
@@ -1474,7 +1474,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build nexus2 image
           image_name: snyk/broker
@@ -1488,7 +1488,7 @@ workflows:
           name: Build universal image
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base"
@@ -1503,7 +1503,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build universal image
           image_name: snyk/broker
@@ -1517,7 +1517,7 @@ workflows:
           name: Build apprisk image (nlatest)
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-nlatest --build-arg BROKER_TYPE=apprisk"
@@ -1532,7 +1532,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build apprisk image (nlatest)
           image_name: snyk/broker
@@ -1546,7 +1546,7 @@ workflows:
           name: Build artifactory image (nlatest)
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-nlatest --build-arg BROKER_TYPE=artifactory"
@@ -1561,7 +1561,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build artifactory image (nlatest)
           image_name: snyk/broker
@@ -1575,7 +1575,7 @@ workflows:
           name: Build azure-repos image (nlatest)
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-nlatest --build-arg BROKER_TYPE=azure-repos"
@@ -1590,7 +1590,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build azure-repos image (nlatest)
           image_name: snyk/broker
@@ -1604,7 +1604,7 @@ workflows:
           name: Build bitbucket-server image (nlatest)
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-nlatest --build-arg BROKER_TYPE=bitbucket-server"
@@ -1619,7 +1619,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build bitbucket-server image (nlatest)
           image_name: snyk/broker
@@ -1633,7 +1633,7 @@ workflows:
           name: Build bitbucket-server-bearer-auth image (nlatest)
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-nlatest --build-arg BROKER_TYPE=bitbucket-server-bearer-auth"
@@ -1648,7 +1648,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build bitbucket-server-bearer-auth image (nlatest)
           image_name: snyk/broker
@@ -1662,7 +1662,7 @@ workflows:
           name: Build container-registry-agent image (nlatest)
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-nlatest --build-arg BROKER_TYPE=container-registry-agent"
@@ -1677,7 +1677,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build container-registry-agent image (nlatest)
           image_name: snyk/broker
@@ -1691,7 +1691,7 @@ workflows:
           name: Build github-com image (nlatest)
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-nlatest --build-arg BROKER_TYPE=github-com"
@@ -1706,7 +1706,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build github-com image (nlatest)
           image_name: snyk/broker
@@ -1720,7 +1720,7 @@ workflows:
           name: Build github-enterprise image (nlatest)
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-nlatest --build-arg BROKER_TYPE=github-enterprise"
@@ -1735,7 +1735,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build github-enterprise image (nlatest)
           image_name: snyk/broker
@@ -1749,7 +1749,7 @@ workflows:
           name: Build github-server-app image (nlatest)
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-nlatest --build-arg BROKER_TYPE=github-server-app"
@@ -1764,7 +1764,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build github-server-app image (nlatest)
           image_name: snyk/broker
@@ -1778,7 +1778,7 @@ workflows:
           name: Build gitlab image (nlatest)
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-nlatest --build-arg BROKER_TYPE=gitlab"
@@ -1793,7 +1793,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build gitlab image (nlatest)
           image_name: snyk/broker
@@ -1807,7 +1807,7 @@ workflows:
           name: Build jira image (nlatest)
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-nlatest --build-arg BROKER_TYPE=jira"
@@ -1822,7 +1822,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build jira image (nlatest)
           image_name: snyk/broker
@@ -1836,7 +1836,7 @@ workflows:
           name: Build jira bearer auth image (nlatest)
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-nlatest --build-arg BROKER_TYPE=jira-bearer-auth"
@@ -1851,7 +1851,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build jira bearer auth image (nlatest)
           image_name: snyk/broker
@@ -1865,7 +1865,7 @@ workflows:
           name: Build nexus image (nlatest)
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-nlatest --build-arg BROKER_TYPE=nexus"
@@ -1880,7 +1880,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build nexus image (nlatest)
           image_name: snyk/broker
@@ -1894,7 +1894,7 @@ workflows:
           name: Build nexus2 image (nlatest)
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-nlatest --build-arg BROKER_TYPE=nexus2"
@@ -1909,7 +1909,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build nexus2 image (nlatest)
           image_name: snyk/broker
@@ -1923,7 +1923,7 @@ workflows:
           name: Build universal image (nlatest)
           context:
             - snyk-bot-slack
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Push base image (nlatest)
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:${CIRCLE_TAG/v/''}-base-nlatest"
@@ -1938,7 +1938,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - Build universal image (nlatest)
           image_name: snyk/broker
@@ -1960,7 +1960,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - github-com-dev image
           additional_arguments: "--build-arg BROKER_TYPE=github-com"
@@ -1984,7 +1984,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - github-com-nlatest-dev image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:base-nlatest --build-arg BROKER_TYPE=github-com"
@@ -2008,7 +2008,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - gitlab-dev image
           additional_arguments: "--build-arg BROKER_TYPE=gitlab"
@@ -2032,7 +2032,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - bitbucket-server-dev image
           additional_arguments: "--build-arg BROKER_TYPE=bitbucket-server"
@@ -2056,7 +2056,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - gitlab-nlatest-dev image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:base-nlatest --build-arg BROKER_TYPE=gitlab"
@@ -2080,7 +2080,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - nexus-dev image
           additional_arguments: "--build-arg BROKER_TYPE=nexus"
@@ -2104,7 +2104,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - nexus-nlatest-dev image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:base-nlatest --build-arg BROKER_TYPE=nexus"
@@ -2128,7 +2128,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - universal-dev image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:base"
@@ -2145,7 +2145,7 @@ workflows:
             - snyk-bot-slack
             - team-broker-cosign
             - team-broker-docker-hub
-            - team-broker-snyk
+            - team-hybrid-snyk
           requires:
             - universal-dev image
           additional_arguments: "--build-arg BASE_IMAGE=snyk/broker:base-nlatest"


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR uses hybrid (instead of broker) org for security scans.

The release-branch parameter for security_scans is adjusted, to enable `snyk monitor` command on broker releases.
