### PR TITLE
feat: add context support to plugins manager [HYB-980]

### DIFF
--- a/lib/broker-workload/websocketRequests.ts
+++ b/lib/broker-workload/websocketRequests.ts
@@ -144,10 +144,12 @@ export class BrokerWorkload extends Workload<WorkloadType.remoteServer> {
         this.websocketConnectionHandler?.socketType,
       );
       if (this.options.config.universalBrokerEnabled) {
+        const contextId = payload.headers['x-snyk-broker-context-id'] ?? null;
         preparedRequest.req = await runPreRequestPlugins(
           this.options,
           this.connectionIdentifier,
           preparedRequest.req,
+          contextId,
         );
         payload.headers[contentLengthHeader] = computeContentLength(payload);
       }

--- a/lib/hybrid-sdk/client/brokerClientPlugins/abstractBrokerPlugin.ts
+++ b/lib/hybrid-sdk/client/brokerClientPlugins/abstractBrokerPlugin.ts
@@ -66,6 +66,12 @@ export default abstract class BrokerPlugin {
     pluginsConfig?: Record<any, string>,
   ): Promise<void>;
 
+  abstract startUpContext(
+    _contextId: string,
+    _connectionConfiguration: Record<string, any>,
+    _pluginsConfig: Record<any, string>,
+  ): Promise<void>;
+
   async preRequest(
     connectionConfiguration: Record<string, any>,
     postFilterPreparedRequest: PostFilterPreparedRequest,

--- a/lib/hybrid-sdk/client/brokerClientPlugins/plugins/containerRegistryCredentialsFormatting.ts
+++ b/lib/hybrid-sdk/client/brokerClientPlugins/plugins/containerRegistryCredentialsFormatting.ts
@@ -78,4 +78,12 @@ export class Plugin extends BrokerPlugin {
         connectionConfiguration.CR_CREDENTIALS;
     }
   }
+  startUpContext(
+    contextId: string,
+    connectionConfiguration: Record<string, any>,
+    pluginsConfig: Record<any, string>,
+  ): Promise<void> {
+    this.logger.debug({ contextId, connectionConfiguration, pluginsConfig });
+    throw new Error('Method not implemented.');
+  }
 }

--- a/lib/hybrid-sdk/client/brokerClientPlugins/plugins/githubServerAppAuth.ts
+++ b/lib/hybrid-sdk/client/brokerClientPlugins/plugins/githubServerAppAuth.ts
@@ -119,6 +119,15 @@ export class Plugin extends BrokerPlugin {
     }
   }
 
+  startUpContext(
+    contextId: string,
+    connectionConfiguration: Record<string, any>,
+    pluginsConfig: Record<any, string>,
+  ): Promise<void> {
+    this.logger.debug({ contextId, connectionConfiguration, pluginsConfig });
+    throw new Error('Method not implemented.');
+  }
+
   _getJWT(
     nowInSeconds: number,
     privatePemPath: string,

--- a/test/fixtures/plugins/dummy-context.js
+++ b/test/fixtures/plugins/dummy-context.js
@@ -1,0 +1,48 @@
+import BrokerPlugin from '../../../lib/hybrid-sdk/client/brokerClientPlugins/abstractBrokerPlugin';
+
+export class Plugin extends BrokerPlugin {
+  pluginCode = 'DUMMY-CONTEXT';
+  pluginName = 'Dummy Context Plugin';
+  description = `
+    dummy plugin
+    `;
+  version = '0.1';
+  applicableBrokerTypes = ['dummy-context'];
+
+  isPluginActive() {
+    if (this.brokerClientConfiguration.DISABLE_DUMMY_PLUGIN) {
+      this.logger.debug({ plugin: this.pluginName }, 'Disabling plugin');
+      return false;
+    }
+    return true;
+  }
+  async startUp(connectionConfig) {
+    this.logger.info({ plugin: this.pluginName }, 'Running Startup');
+    this.logger.info(
+      { config: connectionConfig },
+      'Connection Config passed to the plugin',
+    );
+    connectionConfig['NEW_VAR_ADDED_TO_CONNECTION'] = 'access-token';
+  }
+
+  async startUpContext(contextId, connectionConfig) {
+    this.logger.info(
+      { plugin: this.pluginName, contextId },
+      'Running Context Startup',
+    );
+    this.logger.info(
+      { config: connectionConfig },
+      'Connection Config passed to the plugin',
+    );
+    connectionConfig.contexts[contextId]['NEW_VAR_ADDED_TO_CONNECTION'] =
+      'access-token-context';
+  }
+
+  async preRequest(connectionConfiguration, postFilterPreparedRequest) {
+    this.logger.info({ plugin: this.pluginName }, 'Running prerequest plugin');
+    const customizedRequest = postFilterPreparedRequest;
+    customizedRequest.body['NEW_VAR_ADDED_TO_CONNECTION'] =
+      connectionConfiguration['NEW_VAR_ADDED_TO_CONNECTION'];
+    return customizedRequest;
+  }
+}


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adds context support in plugins manager.

#### Where should the reviewer start?
The contexts are section under a connection in the connections object retrieved from the backend.
The plugin abstract class brings a new startup context method which plugins must implement, giving the opportunity to mutate the configuration just like the regular startup method, but for each context independently.

Using this startupContext method, each context configuration can be mutated to contain whatever updated field/value. The allowed values will likely need tweaking but will be addressed in a separate PR.
Each context object under the given connection will contain the values set by plugins.

The prerequest method, if used/called, will remain largely unchanged, but will get a configuration object containing overriden values by the context (getting the result of `getConfigForIdentifier(connectionIdentifier,clientOpts.config,contextId)` ). It follows the normal pattern for context injection introduced in #941.

#### Any background context you want to provide?

Contexts should be seen as sub objects under connections that are used dynamically for requests with a context id associated, overriding default connection config values by different values stored in that context.
Plugins like github app plugins mutate the config object to store in it temporary credentials retrieved from the gh apps. This PR sets the foundations for plugins to do the same thing by calling a startupcontext method to allow a plugin to do the same for each individual context and store the overriding values under the given context.

![image](https://github.com/user-attachments/assets/b1c3d6a3-3614-4c13-a963-1749a9fe2417)
