### PR TITLE
fix: Override auth config if type is bitbucket-server and bearer auth

### DIFF
--- a/lib/hybrid-sdk/client/utils/connectionValidation.ts
+++ b/lib/hybrid-sdk/client/utils/connectionValidation.ts
@@ -38,7 +38,7 @@ export const validateConnection = async (config: ConnectionConfig) => {
         request as PostFilterPreparedRequest,
       );
       if (response && response.statusCode) {
-        passing = response.statusCode > 200 && response.statusCode < 300;
+        passing = response.statusCode >= 200 && response.statusCode < 300;
       }
       data.push({
         url: sanitisedUrl,


### PR DESCRIPTION
…AT has been configured

- [ ] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Override the validations auth config to use bearer auth if the connection type is `bitbucket-server` and `BITBUCKET_PAT` has been configured in the creds reference.