### PR TITLE
chore(gitlab): allow backstage-catalog-info.yaml

### DIFF
--- a/defaultFilters/apprisk/gitlab.json
+++ b/defaultFilters/apprisk/gitlab.json
@@ -42,6 +42,12 @@
     "origin": "https://${GITLAB}"
   },
   {
+    "//": "used to retrieve organization context from backstage-catalog-info.yaml",
+    "method": "GET",
+    "path": "/api/v4/projects/:project/repository/files/backstage-catalog-info.yaml/raw",
+    "origin": "https://${GITLAB}"
+  },
+  {
     "//": "get metadata",
     "method": "GET",
     "path": "/api/v4/metadata",

--- a/defaultFilters/bitbucket-server-bearer-auth.json
+++ b/defaultFilters/bitbucket-server-bearer-auth.json
@@ -1097,7 +1097,7 @@
       "//": "create a general pull request comment",
       "method": "POST",
       "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
-      "origin": "https://${BITBUCKET_API}",
+      "origin": "https://${BITBUCKET}",
       "auth": {
         "scheme": "bearer",
         "token": "${BITBUCKET_PAT}"
@@ -1107,7 +1107,7 @@
       "//": "update a general pull request comment",
       "method": "PUT",
       "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
-      "origin": "https://${BITBUCKET_API}",
+      "origin": "https://${BITBUCKET}",
       "auth": {
         "scheme": "bearer",
         "token": "${BITBUCKET_PAT}"
@@ -1117,7 +1117,7 @@
       "//": "get a general pull request comment",
       "method": "GET",
       "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
-      "origin": "https://${BITBUCKET_API}",
+      "origin": "https://${BITBUCKET}",
       "auth": {
         "scheme": "bearer",
         "token": "${BITBUCKET_PAT}"
@@ -1127,7 +1127,7 @@
       "//": "create an inline pull request comment",
       "method": "POST",
       "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/inline-comments",
-      "origin": "https://${BITBUCKET_API}",
+      "origin": "https://${BITBUCKET}",
       "auth": {
         "scheme": "bearer",
         "token": "${BITBUCKET_PAT}"
@@ -1137,7 +1137,7 @@
       "//": "resolve a pull request comment",
       "method": "POST",
       "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId/resolve",
-      "origin": "https://${BITBUCKET_API}",
+      "origin": "https://${BITBUCKET}",
       "auth": {
         "scheme": "bearer",
         "token": "${BITBUCKET_PAT}"

--- a/defaultFilters/bitbucket-server.json
+++ b/defaultFilters/bitbucket-server.json
@@ -1205,7 +1205,7 @@
         "//": "create a general pull request comment",
         "method": "POST",
         "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
-        "origin": "https://${BITBUCKET_API}",
+        "origin": "https://${BITBUCKET}",
         "auth": {
           "scheme": "basic",
           "username": "${BITBUCKET_USERNAME}",
@@ -1216,7 +1216,7 @@
         "//": "update a general pull request comment",
         "method": "PUT",
         "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
-        "origin": "https://${BITBUCKET_API}",
+        "origin": "https://${BITBUCKET}",
         "auth": {
           "scheme": "basic",
           "username": "${BITBUCKET_USERNAME}",
@@ -1227,7 +1227,7 @@
         "//": "get a general pull request comment",
         "method": "GET",
         "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
-        "origin": "https://${BITBUCKET_API}",
+        "origin": "https://${BITBUCKET}",
         "auth": {
           "scheme": "basic",
           "username": "${BITBUCKET_USERNAME}",
@@ -1238,7 +1238,7 @@
         "//": "create an inline pull request comment",
         "method": "POST",
         "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/inline-comments",
-        "origin": "https://${BITBUCKET_API}",
+        "origin": "https://${BITBUCKET}",
         "auth": {
           "scheme": "basic",
           "username": "${BITBUCKET_USERNAME}",
@@ -1249,7 +1249,7 @@
         "//": "resolve a pull request comment",
         "method": "POST",
         "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId/resolve",
-        "origin": "https://${BITBUCKET_API}",
+        "origin": "https://${BITBUCKET}",
         "auth": {
           "scheme": "basic",
           "username": "${BITBUCKET_USERNAME}",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Allows files called backstage-caytalog-info.yaml to be downloaded when using a broker with gitlab. Previously allowed catalog-info.yaml

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?
https://snyk.slack.com/archives/C04B9B08G2G/p1748437195315419

this endpoint uses /raw in the end so there is no other rule 

#### Screenshots


#### Additional questions
