### PR TITLE
fix: use rest API prefix for bitbucket-server comment routes [SCM-1313]

### DIFF
--- a/client-templates/bitbucket-server-bearer-auth/accept.json.sample
+++ b/client-templates/bitbucket-server-bearer-auth/accept.json.sample
@@ -1046,8 +1046,8 @@
     {
       "//": "create a general pull request comment",
       "method": "POST",
-      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
-      "origin": "https://${BITBUCKET_API}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+      "origin": "https://${BITBUCKET}",
       "auth": {
         "scheme": "bearer",
         "token": "${BITBUCKET_PAT}"
@@ -1056,8 +1056,8 @@
     {
       "//": "update a general pull request comment",
       "method": "PUT",
-      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
-      "origin": "https://${BITBUCKET_API}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+      "origin": "https://${BITBUCKET}",
       "auth": {
         "scheme": "bearer",
         "token": "${BITBUCKET_PAT}"
@@ -1066,8 +1066,8 @@
     {
       "//": "get a general pull request comment",
       "method": "GET",
-      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
-      "origin": "https://${BITBUCKET_API}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+      "origin": "https://${BITBUCKET}",
       "auth": {
         "scheme": "bearer",
         "token": "${BITBUCKET_PAT}"
@@ -1076,8 +1076,8 @@
     {
       "//": "create an inline pull request comment",
       "method": "POST",
-      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/inline-comments",
-      "origin": "https://${BITBUCKET_API}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/inline-comments",
+      "origin": "https://${BITBUCKET}",
       "auth": {
         "scheme": "bearer",
         "token": "${BITBUCKET_PAT}"
@@ -1086,8 +1086,8 @@
     {
       "//": "resolve a pull request comment",
       "method": "POST",
-      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId/resolve",
-      "origin": "https://${BITBUCKET_API}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId/resolve",
+      "origin": "https://${BITBUCKET}",
       "auth": {
         "scheme": "bearer",
         "token": "${BITBUCKET_PAT}"

--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -1149,8 +1149,8 @@
     {
       "//": "create a general pull request comment",
       "method": "POST",
-      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
-      "origin": "https://${BITBUCKET_API}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
+      "origin": "https://${BITBUCKET}",
       "auth": {
         "scheme": "basic",
         "username": "${BITBUCKET_USERNAME}",
@@ -1160,8 +1160,8 @@
     {
       "//": "update a general pull request comment",
       "method": "PUT",
-      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
-      "origin": "https://${BITBUCKET_API}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+      "origin": "https://${BITBUCKET}",
       "auth": {
         "scheme": "basic",
         "username": "${BITBUCKET_USERNAME}",
@@ -1171,8 +1171,8 @@
     {
       "//": "get a general pull request comment",
       "method": "GET",
-      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
-      "origin": "https://${BITBUCKET_API}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
+      "origin": "https://${BITBUCKET}",
       "auth": {
         "scheme": "basic",
         "username": "${BITBUCKET_USERNAME}",
@@ -1182,8 +1182,8 @@
     {
       "//": "create an inline pull request comment",
       "method": "POST",
-      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/inline-comments",
-      "origin": "https://${BITBUCKET_API}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/inline-comments",
+      "origin": "https://${BITBUCKET}",
       "auth": {
         "scheme": "basic",
         "username": "${BITBUCKET_USERNAME}",
@@ -1193,8 +1193,8 @@
     {
       "//": "resolve a pull request comment",
       "method": "POST",
-      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId/resolve",
-      "origin": "https://${BITBUCKET_API}",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId/resolve",
+      "origin": "https://${BITBUCKET}",
       "auth": {
         "scheme": "basic",
         "username": "${BITBUCKET_USERNAME}",

--- a/defaultFilters/bitbucket-server-bearer-auth.json
+++ b/defaultFilters/bitbucket-server-bearer-auth.json
@@ -1046,56 +1046,6 @@
     {
       "//": "create a general pull request comment",
       "method": "POST",
-      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
-      "origin": "https://${BITBUCKET_API}",
-      "auth": {
-        "scheme": "bearer",
-        "token": "${BITBUCKET_PAT}"
-      }
-    },
-    {
-      "//": "update a general pull request comment",
-      "method": "PUT",
-      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
-      "origin": "https://${BITBUCKET_API}",
-      "auth": {
-        "scheme": "bearer",
-        "token": "${BITBUCKET_PAT}"
-      }
-    },
-    {
-      "//": "get a general pull request comment",
-      "method": "GET",
-      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
-      "origin": "https://${BITBUCKET_API}",
-      "auth": {
-        "scheme": "bearer",
-        "token": "${BITBUCKET_PAT}"
-      }
-    },
-    {
-      "//": "create an inline pull request comment",
-      "method": "POST",
-      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/inline-comments",
-      "origin": "https://${BITBUCKET_API}",
-      "auth": {
-        "scheme": "bearer",
-        "token": "${BITBUCKET_PAT}"
-      }
-    },
-    {
-      "//": "resolve a pull request comment",
-      "method": "POST",
-      "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId/resolve",
-      "origin": "https://${BITBUCKET_API}",
-      "auth": {
-        "scheme": "bearer",
-        "token": "${BITBUCKET_PAT}"
-      }
-    },
-    {
-      "//": "create a general pull request comment",
-      "method": "POST",
       "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
       "origin": "https://${BITBUCKET}",
       "auth": {

--- a/defaultFilters/bitbucket-server.json
+++ b/defaultFilters/bitbucket-server.json
@@ -1149,61 +1149,6 @@
       {
         "//": "create a general pull request comment",
         "method": "POST",
-        "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
-        "origin": "https://${BITBUCKET_API}",
-        "auth": {
-          "scheme": "basic",
-          "username": "${BITBUCKET_USERNAME}",
-          "password": "${BITBUCKET_PASSWORD}"
-        }
-      },
-      {
-        "//": "update a general pull request comment",
-        "method": "PUT",
-        "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
-        "origin": "https://${BITBUCKET_API}",
-        "auth": {
-          "scheme": "basic",
-          "username": "${BITBUCKET_USERNAME}",
-          "password": "${BITBUCKET_PASSWORD}"
-        }
-      },
-      {
-        "//": "get a general pull request comment",
-        "method": "GET",
-        "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId",
-        "origin": "https://${BITBUCKET_API}",
-        "auth": {
-          "scheme": "basic",
-          "username": "${BITBUCKET_USERNAME}",
-          "password": "${BITBUCKET_PASSWORD}"
-        }
-      },
-      {
-        "//": "create an inline pull request comment",
-        "method": "POST",
-        "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/inline-comments",
-        "origin": "https://${BITBUCKET_API}",
-        "auth": {
-          "scheme": "basic",
-          "username": "${BITBUCKET_USERNAME}",
-          "password": "${BITBUCKET_PASSWORD}"
-        }
-      },
-      {
-        "//": "resolve a pull request comment",
-        "method": "POST",
-        "path": "/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments/:commentId/resolve",
-        "origin": "https://${BITBUCKET_API}",
-        "auth": {
-          "scheme": "basic",
-          "username": "${BITBUCKET_USERNAME}",
-          "password": "${BITBUCKET_PASSWORD}"
-        }
-      },
-      {
-        "//": "create a general pull request comment",
-        "method": "POST",
         "path": "/rest/api/1.0/projects/:project/repos/:repo/pull-requests/:pullRequestId/comments",
         "origin": "https://${BITBUCKET}",
         "auth": {

--- a/test/unit/filters-and-interpolates.test.ts
+++ b/test/unit/filters-and-interpolates.test.ts
@@ -168,7 +168,7 @@ describe('filters and interpolates', () => {
 
       it('should allow creating a general pull request comment', () => {
         const url =
-          '/projects/test-org/repos/test-repo/pull-requests/1/comments';
+          '/rest/api/1.0/projects/test-org/repos/test-repo/pull-requests/1/comments';
 
         const filterResponse = filter({
           url,
@@ -191,7 +191,7 @@ describe('filters and interpolates', () => {
 
       it('should allow updating a general pull request comment', () => {
         const url =
-          '/projects/test-org/repos/test-repo/pull-requests/1/comments/12345';
+          '/rest/api/1.0/projects/test-org/repos/test-repo/pull-requests/1/comments/12345';
 
         const filterResponse = filter({
           url,
@@ -214,7 +214,7 @@ describe('filters and interpolates', () => {
 
       it('should allow getting a general pull request comment', () => {
         const url =
-          '/projects/test-org/repos/test-repo/pull-requests/1/comments/12345';
+          '/rest/api/1.0/projects/test-org/repos/test-repo/pull-requests/1/comments/12345';
 
         const filterResponse = filter({
           url,
@@ -237,7 +237,7 @@ describe('filters and interpolates', () => {
 
       it('should allow creating an inline pull request comment', () => {
         const url =
-          '/projects/test-org/repos/test-repo/pull-requests/1/inline-comments';
+          '/rest/api/1.0/projects/test-org/repos/test-repo/pull-requests/1/inline-comments';
 
         const filterResponse = filter({
           url,
@@ -260,7 +260,7 @@ describe('filters and interpolates', () => {
 
       it('should allow resolving a pull request comment', () => {
         const url =
-          '/projects/test-org/repos/test-repo/pull-requests/1/comments/12345/resolve';
+          '/rest/api/1.0/projects/test-org/repos/test-repo/pull-requests/1/comments/12345/resolve';
 
         const filterResponse = filter({
           url,
@@ -336,7 +336,7 @@ describe('filters and interpolates', () => {
 
       it('should allow creating a general pull request comment', () => {
         const url =
-          '/projects/test-org/repos/test-repo/pull-requests/1/comments';
+          '/rest/api/1.0/projects/test-org/repos/test-repo/pull-requests/1/comments';
 
         const filterResponse = filter({
           url,
@@ -359,7 +359,7 @@ describe('filters and interpolates', () => {
 
       it('should allow updating a general pull request comment', () => {
         const url =
-          '/projects/test-org/repos/test-repo/pull-requests/1/comments/12345';
+          '/rest/api/1.0/projects/test-org/repos/test-repo/pull-requests/1/comments/12345';
 
         const filterResponse = filter({
           url,
@@ -382,7 +382,7 @@ describe('filters and interpolates', () => {
 
       it('should allow getting a general pull request comment', () => {
         const url =
-          '/projects/test-org/repos/test-repo/pull-requests/1/comments/12345';
+          '/rest/api/1.0/projects/test-org/repos/test-repo/pull-requests/1/comments/12345';
 
         const filterResponse = filter({
           url,
@@ -405,7 +405,7 @@ describe('filters and interpolates', () => {
 
       it('should allow creating an inline pull request comment', () => {
         const url =
-          '/projects/test-org/repos/test-repo/pull-requests/1/inline-comments';
+          '/rest/api/1.0/projects/test-org/repos/test-repo/pull-requests/1/inline-comments';
 
         const filterResponse = filter({
           url,
@@ -428,7 +428,7 @@ describe('filters and interpolates', () => {
 
       it('should allow resolving a pull request comment', () => {
         const url =
-          '/projects/test-org/repos/test-repo/pull-requests/1/comments/12345/resolve';
+          '/rest/api/1.0/projects/test-org/repos/test-repo/pull-requests/1/comments/12345/resolve';
 
         const filterResponse = filter({
           url,


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Corrects/removes old comment rules for bitbucket server which assumed we were not making requests with the `/rest/api/1.0` prefix.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?

https://snyk.slack.com/archives/C06AUAGA53N/p1748628317339469

#### Screenshots


#### Additional questions
