### PR TITLE
chore: broker should error correctly if run without default.config.json

### DIFF
--- a/lib/hybrid-sdk/common/config/config.ts
+++ b/lib/hybrid-sdk/common/config/config.ts
@@ -18,7 +18,8 @@ export const setConfigKey = (key: string, value: unknown) => {
   config[key] = value;
 };
 
-export const findProjectRoot = (startDir: string): string | null => {
+
+export const findProjectRoot = (startDir: string): string => {
   let currentDir = startDir;
 
   while (currentDir !== '/') {
@@ -31,7 +32,11 @@ export const findProjectRoot = (startDir: string): string | null => {
     currentDir = path.dirname(currentDir);
   }
 
-  return null;
+  const errorMessage = 'Error: config.default.json is missing, please ensure the file exists when running the broker.';
+  logger.error(errorMessage);
+  const refError = new ReferenceError(errorMessage);
+  refError['code'] = 'MISSING_DEFAULT_CONFIG';
+  throw refError;
 };
 
 export const findFactoryRoot = (startDir: string): string | null => {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Returns an error if the broker is run without `config.default.json` to prevent confusion when the broker is misconfigured at run time. 