### PR TITLE
chore(gitlab): allow backstage-catalog-info.yaml

### DIFF
--- a/defaultFilters/apprisk/gitlab.json
+++ b/defaultFilters/apprisk/gitlab.json
@@ -42,6 +42,12 @@
     "origin": "https://${GITLAB}"
   },
   {
+    "//": "used to retrieve organization context from backstage-catalog-info.yaml",
+    "method": "GET",
+    "path": "/api/v4/projects/:project/repository/files/backstage-catalog-info.yaml/raw",
+    "origin": "https://${GITLAB}"
+  },
+  {
     "//": "get metadata",
     "method": "GET",
     "path": "/api/v4/metadata",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Allows files called backstage-caytalog-info.yaml to be downloaded when using a broker with gitlab. Previously allowed catalog-info.yaml

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?
https://snyk.slack.com/archives/C04B9B08G2G/p1748437195315419

this endpoint uses /raw in the end so there is no other rule 

#### Screenshots


#### Additional questions
