### PR TITLE
chore(circleci): increase timeout for default context deadline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,6 +395,7 @@ jobs:
           at: ~/broker
       - run:
           name: Release to GitHub
+          no_output_timeout: 20m
           command: |
             npm install --save-exact --save-dev semantic-release@22.0.12 @semantic-release/exec@6.0.3 pkg@5.8.1
             npx semantic-release


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR increases timeout for `Release to GitHub and NPM` step and fixes the issue with failed builds. `pkg` by building standalone binaries takes sometime more than 10 minutes, this is default by CircleCI and leads to failed `Release to GitHub and NPM` step.

https://support.circleci.com/hc/en-us/articles/360007188574-Build-has-Hit-Timeout-Limit
