### PR TITLE
fix: add rest prefix to a copy of existing suspect bitbucket-server-a…

### DIFF
--- a/client-templates/bitbucket-server-bearer-auth/accept.json.sample
+++ b/client-templates/bitbucket-server-bearer-auth/accept.json.sample
@@ -1094,6 +1094,56 @@
       }
     },
     {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
+    },
+    {
+      "//": "update a general pull request comment",
+      "method": "PUT",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
+    },
+    {
+      "//": "get a general pull request comment",
+      "method": "GET",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
+    },
+    {
+      "//": "create an inline pull request comment",
+      "method": "POST",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/inline-comments",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
+    },
+    {
+      "//": "resolve a pull request comment",
+      "method": "POST",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId/resolve",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
+    },
+    {
       "//": "used to validate credentials",
       "method": "GET",
       "path": "/rest/api/1.0/projects/:project/repos/:repo/permissions/search",

--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -1202,6 +1202,61 @@
       }
     },
     {
+      "//": "create a general pull request comment",
+      "method": "POST",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+      "origin": "https://${BITBUCKET_API}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+        }
+      },
+      {
+        "//": "update a general pull request comment",
+        "method": "PUT",
+        "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+        "origin": "https://${BITBUCKET_API}",
+        "auth": {
+          "scheme": "basic",
+          "username": "${BITBUCKET_USERNAME}",
+          "password": "${BITBUCKET_PASSWORD}"
+        }
+      },
+      {
+        "//": "get a general pull request comment",
+        "method": "GET",
+        "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+        "origin": "https://${BITBUCKET_API}",
+        "auth": {
+          "scheme": "basic",
+          "username": "${BITBUCKET_USERNAME}",
+          "password": "${BITBUCKET_PASSWORD}"
+        }
+      },
+      {
+        "//": "create an inline pull request comment",
+        "method": "POST",
+        "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/inline-comments",
+        "origin": "https://${BITBUCKET_API}",
+        "auth": {
+          "scheme": "basic",
+          "username": "${BITBUCKET_USERNAME}",
+          "password": "${BITBUCKET_PASSWORD}"
+        }
+      },
+      {
+        "//": "resolve a pull request comment",
+        "method": "POST",
+        "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId/resolve",
+        "origin": "https://${BITBUCKET_API}",
+        "auth": {
+          "scheme": "basic",
+          "username": "${BITBUCKET_USERNAME}",
+          "password": "${BITBUCKET_PASSWORD}"
+        }
+      },
+    {
       "//": "used to validate credentials",
       "method": "GET",
       "path": "/rest/api/1.0/projects/:project/repos/:repo/permissions/search",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

What does this PR do?
Adds a copy of existing broker rules with missing /rest/api/1.0 for comment routes in accept.json.sample for legacy broker.

Where should the reviewer start?
How should this be manually tested?
Any background context you want to provide?
I've yet to confirm if these routes are necessary, but in the interest of time-to-fix, this will add the missing prefixes separately, clean up to follow by @mfren 

Screenshots
Additional questions