### PR TITLE
chore: allow gitlab mr diffs

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -37,6 +37,11 @@ ignore:
         reason: No fix from RHEL available
         expires: 2025-05-24T15:32:17.640Z
         created: 2025-04-24T15:32:17.640Z
+  SNYK-RHEL8-ZLIB-10174471:
+    - '*':
+        reason: No fix from RHEL available
+        expires: 2025-06-19T23:59:69.000Z
+        created: 2025-05-20T10:20:00.000Z
 patch: {}
 exclude:
   global:

--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -1629,6 +1629,12 @@
       "method": "PUT",
       "path": "/api/v4/projects/:project/merge_requests/:pullRef/discussions/:discussion",
       "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "get merge request files and diffs",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/merge_requests/:pullRef/diffs",
+      "origin": "https://${GITLAB}"
     }
   ]
 }

--- a/defaultFilters/gitlab.json
+++ b/defaultFilters/gitlab.json
@@ -1629,6 +1629,12 @@
         "method": "PUT",
         "path": "/api/v4/projects/:project/merge_requests/:pullRef/discussions/:discussion",
         "origin": "https://${GITLAB}"
+      },
+      {
+        "//": "get merge request files and diffs",
+        "method": "GET",
+        "path": "/api/v4/projects/:project/merge_requests/:pullRef/diffs",
+        "origin": "https://${GITLAB}"
       }
     ]
   }

--- a/test/unit/filters-and-interpolates.test.ts
+++ b/test/unit/filters-and-interpolates.test.ts
@@ -913,6 +913,28 @@ describe('filters and interpolates', () => {
         );
         expect(result.url).toMatch(url);
       });
+
+      it('should allow retrieving MR diffs', () => {
+        const url = '/api/v4/projects/123/merge_requests/1/diffs';
+
+        const filterResponse = filter({
+          url,
+          method: 'GET',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseAsRule = filterResponse as Rule;
+        const result = getInterpolatedRequest(
+          null,
+          filterResponseAsRule,
+          {
+            url,
+            method: 'GET',
+          },
+          {},
+          {},
+        );
+        expect(result.url).toMatch(url);
+      });
     });
   });
 


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Allows the retrieval of MR changes/diffs in Gitlab by allowing the `/api/v4/projects/:project/merge_requests/:pullRef/diffs` endpoint. This can be used to help determine which lines in a Gitlab MR can be commented on, since Gitlab does not allow commenting outside the diff of a MR.
