### PR TITLE
chore: add gitlab filter rules for pr agent fix [TREX-2265]

### DIFF
--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -1635,6 +1635,24 @@
       "method": "GET",
       "path": "/api/v4/projects/:project/merge_requests/:pullRef/diffs",
       "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "react to an inline MR comment (note)",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/merge_requests/:pullRef/notes/:note/award_emoji",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "reply to an inline MR comment (discussion)",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/merge_requests/:pullRef/discussions/:discussion/notes",
+      "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "create commit to apply a fix",
+      "method": "POST",
+      "path": "/api/v4/projects/:project/repository/commits",
+      "origin": "https://${GITLAB}"
     }
   ]
 }

--- a/defaultFilters/gitlab.json
+++ b/defaultFilters/gitlab.json
@@ -49,7 +49,7 @@
         "path": "/api/v4/projects/:project/repository/tree",
         "origin": "https://${GITLAB}"
       },
-  
+
       {
         "//": "used to determine the full dependency tree",
         "method": "GET",
@@ -170,7 +170,7 @@
         "path": "/api/v4/projects/:project/repository/files*%2FPipfile",
         "origin": "https://${GITLAB}"
       },
-  
+
       {
         "//": "used to determine the full dependency tree",
         "method": "GET",
@@ -554,7 +554,7 @@
           }
         ]
       },
-  
+
       {
         "//": "used to create manifest file",
         "method": "POST",
@@ -1485,7 +1485,7 @@
           }
         ]
       },
-  
+
       {
         "//": "allow webhooks to be added, to allow commits to be checked by Snyk. Rules for what is sent to Snyk are controlled in the `public` accept filters",
         "method": "POST",
@@ -1634,6 +1634,24 @@
         "//": "get merge request files and diffs",
         "method": "GET",
         "path": "/api/v4/projects/:project/merge_requests/:pullRef/diffs",
+        "origin": "https://${GITLAB}"
+      },
+      {
+        "//": "react to an inline MR comment (note)",
+        "method": "POST",
+        "path": "/api/v4/projects/:project/merge_requests/:pullRef/notes/:note/award_emoji",
+        "origin": "https://${GITLAB}"
+      },
+      {
+        "//": "reply to an inline MR comment (discussion)",
+        "method": "POST",
+        "path": "/api/v4/projects/:project/merge_requests/:pullRef/discussions/:discussion/notes",
+        "origin": "https://${GITLAB}"
+      },
+      {
+        "//": "create commit",
+        "method": "POST",
+        "path": "/api/v4/projects/:project/repository/commits",
         "origin": "https://${GITLAB}"
       }
     ]

--- a/test/unit/filters-and-interpolates.test.ts
+++ b/test/unit/filters-and-interpolates.test.ts
@@ -982,6 +982,72 @@ describe('filters and interpolates', () => {
         );
         expect(result.url).toMatch(url);
       });
+
+      it('should allow reacting to an inline comment', () => {
+        const url = '/api/v4/projects/123/merge_requests/1/notes/1/award_emoji';
+
+        const filterResponse = filter({
+          url,
+          method: 'POST',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseAsRule = filterResponse as Rule;
+        const result = getInterpolatedRequest(
+          null,
+          filterResponseAsRule,
+          {
+            url,
+            method: 'GET',
+          },
+          {},
+          {},
+        );
+        expect(result.url).toMatch(url);
+      });
+
+      it('should allow replying to an inline comment', () => {
+        const url = '/api/v4/projects/123/merge_requests/1/discussions/1/notes';
+
+        const filterResponse = filter({
+          url,
+          method: 'POST',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseAsRule = filterResponse as Rule;
+        const result = getInterpolatedRequest(
+          null,
+          filterResponseAsRule,
+          {
+            url,
+            method: 'GET',
+          },
+          {},
+          {},
+        );
+        expect(result.url).toMatch(url);
+      });
+
+      it('should allow commiting a fix', () => {
+        const url = '/api/v4/projects/123/repository/commits';
+
+        const filterResponse = filter({
+          url,
+          method: 'POST',
+        });
+        expect(filterResponse).not.toEqual(false);
+        const filterResponseAsRule = filterResponse as Rule;
+        const result = getInterpolatedRequest(
+          null,
+          filterResponseAsRule,
+          {
+            url,
+            method: 'GET',
+          },
+          {},
+          {},
+        );
+        expect(result.url).toMatch(url);
+      });
     });
   });
 


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

- Adds Gitlab filter rules to support Agent Fix in merge requests


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
