### PR TITLE
chore: add new websocket event handling

### DIFF
--- a/lib/hybrid-sdk/client/metrics/client.ts
+++ b/lib/hybrid-sdk/client/metrics/client.ts
@@ -84,4 +84,13 @@ export interface Client {
    * round-trip time in seconds.
    */
   recordPingLatency(durationSeconds: number): void;
+
+  /**
+   * Increment broker.client.ws.lifecycle.total for websocket lifecycle events.
+   * event: a human-readable lifecycle label, e.g.:
+   *   'connection_lost', 'connection_ended', 'connection_destroyed',
+   *   'connection_timed_out', 'connection_error', 'server_requested_close'.
+   * role: 'primary' | 'secondary'.
+   */
+  recordWebsocketLifecycleEvent(event: string, role: string): void;
 }

--- a/lib/hybrid-sdk/client/metrics/noopClient.ts
+++ b/lib/hybrid-sdk/client/metrics/noopClient.ts
@@ -24,4 +24,5 @@ export class NoopClient implements Client {
   incrementInflight(): void {}
   decrementInflight(): void {}
   recordPingLatency(): void {}
+  recordWebsocketLifecycleEvent(): void {}
 }

--- a/lib/hybrid-sdk/client/metrics/otelClient.ts
+++ b/lib/hybrid-sdk/client/metrics/otelClient.ts
@@ -61,6 +61,7 @@ export class OtelClient implements Client {
   private readonly upstreamResponseBytesHistogram: Histogram;
   private readonly inflightRequestsCounter: UpDownCounter;
   private readonly pingLatencyHistogram: Histogram;
+  private readonly wsLifecycleCounter: Counter;
 
   constructor(config: OtelClientConfig) {
     const reader =
@@ -253,6 +254,15 @@ export class OtelClient implements Client {
         },
       },
     );
+
+    this.wsLifecycleCounter = meter.createCounter(
+      'broker.client.ws.lifecycle.total',
+      {
+        description:
+          'Websocket lifecycle events by type (connection_lost, connection_ended, connection_destroyed, connection_timed_out, connection_error, server_requested_close)',
+        valueType: ValueType.INT,
+      },
+    );
   }
 
   // --- Existing ---
@@ -349,5 +359,9 @@ export class OtelClient implements Client {
 
   recordPingLatency(durationSeconds: number): void {
     this.pingLatencyHistogram.record(durationSeconds);
+  }
+
+  recordWebsocketLifecycleEvent(event: string, role: string): void {
+    this.wsLifecycleCounter.add(1, { event, role });
   }
 }

