### PR TITLE
fix: make chunked responses set the content-length if body is mutated

### DIFF
--- a/lib/hybrid-sdk/responseSenders.ts
+++ b/lib/hybrid-sdk/responseSenders.ts
@@ -86,6 +86,7 @@ export class HybridResponseHandler {
     if (this.config.RES_BODY_URL_SUB && isJson(response.headers)) {
       const replaced = replaceUrlPartialChunk(response.body, null, this.config);
       response.body = replaced.newChunk;
+      response.headers['content-length'] = response.body.length;
     }
     const status = (response && response.statusCode) || 500;
     logResponse(logContext, status, response, this.config);


### PR DESCRIPTION
As it stands now, the Broker sometiems rewrites the body. When it does, we don't also set the content-length to match the body.
This can be potentially problematic.