### PR TITLE
fix: add ctx support for connection status endpoint [HYB-981]

### DIFF
--- a/lib/hybrid-sdk/server/index.ts
+++ b/lib/hybrid-sdk/server/index.ts
@@ -65,10 +65,15 @@ export const main = async (serverOpts: ServerOpts) => {
   if (!process.env.JEST_WORKER_ID) {
     app.use(applyPrometheusMiddleware());
   }
-  app.get('/connection-status/:token', connectionStatusHandler);
+  app.get(
+    ['/connection-status/:token', '/connection-status/:token/ctx/:ctxId'],
+    extractPossibleContextFromHttpRequestToHeader,
+    connectionStatusHandler,
+  );
   app.get('/connections-status', connectionsStatusHandler);
   app.get(
     '/service/:token/*',
+    extractPossibleContextFromHttpRequestToHeader,
     overloadHttpRequestWithConnectionDetailsMiddleware,
     serviceHandler,
   );

--- a/test/functional/healthcheck.test.ts
+++ b/test/functional/healthcheck.test.ts
@@ -110,6 +110,32 @@ describe('proxy requests originating from behind the broker client', () => {
     });
   });
 
+  it('check connection-status with context enabled connected client', async () => {
+    bc = await createBrokerClient({
+      brokerServerUrl: `http://localhost:${bs.port}`,
+      brokerToken: '00000000-0000-0000-0000-00000000002',
+      filters: clientAccept,
+    });
+    await waitForBrokerClientConnection(bs);
+
+    const response = await axiosClient.get(
+      `http://localhost:${bs.port}/connection-status/00000000-0000-0000-0000-00000000002/ctx/00000000-0000-0000-0000-00000000003`,
+    );
+    const expectedFilters = require(clientAccept);
+
+    expect(response.status).toEqual(200);
+    expect(response.data).toStrictEqual({
+      ok: true,
+      clients: expect.any(Array),
+    });
+
+    const connectionStatusBody = response.data.clients[0];
+    expect(connectionStatusBody).toStrictEqual({
+      version: version,
+      filters: expectedFilters,
+    });
+  });
+
   it('check connection-status after client disconnected', async () => {
     bc = await createBrokerClient({
       brokerServerUrl: `http://localhost:${bs.port}`,


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Add ctx pattern and middleware for connection-status endpoint
