### PR TITLE
chore: allow native pr experience azure repos and gitlab

### DIFF
--- a/client-templates/azure-repos/accept.json.sample
+++ b/client-templates/azure-repos/accept.json.sample
@@ -424,6 +424,46 @@
         "scheme": "basic",
         "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
       }
+    },
+    {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "path": "/_apis/git/repositories/:repo/pullRequests/:pullRef/threads",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
+    },
+    {
+      "//": "update a general pull request comment",
+      "method": "PATCH",
+      "path": "/_apis/git/repositories/:repo/pullRequests/:pullRef/threads/:threadId/comments/:commentId",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
+    },
+    {
+      "//": "create an inline pull request comment",
+      "method": "POST",
+      "path": "/_apis/git/repositories/:repo/pullRequests/:pullRef/threads",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
+    },
+    {
+      "//": "resolve an inline pull request comment",
+      "method": "PATCH",
+      "path": "/_apis/git/repositories/:repo/pullRequests/:pullRef/threads/:commentId",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
     }
   ]
 }

--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -1599,6 +1599,36 @@
         "method": "GET",
         "path": "/api/v4/projects/:project/merge_requests/:pullRef",
         "origin": "https://${GITLAB}"
-      }
+    },
+    {
+      "//": "create a new MR summary comment (note)",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/merge_requests/:pullRef/notes",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "update an existing MR summary comment (note)",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/merge_requests/:pullRef/notes/:noteId",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "get diff version for a given commit SHA in a merge request",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/merge_requests/:pullRef/versions",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "create an inline MR comment (discussion)",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/merge_requests/:pullRef/discussions",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "resolve an inline MR comment (discussion)",
+      "method": "PUT",
+      "path": "/api/v4/projects/:project/merge_requests/:pullRef/discussions/:discussion",
+      "origin": "https://${GITLAB}"
+    }
   ]
 }

--- a/defaultFilters/azure-repos.json
+++ b/defaultFilters/azure-repos.json
@@ -432,6 +432,46 @@
           "scheme": "basic",
           "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
         }
+      },
+      {
+        "//": "create a general pull request comment",
+        "method": "POST",
+        "path": "/_apis/git/repositories/:repo/pullRequests/:pullRef/threads",
+        "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+        "auth": {
+          "scheme": "basic",
+          "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+        }
+      },
+      {
+        "//": "update a general pull request comment",
+        "method": "PATCH",
+        "path": "/_apis/git/repositories/:repo/pullRequests/:pullRef/threads/:threadId/comments/:commentId",
+        "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+        "auth": {
+          "scheme": "basic",
+          "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+        }
+      },
+      {
+        "//": "create an inline pull request comment",
+        "method": "POST",
+        "path": "/_apis/git/repositories/:repo/pullRequests/:pullRef/threads",
+        "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+        "auth": {
+          "scheme": "basic",
+          "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+        }
+      },
+      {
+        "//": "resolve an inline pull request comment",
+        "method": "PATCH",
+        "path": "/_apis/git/repositories/:repo/pullRequests/:pullRef/threads/{comment_id}",
+        "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+        "auth": {
+          "scheme": "basic",
+          "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+        }
       }
     ]
   }

--- a/defaultFilters/gitlab.json
+++ b/defaultFilters/gitlab.json
@@ -49,6 +49,7 @@
         "path": "/api/v4/projects/:project/repository/tree",
         "origin": "https://${GITLAB}"
       },
+  
       {
         "//": "used to determine the full dependency tree",
         "method": "GET",
@@ -169,6 +170,7 @@
         "path": "/api/v4/projects/:project/repository/files*%2FPipfile",
         "origin": "https://${GITLAB}"
       },
+  
       {
         "//": "used to determine the full dependency tree",
         "method": "GET",
@@ -552,6 +554,7 @@
           }
         ]
       },
+  
       {
         "//": "used to create manifest file",
         "method": "POST",
@@ -1482,6 +1485,7 @@
           }
         ]
       },
+  
       {
         "//": "allow webhooks to be added, to allow commits to be checked by Snyk. Rules for what is sent to Snyk are controlled in the `public` accept filters",
         "method": "POST",

--- a/defaultFilters/gitlab.json
+++ b/defaultFilters/gitlab.json
@@ -49,7 +49,7 @@
         "path": "/api/v4/projects/:project/repository/tree",
         "origin": "https://${GITLAB}"
       },
-  
+
       {
         "//": "used to determine the full dependency tree",
         "method": "GET",
@@ -170,7 +170,7 @@
         "path": "/api/v4/projects/:project/repository/files*%2FPipfile",
         "origin": "https://${GITLAB}"
       },
-  
+
       {
         "//": "used to determine the full dependency tree",
         "method": "GET",
@@ -554,7 +554,7 @@
           }
         ]
       },
-  
+
       {
         "//": "used to create manifest file",
         "method": "POST",
@@ -1485,7 +1485,7 @@
           }
         ]
       },
