### PR TITLE
fix: azure repos npx rules

### DIFF
--- a/client-templates/azure-repos/accept.json.sample
+++ b/client-templates/azure-repos/accept.json.sample
@@ -426,9 +426,9 @@
       }
     },
     {
-      "//": "create a general pull request comment",
+      "//": "create a general/inline pull request comment",
       "method": "POST",
-      "path": "/_apis/git/repositories/:repo/pullRequests/:pullRef/threads",
+      "path": "/:owner/_apis/git/repositories/:repo/pullRequests/:pullRef/threads",
       "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
       "auth": {
         "scheme": "basic",
@@ -438,17 +438,7 @@
     {
       "//": "update a general pull request comment",
       "method": "PATCH",
-      "path": "/_apis/git/repositories/:repo/pullRequests/:pullRef/threads/:threadId/comments/:commentId",
-      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
-      "auth": {
-        "scheme": "basic",
-        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
-      }
-    },
-    {
-      "//": "create an inline pull request comment",
-      "method": "POST",
-      "path": "/_apis/git/repositories/:repo/pullRequests/:pullRef/threads",
+      "path": "/:owner/_apis/git/repositories/:repo/pullRequests/:pullRef/threads/:threadId/comments/:commentId",
       "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
       "auth": {
         "scheme": "basic",
@@ -458,7 +448,7 @@
     {
       "//": "resolve an inline pull request comment",
       "method": "PATCH",
-      "path": "/_apis/git/repositories/:repo/pullRequests/:pullRef/threads/:commentId",
+      "path": "/:owner/_apis/git/repositories/:repo/pullRequests/:pullRef/threads/:commentId",
       "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
       "auth": {
         "scheme": "basic",

--- a/defaultFilters/azure-repos.json
+++ b/defaultFilters/azure-repos.json
@@ -434,9 +434,9 @@
         }
       },
       {
-        "//": "create a general pull request comment",
+        "//": "create a general/inline pull request comment",
         "method": "POST",
-        "path": "/_apis/git/repositories/:repo/pullRequests/:pullRef/threads",
+        "path": "/:owner/_apis/git/repositories/:repo/pullRequests/:pullRef/threads",
         "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
         "auth": {
           "scheme": "basic",
@@ -446,17 +446,7 @@
       {
         "//": "update a general pull request comment",
         "method": "PATCH",
-        "path": "/_apis/git/repositories/:repo/pullRequests/:pullRef/threads/:threadId/comments/:commentId",
-        "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
-        "auth": {
-          "scheme": "basic",
-          "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
-        }
-      },
-      {
-        "//": "create an inline pull request comment",
-        "method": "POST",
-        "path": "/_apis/git/repositories/:repo/pullRequests/:pullRef/threads",
+        "path": "/:owner/_apis/git/repositories/:repo/pullRequests/:pullRef/threads/:threadId/comments/:commentId",
         "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
         "auth": {
           "scheme": "basic",
@@ -466,7 +456,7 @@
       {
         "//": "resolve an inline pull request comment",
         "method": "PATCH",
-        "path": "/_apis/git/repositories/:repo/pullRequests/:pullRef/threads/{comment_id}",
+        "path": "/:owner/_apis/git/repositories/:repo/pullRequests/:pullRef/threads/{comment_id}",
         "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
         "auth": {
           "scheme": "basic",

--- a/test/unit/filters-and-interpolates.test.ts
+++ b/test/unit/filters-and-interpolates.test.ts
@@ -666,7 +666,8 @@ describe('filters and interpolates', () => {
       });
 
       it('should allow creating a pull request comment (general or inline)', () => {
-        const url = '/_apis/git/repositories/test-repo/pullRequests/1/threads';
+        const url =
+          '/test-owner/_apis/git/repositories/test-repo/pullRequests/1/threads';
 
         const filterResponse = filter({
           url,
@@ -689,7 +690,7 @@ describe('filters and interpolates', () => {
 
       it('should allow updating/resolving a pull request comment (general or inline)', () => {
         const url =
-          '/_apis/git/repositories/test-repo/pullRequests/1/threads/1/comments/1';
+          '/test-owner/_apis/git/repositories/test-repo/pullRequests/1/threads/1/comments/1';
 
         const filterResponse = filter({
           url,


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Fixes the Azure Repos filtering rules for Native PR Experience - adds the missing `/:owner` prefix to the API endpoints.

In addition, this PR removes a duplicate from the Native PR Experience filter rules.

#### Any background context you want to provide?

Fixes a bug introduced in #946 where the API calls for Native PR Experience flows failed due to the missing repo owner prefix.