### PR TITLE
fix: add DELETE method for branch deletion in ghe

### DIFF
--- a/client-templates/github-enterprise/accept.json.sample
+++ b/client-templates/github-enterprise/accept.json.sample
@@ -384,6 +384,12 @@
       "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
     },
     {
+      "//": "used to delete a branch",
+      "method": "DELETE",
+      "path": "/repos/:user/:repo/git/refs/:branch",
+      "origin": "https://${GITHUB_TOKEN}@${GITHUB_API}"
+    },
+    {
       "//": "used to get status checks on a branch",
       "method": "GET",
       "path": "/repos/:user/:repo/branches/:branch/protection/required_status_checks/contexts",


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

We've seen issues related to accept rules when it comes to deleting branches on ghe clients. Example [here](https://app.datadoghq.com/logs?query=%40actingOrgPublicId%3A98f97f89-fa22-4859-a320-b46ed26a86f6%20%22delete%22&agg_m=%40request_duration&agg_m_source=base&agg_t=max&analyticsOptions=%5B%22line%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&clustering_pattern_field_path=%40url&cols=host%2Cservice%2C%40http_user_agent%2C%40request_duration%2C%40method%2C%40url&event=AwAAAZvZc2ms9AhkfQAAABhBWnZaYzNjTkFBQzNvbEJ0RW0tN3VnQU4AAAAkZjE5YmQ5NzMtOTQyNS00ZjQwLWFmYzMtZjY5YmJlNjE0Y2RlAAF-Pw&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1768311737375&to_ts=1769607737375&live=true)

Example error message 
```
{"message":"blocked","reason":"[Websocket Flow][Blocked Request] Does not match any accept rule","url":"/repos/BCBSNC-Git/checkmarx-bcbsnc-web/git/refs/heads%2Fsnyk-fix-936792ffbb98fdfd7bf5784d73d7ed1a"}
```