-  
+
       {
         "//": "allow webhooks to be added, to allow commits to be checked by Snyk. Rules for what is sent to Snyk are controlled in the `public` accept filters",
         "method": "POST",
@@ -1598,6 +1598,36 @@
         "//": "get single pull request info",
         "method": "GET",
         "path": "/api/v4/projects/:project/merge_requests/:pullRef",
+        "origin": "https://${GITLAB}"
+      },
+      {
+        "//": "create a new MR summary comment (note)",
+        "method": "POST",
+        "path": "/api/v4/projects/:project/merge_requests/:pullRef/notes",
+        "origin": "https://${GITLAB}"
+      },
+      {
+        "//": "update an existing MR summary comment (note)",
+        "method": "PUT",
+        "path": "/api/v4/projects/:project/merge_requests/:pullRef/notes/:noteId",
+        "origin": "https://${GITLAB}"
+      },
+      {
+        "//": "get diff version for a given commit SHA in a merge request",
+        "method": "GET",
+        "path": "/api/v4/projects/:project/merge_requests/:pullRef/versions",
+        "origin": "https://${GITLAB}"
+      },
+      {
+        "//": "create an inline MR comment (discussion)",
+        "method": "POST",
+        "path": "/api/v4/projects/:project/merge_requests/:pullRef/discussions",
+        "origin": "https://${GITLAB}"
+      },
+      {
+        "//": "resolve an inline MR comment (discussion)",
+        "method": "PUT",
+        "path": "/api/v4/projects/:project/merge_requests/:pullRef/discussions/:discussion",
         "origin": "https://${GITLAB}"
       }
     ]

--- a/defaultFilters/gitlab.json
+++ b/defaultFilters/gitlab.json
@@ -49,7 +49,6 @@
         "path": "/api/v4/projects/:project/repository/tree",
         "origin": "https://${GITLAB}"
       },
-
       {
         "//": "used to determine the full dependency tree",
         "method": "GET",
@@ -170,7 +169,6 @@
         "path": "/api/v4/projects/:project/repository/files*%2FPipfile",
         "origin": "https://${GITLAB}"
       },
-
       {
         "//": "used to determine the full dependency tree",
         "method": "GET",
@@ -554,7 +552,6 @@
           }
         ]
       },
-
       {
         "//": "used to create manifest file",
         "method": "POST",
@@ -1485,7 +1482,6 @@
           }
         ]
       },
-
       {
         "//": "allow webhooks to be added, to allow commits to be checked by Snyk. Rules for what is sent to Snyk are controlled in the `public` accept filters",
         "method": "POST",

--- a/test/unit/filters.testskip.ts
+++ b/test/unit/filters.testskip.ts
@@ -395,6 +395,31 @@ describe('filters', () => {
         const filterResponseUrl = filterResponse ? filterResponse.url : '';
         expect(filterResponseUrl).toMatch(url);
       });
+
+      it('should allow creating a pull request comment (general or inline)', () => {
+        const url = '/_apis/git/repositories/test-repo/pullRequests/1/threads';
+
+        const filterResponse = filter({
+          url,
+          method: 'POST',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseUrl = filterResponse ? filterResponse.url : '';
+        expect(filterResponseUrl).toMatch(url);
+      });
+
+      it('should allow updating/resolving a pull request comment (general or inline)', () => {
+        const url =
+          '/_apis/git/repositories/test-repo/pullRequests/1/threads/1/comments/1';
+
+        const filterResponse = filter({
+          url,
+          method: 'PATCH',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseUrl = filterResponse ? filterResponse.url : '';
+        expect(filterResponseUrl).toMatch(url);
+      });
     });
 
     describe('for gitlab', () => {

--- a/test/unit/filters.testskip.ts
+++ b/test/unit/filters.testskip.ts
@@ -448,6 +448,29 @@ describe('filters', () => {
         const filterResponseUrl = filterResponse ? filterResponse.url : '';
         expect(filterResponseUrl).toMatch(url);
       });
+      it('should allow creating a summary merge request comment', () => {
+        const url = '/api/v4/projects/123/merge_requests/1/notes';
+
+        const filterResponse = filter({
+          url,
+          method: 'POST',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseUrl = filterResponse ? filterResponse.url : '';
+        expect(filterResponseUrl).toMatch(url);
+      });
+
+      it('should allow updating a general pull request comment', () => {
+        const url = '/api/v4/projects/123/merge_requests/1/notes/12345';
+
+        const filterResponse = filter({
+          url,
+          method: 'PUT',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseUrl = filterResponse ? filterResponse.url : '';
+        expect(filterResponseUrl).toMatch(url);
+      });
     });
   });
 

--- a/test/unit/filters.testskip.ts
+++ b/test/unit/filters.testskip.ts
@@ -471,6 +471,43 @@ describe('filters', () => {
         const filterResponseUrl = filterResponse ? filterResponse.url : '';
         expect(filterResponseUrl).toMatch(url);
       });
+
+      it('should allow retrieving diff version for a given commit SHA', () => {
+        const url = '/api/v4/projects/123/merge_requests/1/versions';
+
+        const filterResponse = filter({
+          url,
+          method: 'GET',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseUrl = filterResponse ? filterResponse.url : '';
+        expect(filterResponseUrl).toMatch(url);
+      });
+
+      it('should allow creating an inline comment', () => {
+        const url = '/api/v4/projects/123/merge_requests/1/discussions';
+
+        const filterResponse = filter({
+          url,
+          method: 'POST',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseUrl = filterResponse ? filterResponse.url : '';
+        expect(filterResponseUrl).toMatch(url);
+      });
+
+      it('should allow resolving an inline comment', () => {
+        const url =
+          '/api/v4/projects/123/merge_requests/1/discussions/abcd1234';
+
+        const filterResponse = filter({
+          url,
+          method: 'PUT',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseUrl = filterResponse ? filterResponse.url : '';
+        expect(filterResponseUrl).toMatch(url);
+      });
     });
   });
 


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adds the ability to allow native PR experience calls through the Broker, to manage general comments, create discussions and resolve discussions in Azure Repos.