### PR TITLE
chore(docker): clean up cache after upgrading npm to latest

### DIFF
--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -68,6 +68,7 @@ RUN <<EOF
     npm --version
     # update npm to the latest version globally
     npm install --global npm@latest
+    npm cache clean --force
     npm --version
     # remove non-needed packages and clean apt cache
     apt remove --assume-yes \


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR cleans up NPM cache after upgrading NPM to the latest version when building base image. It can save ca. 28MB in the final image.

```
root@7b6ea5e3f86d:~/.npm# du -sh _cacache/
28M	_cacache/
```

