### PR TITLE
fix: add injected rules to be evaluated first

### DIFF
--- a/lib/hybrid-sdk/common/filter/filter-rules-loading.ts
+++ b/lib/hybrid-sdk/common/filter/filter-rules-loading.ts
@@ -294,7 +294,7 @@ function injectRulesAtRuntime(
           `Caution, possible overlapping rules with apprisk rules extension.`,
         );
       }
-      filters.private.push(...appRiskRules);
+      filters.private.unshift(...appRiskRules);
     }
   }
 
@@ -340,7 +340,7 @@ function injectRulesAtRuntime(
           `Caution, possible overlapping rules with custom PR templates.`,
         );
       }
-      filters.private.push(...customPRTemplatesRules);
+      filters.private.unshift(...customPRTemplatesRules);
     }
   }
 

--- a/test/functional/server-client-universal-termination-signal.test.ts
+++ b/test/functional/server-client-universal-termination-signal.test.ts
@@ -63,6 +63,7 @@ describe('client send termination signal to broker server', () => {
     process.env.CLIENT_ID = 'clienid';
     process.env.CLIENT_SECRET = 'clientsecret';
     process.env.SKIP_REMOTE_CONFIG = 'true';
+    process.env.ACCEPT_APPRISK = 'false';
 
     bc = await createUniversalBrokerClient();
     await waitForUniversalBrokerClientsConnection(bs, 2);

--- a/test/functional/server-client-universal.test.ts
+++ b/test/functional/server-client-universal.test.ts
@@ -55,6 +55,7 @@ describe('proxy requests originating from behind the broker server', () => {
     process.env.CLIENT_ID = 'clienid';
     process.env.CLIENT_SECRET = 'clientsecret';
     process.env.SKIP_REMOTE_CONFIG = 'true';
+    process.env.ACCEPT_APPRISK = 'false';
 
     bc = await createUniversalBrokerClient();
     await waitForUniversalBrokerClientsConnection(bs, 2);


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Prepends the injected rules for essentials and custom pr templates in the filters lists to have them evaluated first.

#### Any background context you want to provide?
The injected rules tends to be more restrictive than others. Being evaluated first allows to avoid some issues in some corner cases where other more permissive filters are a match before the actual targeted rule.

This PR fixes corner cases like where a repo called something containing "dockerfile" would not be functional for repos/:org/:repos/languages as another rule with *Dockerfile would catch it prior, injecting different origin scheme.

