### PR TITLE
fix: broker server should start without config.default.json

### DIFF
--- a/lib/hybrid-sdk/common/config/config.ts
+++ b/lib/hybrid-sdk/common/config/config.ts
@@ -18,7 +18,7 @@ export const setConfigKey = (key: string, value: unknown) => {
   config[key] = value;
 };
 
-export const findProjectRoot = (startDir: string): string => {
+export const findProjectRoot = (startDir: string, isServerMode = false): string => {
   let currentDir = startDir;
 
   while (currentDir !== '/') {
@@ -29,6 +29,11 @@ export const findProjectRoot = (startDir: string): string => {
     }
 
     currentDir = path.dirname(currentDir);
+  }
+
+  // In server mode, don't require config.default.json
+  if (isServerMode) {
+    return startDir;
   }
 
   const errorMessage =
@@ -78,14 +83,14 @@ export const findPluginFolder = async (
   return null;
 };
 
-export const loadBrokerConfig = async (localConfigForTest?) => {
+export const loadBrokerConfig = async (localConfigForTest?, isServerMode = false) => {
   dotenv.config({
     path: path.join(process.cwd(), '.env'),
   });
   try {
     const localConfig = localConfigForTest
       ? localConfigForTest
-      : loadConfig(findProjectRoot(__dirname) ?? process.cwd());
+      : loadConfig(findProjectRoot(__dirname, isServerMode) ?? process.cwd());
     expand(process.env);
     config = Object.assign({}, camelify(localConfig), camelify(process.env));
     // for each in config.brokerClientConfiguration.common.default check if process env exist and if it does,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -33,8 +33,8 @@ export const app = async ({ port = 7341, client = false, config }) => {
       process.env.SERVICE_ENV = process.env.SERVICE_ENV || 'universal';
     }
 
-    // loading it "manually" simplifies lot testing
-    await loadBrokerConfig();
+    const isServerMode = !client;
+    await loadBrokerConfig(undefined, isServerMode);
     const globalConfig = getConfig();
     const localConfig = Object.assign({}, globalConfig, config) as Record<
       string,


### PR DESCRIPTION
This fixes a bug where the broker server fails to start if config.default.json is not present