### PR TITLE
fix: add diff compare urls [PLC-4479]

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -17,6 +17,16 @@ ignore:
         reason: No fix for rhel-ubi8 available yet
         created: 2026-01-28T00:00:00.000Z
         expires: 2026-04-28T00:00:00.000Z
+  SNYK-RHEL8-GLIBC-15885581:
+    - '*':
+        reason: No fix for rhel-ubi8 available yet
+        created: 2026-04-07T00:00:00.000Z
+        expires: 2026-07-07T00:00:00.000Z
+  SNYK-RHEL8-LIBCAP-16000755:
+    - '*':
+        reason: No fix for rhel-ubi8 available yet
+        created: 2026-04-14T00:00:00.000Z
+        expires: 2026-07-14T00:00:00.000Z
 patch: {}
 exclude:
   global:

--- a/client-templates/azure-repos/accept.json.sample
+++ b/client-templates/azure-repos/accept.json.sample
@@ -479,5 +479,15 @@
         "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
       }
     },
+    {
+      "//": "get the diff of two commits",
+      "method": "GET",
+      "path": "/:owner/_apis/git/repositories/:repo/diffs/commits",
+      "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+      "auth": {
+        "scheme": "basic",
+        "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+      }
+    }
   ]
 }

--- a/client-templates/bitbucket-server-bearer-auth/accept.json.sample
+++ b/client-templates/bitbucket-server-bearer-auth/accept.json.sample
@@ -1162,6 +1162,16 @@
         "scheme": "bearer",
         "token": "${BITBUCKET_PAT}"
       }
+    },
+    {
+      "//": "get the diff of two commits",
+      "method": "GET",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/compare/changes",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
     }
   ]
 }

--- a/client-templates/bitbucket-server/accept.json.sample
+++ b/client-templates/bitbucket-server/accept.json.sample
@@ -1277,6 +1277,17 @@
         "username": "${BITBUCKET_USERNAME}",
         "password": "${BITBUCKET_PASSWORD}"
       }
+    },
+    {
+      "//": "get the diff of two commits",
+      "method": "GET",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/compare/changes",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${BITBUCKET_USERNAME}",
+        "password": "${BITBUCKET_PASSWORD}"
+      }
     }
   ]
 }

--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -1665,6 +1665,12 @@
       "method": "POST",
       "path": "/api/v4/projects/:project/repository/commits",
       "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "get the diff of two commits",
+      "method": "GET",
+      "path": "/api/v4/projects/:project/repository/compare",
+      "origin": "https://${GITLAB}"
     }
   ]
 }

--- a/defaultFilters/azure-repos.json
+++ b/defaultFilters/azure-repos.json
@@ -486,6 +486,16 @@
           "scheme": "basic",
           "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
         }
+      },
+      {
+        "//": "get the diff of two commits",
+        "method": "GET",
+        "path": "/:owner/_apis/git/repositories/:repo/diffs/commits",
+        "origin": "https://${AZURE_REPOS_HOST}/${AZURE_REPOS_ORG}",
+        "auth": {
+          "scheme": "basic",
+          "token": "${BROKER_CLIENT_VALIDATION_BASIC_AUTH}"
+        }
       }
     ]
   }

--- a/defaultFilters/bitbucket-server-bearer-auth.json
+++ b/defaultFilters/bitbucket-server-bearer-auth.json
@@ -1162,6 +1162,16 @@
         "scheme": "bearer",
         "token": "${BITBUCKET_PAT}"
       }
+    },
+    {
+      "//": "get the diff of two commits",
+      "method": "GET",
+      "path": "/rest/api/1.0/projects/:project/repos/:repo/compare/changes",
+      "origin": "https://${BITBUCKET}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${BITBUCKET_PAT}"
+      }
     }
   ]
 }

--- a/defaultFilters/bitbucket-server.json
+++ b/defaultFilters/bitbucket-server.json
@@ -1277,6 +1277,17 @@
           "username": "${BITBUCKET_USERNAME}",
           "password": "${BITBUCKET_PASSWORD}"
         }
+      },
+      {
+        "//": "get the diff of two commits",
+        "method": "GET",
+        "path": "/rest/api/1.0/projects/:project/repos/:repo/compare/changes",
+        "origin": "https://${BITBUCKET}",
+        "auth": {
+          "scheme": "basic",
+          "username": "${BITBUCKET_USERNAME}",
+          "password": "${BITBUCKET_PASSWORD}"
+        }
       }
     ]
   }

--- a/defaultFilters/gitlab.json
+++ b/defaultFilters/gitlab.json
@@ -1707,6 +1707,12 @@
         "method": "POST",
         "path": "/api/v4/projects/:project/repository/commits",
         "origin": "https://${GITLAB}"
+      },
+      {
+        "//": "get the diff of two commits",
+        "method": "GET",
+        "path": "/api/v4/projects/:project/repository/compare",
+        "origin": "https://${GITLAB}"
       }
     ]
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@opentelemetry/instrumentation": "0.212.0",
         "@opentelemetry/instrumentation-runtime-node": "0.25.0",
         "@opentelemetry/sdk-metrics": "2.5.1",
-        "axios": "1.13.5",
+        "axios": "1.15.0",
         "axios-retry": "4.5.0",
         "body-parser": "1.20.4",
         "bunyan": "^1.8.12",
@@ -2393,14 +2393,13 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
-      "license": "MIT",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios-retry": {
@@ -2412,6 +2411,14 @@
       },
       "peerDependencies": {
         "axios": "0.x || 1.x"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/babel-jest": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@opentelemetry/instrumentation": "0.212.0",
     "@opentelemetry/instrumentation-runtime-node": "0.25.0",
     "@opentelemetry/sdk-metrics": "2.5.1",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "axios-retry": "4.5.0",
     "body-parser": "1.20.4",
     "bunyan": "^1.8.12",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adds missing SCM urls for newly added endpoints to compare diffs. Github had already these URLs defined.

#### Where should the reviewer start?


#### How should this be manually tested?

We're monitoring this change through this [DD metric](https://app.datadoghq.com/logs?query=%40service%3Acode-discovery%20status%3Aerror%20%22error%20fetching%20diff%20for%20ref%22&agg_m=count&agg_m_source=base&agg_q=%40source&agg_q_source=base&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40errorMessage&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=sunburst&x_missing=true&from_ts=1776020440123&to_ts=1776106840123&live=true). There should be no instances of this error after the fix is deployed.