### PR TITLE
fix: make approval steps work on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -514,7 +514,7 @@ workflows:
           type: approval
           requires:
             - Scan repository for secrets
-          <<: *filter-dev-branch-only
+          <<: *filter-tags-only
       - build-and-save-docker-ubi-image:
           name: Build base UBI image
           context:
@@ -1006,7 +1006,7 @@ workflows:
           type: approval
           requires:
             - Scan repository for secrets
-          <<: *filter-dev-branch-only
+          <<: *filter-tags-only
 
       - build-and-save-docker-image:
           name: Build base image


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Put the image building approval steps on releases, on tags and not dev branches.