### PR TITLE
fix: resolve happy eyeballs issue

### DIFF
--- a/lib/hybrid-sdk/client/index.ts
+++ b/lib/hybrid-sdk/client/index.ts
@@ -129,10 +129,17 @@ export const main = async (clientOpts: ClientOpts) => {
     }
     await validateMinimalConfig(clientOpts);
 
-    const brokerServerHost = new URL(
-      clientOpts.config.brokerServerUrl ?? 'https://broker.snyk.io',
-    ).hostname;
-    await probeIpv6WithIpv4Fallback(brokerServerHost);
+    if (clientOpts.config.IPV6_CONNECTIVITY_CHECK_ENABLED !== 'false') {
+      const brokerServerHost = new URL(
+        clientOpts.config.brokerServerUrl ?? 'https://broker.snyk.io',
+      ).hostname;
+      await probeIpv6WithIpv4Fallback(brokerServerHost);
+    } else {
+      logger.info(
+        {},
+        'IPv6 connectivity check disabled via IPV6_CONNECTIVITY_CHECK_ENABLED=false.',
+      );
+    }
 
     if (clientOpts.config.universalBrokerEnabled) {
       const pluginsFolderPath = await findPluginFolder(

--- a/lib/hybrid-sdk/client/index.ts
+++ b/lib/hybrid-sdk/client/index.ts
@@ -28,6 +28,7 @@ import { loadPlugins } from './brokerClientPlugins/pluginManager';
 import { manageWebsocketConnections } from './connectionsManager/manager';
 import { findPluginFolder } from '../common/config/config';
 import { retrieveAndLoadFilters } from './utils/filterLoading';
+import { probeIpv6WithIpv4Fallback } from './utils/probeIpv6WithIpv4Fallback';
 import * as metrics from './metrics';
 
 const ONEDAY = 24 * 3600 * 1000; // 24h in ms
@@ -127,6 +128,11 @@ export const main = async (clientOpts: ClientOpts) => {
       process.env.SNYK_DISPATCHER_URL_PREFIX = '/hidden/brokers';
     }
     await validateMinimalConfig(clientOpts);
+
+    const brokerServerHost = new URL(
+      clientOpts.config.brokerServerUrl ?? 'https://broker.snyk.io',
+    ).hostname;
+    await probeIpv6WithIpv4Fallback(brokerServerHost);
 
     if (clientOpts.config.universalBrokerEnabled) {
       const pluginsFolderPath = await findPluginFolder(

--- a/lib/hybrid-sdk/client/types/config.ts
+++ b/lib/hybrid-sdk/client/types/config.ts
@@ -7,6 +7,7 @@ interface BrokerClient {
   HTTPS_CERT: string;
   HTTPS_KEY: string;
   INSECURE_DOWNSTREAM: string;
+  IPV6_CONNECTIVITY_CHECK_ENABLED: string;
   PREFLIGHT_CHECKS_ENABLED: string;
 }
 

--- a/lib/hybrid-sdk/client/utils/probeIpv6WithIpv4Fallback.ts
+++ b/lib/hybrid-sdk/client/utils/probeIpv6WithIpv4Fallback.ts
@@ -1,0 +1,47 @@
+import dns from 'node:dns';
+import net from 'node:net';
+import { log as logger } from '../../../logs/logger';
+
+const disableHappyEyeballs = () => {
+  dns.setDefaultResultOrder('ipv4first');
+  net.setDefaultAutoSelectFamily(false);
+};
+
+/**
+ * Probes `host:port` over IPv6 (family: 6). If the probe fails or times out,
+ * disables the Node.js Happy Eyeballs algorithm by setting the DNS result order
+ * to 'ipv4first' and turning off autoSelectFamily, eliminating the ~250 ms
+ * fallback penalty on every new TCP connection when IPv6 routing is unavailable.
+ */
+export async function probeIpv6WithIpv4Fallback(
+  host: string,
+  port = 443,
+  timeoutMs = 3_000,
+): Promise<'ipv4first' | 'default'> {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host, port, family: 6 });
+    socket.setTimeout(timeoutMs);
+
+    const cleanup = (ipv6Works: boolean) => {
+      socket.destroy();
+      if (ipv6Works) {
+        logger.info(
+          { host },
+          'IPv6 probe succeeded. Keeping default IP family.',
+        );
+        resolve('default');
+      } else {
+        logger.info(
+          { host },
+          'IPv6 probe failed. Disabling Happy Eyeballs (dns ipv4first + net autoSelectFamily off).',
+        );
+        disableHappyEyeballs();
+        resolve('ipv4first');
+      }
+    };
+
+    socket.on('connect', () => cleanup(true));
+    socket.on('error', () => cleanup(false));
+    socket.on('timeout', () => cleanup(false));
+  });
+}

