### PR TITLE
fix: add rest prefix to a copy of existing suspect bitbucket-server-agent rules [SCM-1313][ARI-987]

### DIFF
--- a/defaultFilters/bitbucket-server-bearer-auth.json
+++ b/defaultFilters/bitbucket-server-bearer-auth.json
@@ -814,7 +814,7 @@
       "origin": "https://${BITBUCKET}",
       "auth": {
         "scheme": "bearer",
-        "token": "${BITBUCKET_PAT}" 
+        "token": "${BITBUCKET_PAT}"
       }
     },
     {
@@ -1087,6 +1087,56 @@
       "//": "resolve a pull request comment",
       "method": "POST",
       "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId/resolve",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
+    },
+    {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
+    },
+    {
+      "//": "update a general pull request comment",
+      "method": "PUT",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
+    },
+    {
+      "//": "get a general pull request comment",
+      "method": "GET",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
+    },
+    {
+      "//": "create an inline pull request comment",
+      "method": "POST",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/inline-comments",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
+    },
+    {
+      "//": "resolve a pull request comment",
+      "method": "POST",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId/resolve",
       "origin": "https://${BITBUCKET_API}",
       "auth": {
         "scheme": "bearer",

--- a/defaultFilters/bitbucket-server.json
+++ b/defaultFilters/bitbucket-server.json
@@ -1202,6 +1202,61 @@
         }
       },
       {
+        "//": "create a general pull request comment",
+        "method": "POST",
+        "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+        "origin": "https://${BITBUCKET_API}",
+        "auth": {
+          "scheme": "basic",
+          "username": "${BITBUCKET_USERNAME}",
+          "password": "${BITBUCKET_PASSWORD}"
+        }
+      },
+      {
+        "//": "update a general pull request comment",
+        "method": "PUT",
+        "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+        "origin": "https://${BITBUCKET_API}",
+        "auth": {
+          "scheme": "basic",
+          "username": "${BITBUCKET_USERNAME}",
+          "password": "${BITBUCKET_PASSWORD}"
+        }
+      },
+      {
+        "//": "get a general pull request comment",
+        "method": "GET",
+        "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+        "origin": "https://${BITBUCKET_API}",
+        "auth": {
+          "scheme": "basic",
+          "username": "${BITBUCKET_USERNAME}",
+          "password": "${BITBUCKET_PASSWORD}"
+        }
+      },
+      {
+        "//": "create an inline pull request comment",
+        "method": "POST",
+        "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/inline-comments",
+        "origin": "https://${BITBUCKET_API}",
+        "auth": {
+          "scheme": "basic",
+          "username": "${BITBUCKET_USERNAME}",
+          "password": "${BITBUCKET_PASSWORD}"
+        }
+      },
+      {
+        "//": "resolve a pull request comment",
+        "method": "POST",
+        "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId/resolve",
+        "origin": "https://${BITBUCKET_API}",
+        "auth": {
+          "scheme": "basic",
+          "username": "${BITBUCKET_USERNAME}",
+          "password": "${BITBUCKET_PASSWORD}"
+        }
+      },
+      {
         "//": "used to validate credentials",
         "method": "GET",
         "path": "/rest/api/1.0/projects/:project/repos/:repo/permissions/search",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adds a copy of existing broker rules with missing `/rest/api/1.0` for comment routes.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?

I've yet to confirm if these routes are necessary, but in the interest of time-to-fix, this will add the missing prefixes separately, and I'll follow up to cleanup the old rules.

#### Screenshots


#### Additional questions
