### PR TITLE
feat: add repository based commit status rules for bitbucket server

### DIFF
--- a/client-templates/bitbucket-server-bearer-auth/accept.json.sample
+++ b/client-templates/bitbucket-server-bearer-auth/accept.json.sample
@@ -1132,6 +1132,16 @@
         "scheme": "bearer",
         "token": "${BITBUCKET_PAT}"
       }
+    },
+    {
+      "//": "create repository based commit status",
+      "method": "POST",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/commits/:commitId/builds",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
     }
   ]
 }

--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -1244,6 +1244,17 @@
         "username": "${BITBUCKET_USERNAME}",
         "password": "${BITBUCKET_PASSWORD}"
       }
+    },
+    {
+      "//": "create repository based commit status",
+      "method": "POST",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/commits/:commitId/builds",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
     }
   ]
 }

--- a/defaultFilters/bitbucket-server-bearer-auth.json
+++ b/defaultFilters/bitbucket-server-bearer-auth.json
@@ -1132,6 +1132,17 @@
         "scheme": "bearer",
         "token": "${BITBUCKET_PAT}"
       }
+    },
+    {
+      "//": "create repository based commit status",
+      "method": "POST",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/commits/:commitId/builds",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
     }
   ]
 }

--- a/defaultFilters/bitbucket-server.json
+++ b/defaultFilters/bitbucket-server.json
@@ -1244,6 +1244,16 @@
           "username": "${BITBUCKET_USERNAME}",
           "password": "${BITBUCKET_PASSWORD}"
         }
+      },
+      {
+        "//": "create repository based commit status",
+        "method": "POST",
+        "path": "/rest/api/1.0/projects/:project/repos/:repo/commits/:commitId/builds",
+        "origin": "https://${BITBUCKET}",
+        "auth": {
+          "scheme": "bearer",
+          "token": "${BITBUCKET_PAT}"
+        }
       }
     ]
   }

--- a/test/unit/filters-and-interpolates.test.ts
+++ b/test/unit/filters-and-interpolates.test.ts
@@ -326,6 +326,29 @@ describe('filters and interpolates', () => {
         );
         expect(result.url).toMatch(url);
       });
+
+      it('should allow creating repository based commit status', () => {
+        const url =
+          '/rest/api/1.0/projects/test-org/repos/test-repo/commits/12345/builds';
+
+        const filterResponse = filter({
+          url,
+          method: 'POST',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseAsRule = filterResponse as Rule;
+        const result = getInterpolatedRequest(
+          null,
+          filterResponseAsRule,
+          {
+            url,
+            method: 'POST',
+          },
+          {},
+          {},
+        );
+        expect(result.url).toMatch(url);
+      });
     });
 
     describe('for bitbucket server bearer auth private filters', () => {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

adds rules to support repository based commit statuses for bitbucket server

https://developer.atlassian.com/server/bitbucket/reference/api-changelog/#new-rich-build-status

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
