### PR TITLE
fix(deps): override brace-expansion to v1.1.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2859,9 +2859,10 @@
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info."
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "express": {
       "path-to-regexp": "^0.1.13"
     },
+    "brace-expansion": "1.1.14",
     "form-data": "4.0.4",
     "ws": "7.5.10"
   }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR fixes this vulnerability https://security.snyk.io/vuln/SNYK-JS-BRACEEXPANSION-15789759 by overriding `brace-expansion` package.

The package comes as transitive dependency for minimatch. minimatch 3.x and 4.x uses brace-expansion 1.x, so bumping minimatch withing those major versions wouldn't escape it. The override pins brace-expansion to 1.1.14 across the whole dependency tree without any API changes.