--- a/test/unit/client/utils/probeIpv6WithIpv4Fallback.test.ts
+++ b/test/unit/client/utils/probeIpv6WithIpv4Fallback.test.ts
@@ -1,0 +1,84 @@
+import { EventEmitter } from 'node:events';
+import dns from 'node:dns';
+import net from 'node:net';
+
+jest.mock('node:dns');
+jest.mock('node:net');
+
+import { probeIpv6WithIpv4Fallback } from '../../../../lib/hybrid-sdk/client/utils/probeIpv6WithIpv4Fallback';
+
+const mockedCreateConnection = net.createConnection as jest.Mock;
+const mockedSetDefaultResultOrder = dns.setDefaultResultOrder as jest.Mock;
+const mockedSetDefaultAutoSelectFamily =
+  net.setDefaultAutoSelectFamily as jest.Mock;
+
+class FakeSocket extends EventEmitter {
+  destroyed = false;
+  setTimeout = jest.fn();
+  destroy() {
+    this.destroyed = true;
+  }
+}
+
+describe('probeIpv6WithIpv4Fallback', () => {
+  let fakeSocket: FakeSocket;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fakeSocket = new FakeSocket();
+    mockedCreateConnection.mockReturnValue(fakeSocket);
+  });
+
+  it('should return "default" and keep default IP family when IPv6 connects successfully', async () => {
+    const probe = probeIpv6WithIpv4Fallback('broker.snyk.io');
+    fakeSocket.emit('connect');
+
+    const result = await probe;
+
+    expect(result).toBe('default');
+    expect(mockedSetDefaultResultOrder).not.toHaveBeenCalled();
+    expect(mockedSetDefaultAutoSelectFamily).not.toHaveBeenCalled();
+  });
+
+  it('should return "ipv4first" and disable Happy Eyeballs when IPv6 connection errors', async () => {
+    const probe = probeIpv6WithIpv4Fallback('broker.snyk.io');
+    fakeSocket.emit('error', new Error('ECONNREFUSED'));
+
+    const result = await probe;
+
+    expect(result).toBe('ipv4first');
+    expect(mockedSetDefaultResultOrder).toHaveBeenCalledWith('ipv4first');
+    expect(mockedSetDefaultAutoSelectFamily).toHaveBeenCalledWith(false);
+  });
+
+  it('should return "ipv4first" and disable Happy Eyeballs when IPv6 connection times out', async () => {
+    const probe = probeIpv6WithIpv4Fallback('broker.snyk.io');
+    fakeSocket.emit('timeout');
+
+    const result = await probe;
+
+    expect(result).toBe('ipv4first');
+    expect(mockedSetDefaultResultOrder).toHaveBeenCalledWith('ipv4first');
+    expect(mockedSetDefaultAutoSelectFamily).toHaveBeenCalledWith(false);
+  });
+
+  it('should pass the correct host, port and family to net.createConnection', async () => {
+    const probe = probeIpv6WithIpv4Fallback('example.com', 8443);
+    fakeSocket.emit('connect');
+    await probe;
+
+    expect(mockedCreateConnection).toHaveBeenCalledWith({
+      host: 'example.com',
+      port: 8443,
+      family: 6,
+    });
+  });
+
+  it('should set a timeout on the socket using the provided timeoutMs', async () => {
+    const probe = probeIpv6WithIpv4Fallback('broker.snyk.io', 443, 1500);
+    fakeSocket.emit('connect');
+    await probe;
+
+    expect(fakeSocket.setTimeout).toHaveBeenCalledWith(1500);
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR adds a functionality to configure Node.js autoselection option for `dns` and `net`. It corresponds to NODE_OPTIONS `--no-network-family-autoselection --dns-result-order=ipv4first`.

> **More context why**
> Node.js 18+ uses the Happy Eyeballs algorithm when connecting to hosts that have both A and AAAA DNS records. If IPv6 routing is unavailable, every new TCP connection pays a ~250ms penalty before falling back to IPv4. In case customer networks need more than 250ms requests back to Snyk will timeout.

#### Where should the reviewer start?

At broker client startup, after config validation, a TCP probe is made to the broker server host over IPv6. If it fails or times out, two global settings are applied for the lifetime of the process:
  - dns.setDefaultResultOrder('ipv4first') — DNS resolves IPv4 addresses first. This corresponds to `--dns-result-order=ipv4first` NODE_OPTIONS.
  - net.setDefaultAutoSelectFamily(false) — disables the Happy Eyeballs connection racing timer. This corresponds to `--no-network-family-autoselection` NODE_OPTIONS

This fixes the latency for all outbound connections:
  
- the WebSocket tunnel to broker.snyk.io
- preflight HTTP checks
- and downstream requests.

To restore original behavior of Broker client following setting can be applied:

- `IPV6_CONNECTIVITY_CHECK_ENABLED=false` to skip the probe and preserve default Node.js behavior.

#### Links

PRs in helm repo that does the same but via NODE_OPTIONS:
- https://github.com/snyk/snyk-broker-helm/pull/179
- https://github.com/snyk/snyk-broker-helm/pull/181