--- a/lib/hybrid-sdk/client/socket.ts
+++ b/lib/hybrid-sdk/client/socket.ts
@@ -10,7 +10,7 @@ import {
 import { identifyHandler } from './socketHandlers/identifyHandler';
 import { errorHandler } from './socketHandlers/errorHandler';
 import { openHandler } from './socketHandlers/openHandler';
-import { closeHandler } from './socketHandlers/closeHandler';
+import { reportWebSocketClosureEvent } from './socketHandlers/reportWebSocketClosureEvent';
 import { IdentifyingMetadata, Role, WebSocketConnection } from './types/client';
 import { requestHandler } from './socketHandlers/requestHandler';
 import { chunkHandler } from './socketHandlers/chunkHandler';
@@ -273,6 +273,7 @@ export const createWebSocket = (
   }
 
   websocket.on('incoming::error', (e) => {
+    metricsClient.recordWebsocketLifecycleEvent('connection_error', identifyingMetadata.role);
     websocket.emit('error', { type: e.type, description: e.description });
   });
 
@@ -325,9 +326,9 @@ export const createWebSocket = (
   websocket.on('notification', notificationHandler);
   websocket.on('error', errorHandler);
 
-  websocket.on('open', () =>
-    openHandler(websocket, localClientOps, identifyingMetadata, metricsClient),
-  );
+  websocket.on('open', () => {
+    openHandler(websocket, localClientOps, identifyingMetadata, metricsClient);
+  });
 
   websocket.on('service', serviceHandler);
 
@@ -336,7 +337,23 @@ export const createWebSocket = (
   });
 
   websocket.on('close', () => {
-    closeHandler(websocket, localClientOps, identifyingMetadata, metricsClient);
+    reportWebSocketClosureEvent(websocket, localClientOps, identifyingMetadata, metricsClient, 'connection_lost');
+  });
+
+  websocket.on('end', () => {
+    reportWebSocketClosureEvent(websocket, localClientOps, identifyingMetadata, metricsClient, 'connection_ended');
+  });
+
+  websocket.on('destroy', () => {
+    reportWebSocketClosureEvent(websocket, localClientOps, identifyingMetadata, metricsClient, 'connection_destroyed');
+  });
+
+  websocket.on('timeout', () => {
+    reportWebSocketClosureEvent(websocket, localClientOps, identifyingMetadata, metricsClient, 'connection_timed_out');
+  });
+
+  websocket.on('closing', () => {
+    reportWebSocketClosureEvent(websocket, localClientOps, identifyingMetadata, metricsClient, 'server_requested_close');
   });
 
   return websocket;

--- a/lib/hybrid-sdk/client/socketHandlers/reportWebSocketClosureEvent.ts
+++ b/lib/hybrid-sdk/client/socketHandlers/reportWebSocketClosureEvent.ts
@@ -3,26 +3,34 @@ import { log as logger } from '../../../logs/logger';
 import { WebSocketConnection } from '../types/client';
 import { Client } from '../metrics/client';
 
-export const closeHandler = (
+export const reportWebSocketClosureEvent = (
   websocket: WebSocketConnection,
   clientOps: LoadedClientOpts,
   identifyingMetadata,
   metricsClient: Client,
+  reason: string,
 ) => {
   // default duration of -1 so that it is obvious if this misbehaves
   let durationMs = -1;
   if (websocket.connectionStartTime) {
     durationMs = Date.now() - websocket.connectionStartTime;
   }
+
+  metricsClient.recordWebsocketLifecycleEvent(
+    reason,
+    identifyingMetadata.role,
+  );
+
   logger.warn(
     {
       url: clientOps.config.brokerServerUrl,
       token: clientOps.config.universalBrokerEnabled
         ? identifyingMetadata.integrationId
         : clientOps.config.brokerToken,
+      reason,
       durationMs,
     },
-    'Websocket connection to the broker server was closed.',
+    `Websocket connection event: ${reason}`,
   );
 
   if (durationMs >= 0) {

--- a/test/unit/client/metrics/metricsClient.test.ts
+++ b/test/unit/client/metrics/metricsClient.test.ts
@@ -158,6 +158,7 @@ describe('client/metrics', () => {
       ['incrementInflight', []],
       ['decrementInflight', []],
       ['recordPingLatency', [0.05]],
+      ['recordWebsocketLifecycleEvent', ['connection_lost', 'primary']],
     ];
 
     it.each(noopMethods)('%s does not throw', (method, args) => {
@@ -197,6 +198,26 @@ describe('client/metrics', () => {
         ...metric,
         dataPoints: metric.dataPoints as any[],
       };
+    }
+
+    async function findLifecycleDataPoints() {
+      const metric = await findMetric('broker.client.ws.lifecycle.total');
+      expect(metric).toBeDefined();
+      return metric!.dataPoints;
+    }
+
+    function expectDataPoint(
+      dataPoints: any[],
+      attrs: Record<string, string>,
+      expectedValue: number,
+    ) {
+      const match = dataPoints.find((dp) =>
+        Object.entries(attrs).every(
+          ([key, val]) => dp.attributes[key] === val,
+        ),
+      );
+      expect(match).toBeDefined();
+      expect(match?.value).toBe(expectedValue);
     }
 
     it('records broker.client.initialized', async () => {
@@ -417,6 +438,47 @@ describe('client/metrics', () => {
       expect(metric).toBeDefined();
       expect(metric!.dataPointType).toBe(DataPointType.HISTOGRAM);
       expect(metric!.dataPoints).toHaveLength(1);
+    });
+
+    it('records broker.client.ws.lifecycle.total with event and role attributes', async () => {
+      client.recordWebsocketLifecycleEvent('connection_lost', 'primary');
+      const metric = await findMetric('broker.client.ws.lifecycle.total');
+      expect(metric).toBeDefined();
+      expect(metric!.dataPointType).toBe(DataPointType.SUM);
+      expect(metric!.dataPoints[0].value).toBe(1);
+      expect(metric!.dataPoints[0].attributes['event']).toBe(
+        'connection_lost',
+      );
+      expect(metric!.dataPoints[0].attributes['role']).toBe('primary');
+    });
+
+    it('tracks lifecycle events per event type independently', async () => {
+      client.recordWebsocketLifecycleEvent('connection_lost', 'primary');
+      client.recordWebsocketLifecycleEvent('connection_timed_out', 'primary');
+      client.recordWebsocketLifecycleEvent('connection_error', 'primary');
+
+      const dataPoints = await findLifecycleDataPoints();
+      expectDataPoint(dataPoints, { event: 'connection_lost' }, 1);
+      expectDataPoint(dataPoints, { event: 'connection_timed_out' }, 1);
+      expectDataPoint(dataPoints, { event: 'connection_error' }, 1);
+    });
+
+    it('tracks lifecycle events per role independently', async () => {
+      client.recordWebsocketLifecycleEvent('connection_lost', 'primary');
+      client.recordWebsocketLifecycleEvent('connection_lost', 'secondary');
+
+      const dataPoints = await findLifecycleDataPoints();
+      expectDataPoint(dataPoints, { event: 'connection_lost', role: 'primary' }, 1);
+      expectDataPoint(dataPoints, { event: 'connection_lost', role: 'secondary' }, 1);
+    });
+
+    it('accumulates repeated lifecycle events', async () => {
+      client.recordWebsocketLifecycleEvent('connection_destroyed', 'primary');
+      client.recordWebsocketLifecycleEvent('connection_destroyed', 'primary');
+      client.recordWebsocketLifecycleEvent('connection_destroyed', 'primary');
+
+      const dataPoints = await findLifecycleDataPoints();
+      expectDataPoint(dataPoints, { event: 'connection_destroyed' }, 3);
     });
 
     it('rename view produces broker.nodejs.eventloop.delay.p99', async () => {

--- a/test/unit/client/socket.test.ts
+++ b/test/unit/client/socket.test.ts
@@ -59,7 +59,7 @@ jest.mock('../../../lib/hybrid-sdk/client/socketHandlers/openHandler', () => ({
   openHandler: jest.fn(),
 }));
 
-jest.mock('../../../lib/hybrid-sdk/client/socketHandlers/closeHandler', () => ({
+jest.mock('../../../lib/hybrid-sdk/client/socketHandlers/reportWebSocketClosureEvent', () => ({
   closeHandler: jest.fn(),
 }));
 

--- a/test/unit/client/socketHandlers/closeHandler.test.ts
+++ b/test/unit/client/socketHandlers/closeHandler.test.ts
@@ -1,4 +1,4 @@
-import { closeHandler } from '../../../../lib/hybrid-sdk/client/socketHandlers/closeHandler';
+import { reportWebSocketClosureEvent } from '../../../../lib/hybrid-sdk/client/socketHandlers/reportWebSocketClosureEvent';
 import { log as logger } from '../../../../lib/logs/logger';
 import { WebSocketConnection } from '../../../../lib/hybrid-sdk/client/types/client';
 import { LoadedClientOpts } from '../../../../lib/hybrid-sdk/common/types/options';
@@ -9,6 +9,7 @@ jest.mock('../../../../lib/logs/logger');
 describe('closeHandler', () => {
   let mockWebsocket: WebSocketConnection;
   let mockClientOpts: LoadedClientOpts;
+  let metricsClient: NoopClient;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -22,38 +23,102 @@ describe('closeHandler', () => {
         universalBrokerEnabled: false,
       },
     } as unknown as LoadedClientOpts;
+    metricsClient = new NoopClient();
   });
 
   it('should log warning with durationMs when connectionStartTime is present', () => {
-    const startTime = Date.now() - 5000; // 5 seconds ago
+    const startTime = Date.now() - 5000;
     mockWebsocket.connectionStartTime = startTime;
 
-    // Mock Date.now to return startTime + 5000
     const now = startTime + 5000;
     jest.spyOn(Date, 'now').mockReturnValue(now);
 
-    closeHandler(mockWebsocket, mockClientOpts, {}, new NoopClient());
+    reportWebSocketClosureEvent(mockWebsocket, mockClientOpts, {}, metricsClient, 'connection_lost');
 
     expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
         durationMs: 5000,
         url: 'https://broker.snyk.io',
         token: 'mock-token',
+        reason: 'connection_lost',
       }),
-      'Websocket connection to the broker server was closed.',
+      'Websocket connection event: connection_lost',
     );
   });
 
   it('should log warning with durationMs -1 when connectionStartTime is undefined', () => {
-    closeHandler(mockWebsocket, mockClientOpts, {}, new NoopClient());
+    reportWebSocketClosureEvent(mockWebsocket, mockClientOpts, {}, metricsClient, 'connection_lost');
 
     expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
         durationMs: -1,
         url: 'https://broker.snyk.io',
         token: 'mock-token',
+        reason: 'connection_lost',
       }),
-      'Websocket connection to the broker server was closed.',
+      'Websocket connection event: connection_lost',
     );
+  });
+
+  it('should include reason in log for each termination event type', () => {
+    const reasons = [
+      'connection_lost',
+      'connection_ended',
+      'connection_destroyed',
+      'connection_timed_out',
+      'server_requested_close',
+    ];
+
+    for (const reason of reasons) {
+      jest.clearAllMocks();
+      reportWebSocketClosureEvent(mockWebsocket, mockClientOpts, {}, metricsClient, reason);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ reason }),
+        `Websocket connection event: ${reason}`,
+      );
+    }
+  });
+
+  it('should record lifecycle metric with the given reason', () => {
+    const spy = jest.spyOn(metricsClient, 'recordWebsocketLifecycleEvent');
+    reportWebSocketClosureEvent(
+      mockWebsocket,
+      mockClientOpts,
+      { role: 'primary' },
+      metricsClient,
+      'connection_timed_out',
+    );
+
+    expect(spy).toHaveBeenCalledWith('connection_timed_out', 'primary');
+  });
+
+  it('should record connection duration when connectionStartTime is set', () => {
+    const spy = jest.spyOn(metricsClient, 'recordConnectionDuration');
+    mockWebsocket.connectionStartTime = Date.now() - 10000;
+    jest.spyOn(Date, 'now').mockReturnValue(mockWebsocket.connectionStartTime + 10000);
+
+    reportWebSocketClosureEvent(
+      mockWebsocket,
+      mockClientOpts,
+      { role: 'secondary' },
+      metricsClient,
+      'connection_ended',
+    );
+
+    expect(spy).toHaveBeenCalledWith('secondary', 10);
+  });
+
+  it('should not record connection duration when connectionStartTime is undefined', () => {
+    const spy = jest.spyOn(metricsClient, 'recordConnectionDuration');
+    reportWebSocketClosureEvent(
+      mockWebsocket,
+      mockClientOpts,
+      { role: 'primary' },
+      metricsClient,
+      'connection_destroyed',
+    );
+
+    expect(spy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
The purpose of this change is to improve our overall telemetry surface.

The new metric has a human-readable event as a label, rather than the "raw" websocket event. This hopefully makes it clearer for our downstream users what's specifically going on.

Compare "closing" to "server_requested_close".

Also:
- renames the closeHandler to reportWebSocketClosureEvent - this is much closer to what we actually are doing. The code isn't handling any events.
- implements the reportWebSocketClosureEvent function to emit new telemetry
- adds tests to ensure existing and current functionality continues working
