### PR TITLE
chore: ai fix reaction rules

### DIFF
--- a/client-templates/github-com/accept.json.sample
+++ b/client-templates/github-com/accept.json.sample
@@ -2144,9 +2144,21 @@
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
+      "//": "create a reaction for a pull request comment",
+      "method": "POST",
+      "path": "/repos/:name/:repo/pulls/comments/:commentId/reactions",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
       "//": "create a pull request review",
       "method": "POST",
       "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "reply to a review comment",
+      "method": "POST",
+      "path": "/repos/:name/:repo/pulls/:pullRef/comments/:commentId/replies",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {

--- a/client-templates/github-enterprise/accept.json.sample
+++ b/client-templates/github-enterprise/accept.json.sample
@@ -1424,9 +1424,21 @@
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
+      "//": "create a reaction for a pull request comment",
+      "method": "POST",
+      "path": "/repos/:name/:repo/pulls/comments/:commentId/reactions",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
       "//": "create a pull request review",
       "method": "POST",
       "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
+      "//": "reply to a review comment",
+      "method": "POST",
+      "path": "/repos/:name/:repo/pulls/:pullRef/comments/:commentId/replies",
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {

--- a/client-templates/github-server-app/accept.json.sample
+++ b/client-templates/github-server-app/accept.json.sample
@@ -1307,7 +1307,7 @@
       "//": "creates a new commit",
       "method": "POST",
       "path": "/repos/:name/:repo/git/commits",
-      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+      "origin": "https://${GITHUB_API}"
     },
     {
       "//": "get a list of all the refs to match find whether an existing PR is open",
@@ -1424,9 +1424,21 @@
       "origin": "https://${GITHUB_API}"
     },
     {
+      "//": "create a reaction for a pull request comment",
+      "method": "POST",
+      "path": "/repos/:name/:repo/pulls/comments/:commentId/reactions",
+      "origin": "https://${GITHUB_API}"
+    },
+    {
       "//": "create a pull request review",
       "method": "POST",
       "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+      "origin": "https://${GITHUB_API}"
+    },
+    {
+      "//": "reply to a review comment",
+      "method": "POST",
+      "path": "/repos/:name/:repo/pulls/:pullRef/comments/:commentId/replies",
       "origin": "https://${GITHUB_API}"
     },
     {

--- a/defaultFilters/github-cloud-app.json
+++ b/defaultFilters/github-cloud-app.json
@@ -2034,9 +2034,29 @@
         }
       },
       {
+        "//": "create a reaction for a pull request comment",
+        "method": "POST",
+        "path": "/repos/:name/:repo/pulls/comments/:commentId/reactions",
+        "origin": "https://${GITHUB_API}",
+        "auth": {
+          "scheme": "bearer",
+          "token": "${GHA_ACCESS_TOKEN}"
+        }
+      },
+      {
         "//": "create a pull request review",
         "method": "POST",
         "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+        "origin": "https://${GITHUB_API}",
+        "auth": {
+          "scheme": "bearer",
+          "token": "${GHA_ACCESS_TOKEN}"
+        }
+      },
+      {
+        "//": "reply to a review comment",
+        "method": "POST",
+        "path": "/repos/:name/:repo/pulls/:pullRef/comments/:commentId/replies",
         "origin": "https://${GITHUB_API}",
         "auth": {
           "scheme": "bearer",

--- a/defaultFilters/github-enterprise.json
+++ b/defaultFilters/github-enterprise.json
@@ -1424,9 +1424,21 @@
         "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
       },
       {
+        "//": "create a reaction for a pull request comment",
+        "method": "POST",
+        "path": "/repos/:name/:repo/pulls/comments/:commentId/reactions",
+        "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+      },
+      {
         "//": "create a pull request review",
         "method": "POST",
         "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+        "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+      },
+      {
+        "//": "reply to a review comment",
+        "method": "POST",
+        "path": "/repos/:name/:repo/pulls/:pullRef/comments/:commentId/replies",
         "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
       },
       {

--- a/defaultFilters/github-server-app.json
+++ b/defaultFilters/github-server-app.json
@@ -2034,9 +2034,29 @@
         }
       },
       {
+        "//": "create a reaction for a pull request comment",
+        "method": "POST",
+        "path": "/repos/:name/:repo/pulls/comments/:commentId/reactions",
+        "origin": "https://${GITHUB_API}",
+        "auth": {
+          "scheme": "bearer",
+          "token": "${GHA_ACCESS_TOKEN}"
+        }
+      },
+      {
         "//": "create a pull request review",
         "method": "POST",
         "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+        "origin": "https://${GITHUB_API}",
+        "auth": {
+          "scheme": "bearer",
+          "token": "${GHA_ACCESS_TOKEN}"
+        }
+      },
+      {
+        "//": "reply to a review comment",
+        "method": "POST",
+        "path": "/repos/:name/:repo/pulls/:pullRef/comments/:commentId/replies",
         "origin": "https://${GITHUB_API}",
         "auth": {
           "scheme": "bearer",

--- a/defaultFilters/github.json
+++ b/defaultFilters/github.json
@@ -2142,9 +2142,21 @@
         "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
       },
       {
+        "//": "create a reaction for a pull request comment",
+        "method": "POST",
+        "path": "/repos/:name/:repo/pulls/comments/:commentId/reactions",
+        "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+      },
+      {
         "//": "create a pull request review",
         "method": "POST",
         "path": "/repos/:name/:repo/pulls/:pullRef/reviews",
+        "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+      },
+      {
+        "//": "reply to a review comment",
+        "method": "POST",
+        "path": "/repos/:name/:repo/pulls/:pullRef/comments/:commentId/replies",
         "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
       },
       {


### PR DESCRIPTION
#### What does this PR do?

Updates the allowlist and sample templates to include calls to the reaction endpoint in GitHub to create a reaction. Required as part of the AI Fix work, as a reaction is added to a PR comment in response to a user's prompt for an AI fix.

Target integrations:

- GitHub
- GitHub Cloud App
- GitHub Server App
- GitHub Enterprise

