### PR TITLE
fix(circleci): use ubuntu:25.04 for edge images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1058,7 +1058,7 @@ workflows:
             - team-hybrid-snyk
           requires:
             - Scan repository for secrets
-          additional_arguments: "--build-arg BASE_IMAGE=ubuntu:24.10"
+          additional_arguments: "--build-arg BASE_IMAGE=ubuntu:25.04"
           dockerfile: dockerfiles/base/Dockerfile
           nodejs_cycle: "23"
           project_name: broker-edge


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Support for Ubuntu:24.10 ended on 10. July 2025. This PR updates the Ubuntu for edge images to 25.04.

Support matrix: https://endoflife.date/ubuntu

