### PR TITLE
chore: add return code on dispatcher retry info

### DIFF
--- a/lib/hybrid-sdk/client/dispatcher/client/api.ts
+++ b/lib/hybrid-sdk/client/dispatcher/client/api.ts
@@ -51,7 +51,9 @@ export class HttpDispatcherServiceClient implements DispatcherServiceClient {
           { apiResponse },
           'Unexpected Connection Allocation Server response',
         );
-        throw new Error('Unexpected connection allocation server response');
+        throw new Error(
+          `Unexpected connection allocation server response - ${response.statusCode}: ${response.body}`,
+        );
       }
       const snykRequestId = response.headers['snyk-request-id'] || '';
       logger.trace(
@@ -63,7 +65,7 @@ export class HttpDispatcherServiceClient implements DispatcherServiceClient {
       return serverId;
     } catch (err) {
       logger.trace({ err }, 'Error getting connection allocation.');
-      throw new Error('Error getting connection allocation.');
+      throw new Error(`Error getting connection allocation. ${err}`);
     }
   }
 }

--- a/lib/hybrid-sdk/client/dispatcher/index.ts
+++ b/lib/hybrid-sdk/client/dispatcher/index.ts
@@ -40,7 +40,7 @@ export async function getServerId(
     } catch (err) {
       const timeout = 2 ** attempt * 30000;
       logger.warn(
-        { attempt, timeout },
+        { attempt, timeout, err },
         `Waiting for ${timeout}ms before next Broker Dispatcher API call.`,
       );
       Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, timeout);

--- a/test/functional/dispatcher-client-api.test.ts
+++ b/test/functional/dispatcher-client-api.test.ts
@@ -32,18 +32,16 @@ describe('Broker Dispatcher API client', () => {
 
     const client = new HttpDispatcherServiceClient(dispatcherServerBaseUrl);
 
-    try {
-      await client.createConnection(
+    await expect(
+      client.createConnection(
         {
           hashedBrokerToken: hashedToken,
           brokerClientId: '1',
         },
         { deployment_location: 'test', broker_token_first_char: 'a' },
         config,
-      );
-    } catch (err) {
-      expect(err).toEqual(Error('Error getting connection allocation.'));
-    }
+      ),
+    ).rejects.toThrow('Error getting connection allocation.');
   });
 
   it('should return server_id for 201', async () => {


### PR DESCRIPTION
- [x] Ready for review
- [] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Add return code on dispatcher backoff info messages in logs for easier troubleshooting.

#### Any background context you want to provide?
Goal is to provide better clarity as to why the dispatcher is backing off.