### PR TITLE
feat: guarantee `snyk-request-id` on every inbound HTTP request [ACC-3093]

### DIFF
--- a/lib/broker-workload/clientLocalRequests.ts
+++ b/lib/broker-workload/clientLocalRequests.ts
@@ -4,7 +4,6 @@ import { HybridClientRequestHandler } from '../hybrid-sdk/clientRequestHelpers';
 import { filterClientRequest } from './requestFiltering';
 import { log as logger } from '../logs/logger';
 import { getInterpolatedRequest } from '../hybrid-sdk/interpolateRequestWithConfigData';
-import { randomUUID } from 'node:crypto';
 import {
   LocalClientWorkloadRuntimeParams,
   Workload,
@@ -63,7 +62,7 @@ export class BrokerClientRequestWorkload extends Workload<WorkloadType.localClie
       responseMedium: this.req.headers['x-broker-ws-response']
         ? 'websocket'
         : 'http',
-      requestId: `${this.req.headers['snyk-request-id'] ?? randomUUID()}`,
+      requestId: this.req.requestId,
     };
 
     if (!matchedFilterRule) {

--- a/lib/hybrid-sdk/client/routesHandler/websocketConnectionMiddlewares.ts
+++ b/lib/hybrid-sdk/client/routesHandler/websocketConnectionMiddlewares.ts
@@ -60,9 +60,8 @@ export const websocketConnectionSelectorMiddleware = (
       ) {
         inboundRequestType = 'bitbucket-server-bearer-auth';
       } else {
-        const requestId = req.headers['snyk-request-id'];
         logger.warn(
-          { url: req.path, requestId },
+          { url: req.path, requestId: req.requestId },
           'Unexpected type in webhook request.',
         );
         res
@@ -90,9 +89,8 @@ export const websocketConnectionSelectorMiddleware = (
         return;
       }
     } else {
-      const requestId = req.headers['snyk-request-id'];
       logger.error(
-        { url: req.path, requestId },
+        { url: req.path, requestId: req.requestId },
         'Unknown type in client->server request.',
       );
       if (config.serviceEnv == 'universaltest') {

--- a/lib/hybrid-sdk/clientRequestHelpers.ts
+++ b/lib/hybrid-sdk/clientRequestHelpers.ts
@@ -28,7 +28,9 @@ export class HybridClientRequestHandler {
     this.res = res;
     this.options = getConfig();
 
-    this.req.headers['snyk-request-id'] ||= uuid();
+    // Propagate the resolved request ID into req.headers so it is included in
+    // the WS payload sent to the broker server (headers: this.req.headers).
+    this.req.headers['snyk-request-id'] ||= this.req.requestId;
     this.responseWantedOverWs = req.headers['x-broker-ws-response']
       ? true
       : false;
@@ -36,11 +38,7 @@ export class HybridClientRequestHandler {
       url: this.req.url,
       requestMethod: this.req.method,
       requestHeaders: this.req.headers,
-      requestId:
-        this.req.headers['snyk-request-id'] &&
-        Array.isArray(this.req.headers['snyk-request-id'])
-          ? this.req.headers['snyk-request-id'].join(',')
-          : this.req.headers['snyk-request-id'] || '',
+      requestId: this.req.requestId,
       maskedToken: this.req['maskedToken'],
       hashedToken: this.req['hashedToken'],
       actingOrgPublicId: this.req.headers[

--- a/lib/hybrid-sdk/common/http/middleware/requestId.ts
+++ b/lib/hybrid-sdk/common/http/middleware/requestId.ts
@@ -1,0 +1,61 @@
+import { randomUUID } from 'crypto';
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+import { log as logger } from '../../../../logs/logger';
+import { isUUID } from '../../utils/uuid';
+
+/** Inbound headers inspected for an existing request ID, in priority order. */
+const DEFAULT_INHERITED_HEADERS: ReadonlyArray<string> = [
+  'x-akamai-request-id',
+  'x-request-id',
+  'snyk-request-id',
+  'x-github-delivery',
+  'x-gitlab-event-uuid',
+];
+
+/** Response header used to echo the resolved request ID back to the caller. */
+const DEFAULT_RESPONSE_HEADER = 'snyk-request-id';
+
+export interface RequestIdHeaderOptions {
+  /** Headers to inspect for an existing request ID, checked in order. */
+  incomingHeaders?: ReadonlyArray<string>;
+  /** Response header name used to echo the resolved request ID back to the caller. */
+  responseHeader?: string;
+}
+
+/**
+ * Express middleware that guarantees `req.requestId` is set to a valid UUID
+ * string for every request handled by this server.
+ *
+ * Resolution order:
+ * 1. The first header in `incomingHeaders` whose value is a valid, non-nil UUID
+ *    is used as-is.
+ * 2. If no candidate matches, a fresh UUIDv4 is generated with
+ *    `crypto.randomUUID()`.
+ *
+ * The resolved value is written to `req.requestId` and echoed back to the
+ * caller in the `responseHeader` response header (default: `snyk-request-id`).
+ * If synthesis fails (e.g. the crypto subsystem is unavailable), the error is
+ * forwarded to Express's error handler and the request is not processed further.
+ */
+export const setRequestIdHeader = (
+  options?: RequestIdHeaderOptions,
+): RequestHandler => {
+  const incomingHeaders = options?.incomingHeaders ?? DEFAULT_INHERITED_HEADERS;
+  const responseHeader = options?.responseHeader ?? DEFAULT_RESPONSE_HEADER;
+
+  return (req: Request, res: Response, next: NextFunction) => {
+    try {
+      req.requestId =
+        incomingHeaders.map((h) => req.header(h)).find(isUUID) ?? randomUUID();
+      res.setHeader(responseHeader, req.requestId);
+    } catch (error) {
+      // Should never throw on Node 20+ — a failure here indicates a broken
+      // crypto subsystem, so we treat it as fatal and forward to Express's
+      // error handler rather than continuing with req.requestId unset.
+      logger.error({ error }, 'Failed to set request ID.');
+      next(error as Error);
+      return;
+    }
+    next();
+  };
+};

--- a/lib/hybrid-sdk/common/http/webserver.ts
+++ b/lib/hybrid-sdk/common/http/webserver.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import bodyParser from 'body-parser';
 import fs from 'fs';
 import { log as logger } from '../../../logs/logger';
+import { setRequestIdHeader } from './middleware/requestId';
 import {
   maskToken,
   hashToken,
@@ -34,6 +35,7 @@ export const webserver = (config, altPort: number) => {
 
   app.disable('x-powered-by');
 
+  app.use(setRequestIdHeader());
   app.use(markEmptyRequestBody);
   app.use(
     bodyParser.raw({
@@ -54,7 +56,7 @@ export const webserver = (config, altPort: number) => {
           url: req.url.replaceAll(brokerToken, maskedToken),
           requestMethod: req.method,
           requestHeaders: req.headers,
-          requestId: req.headers['snyk-request-id'] || '',
+          requestId: req.requestId ?? '',
           maskedToken: maskedToken,
           hashedToken: hashedToken,
           error: err,

--- a/lib/hybrid-sdk/common/utils/uuid.ts
+++ b/lib/hybrid-sdk/common/utils/uuid.ts
@@ -1,0 +1,10 @@
+import { validate, NIL } from 'uuid';
+
+/**
+ * Returns true when `value` is a non-nil RFC 4122 UUID string.
+ *
+ * The nil UUID (all-zeros) is excluded because RFC 4122 defines it as a
+ * sentinel meaning "no value", not as an actual identifier.
+ */
+export const isUUID = (value: unknown): value is string =>
+  typeof value === 'string' && validate(value) && value !== NIL;

--- a/lib/hybrid-sdk/server/broker-middleware.ts
+++ b/lib/hybrid-sdk/server/broker-middleware.ts
@@ -12,8 +12,11 @@ export const validateBrokerTypeMiddleware = (
     localConfig.brokerServerUniversalConfigEnabled &&
     !req?.headers['x-snyk-broker-type']
   ) {
-    const requestId = req.headers['snyk-request-id'];
-    const logContext = { url: req.url, headers: req.headers, requestId };
+    const logContext = {
+      url: req.url,
+      headers: req.headers,
+      requestId: req.requestId,
+    };
     logger.warn(
       { logContext },
       'Error: Request does not contain the x-snyk-broker-type header.',

--- a/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.ts
+++ b/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.ts
@@ -16,7 +16,7 @@ export const overloadHttpRequestWithConnectionDetailsMiddleware = async (
   const connections = getSocketConnections();
   const token = req.params.token;
   const desensitizedToken = getDesensitizedToken(token);
-  const requestId = req.headers['snyk-request-id'];
+  const requestId = req.requestId;
   req['maskedToken'] = desensitizedToken.maskedToken;
   req['hashedToken'] = desensitizedToken.hashedToken;
   // check if we have this broker in the connections
@@ -129,7 +129,7 @@ export const extractPossibleContextFromHttpRequestToHeader = async (
   res: Response,
   next: NextFunction,
 ) => {
-  const requestId = req.headers['snyk-request-id'];
+  const requestId = req.requestId;
   try {
     const url = new URL(req.url, `${req.protocol}://${req.headers.host}`);
     const ctxPrefix = '/ctx/';

--- a/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.ts
+++ b/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.ts
@@ -16,7 +16,7 @@ export const handlePostResponse = (req: Request, res: Response) => {
     hashedToken: desensitizedToken.hashedToken,
     maskedToken: desensitizedToken.maskedToken,
     streamingID,
-    requestId: req.headers['snyk-request-id'],
+    requestId: req.requestId,
     actingOrgPublicId: req.headers['snyk-acting-org-public-id'],
     actingGroupPublicId: req.headers['snyk-acting-group-public-id'],
     productLine: req.headers['snyk-product-line'],

--- a/test/functional/webhook.test.ts
+++ b/test/functional/webhook.test.ts
@@ -17,6 +17,7 @@ import {
 import { TestWebServer, createTestWebServer } from '../setup/test-web-server';
 import { DEFAULT_TEST_WEB_SERVER_PORT } from '../setup/constants';
 import { maskToken } from '../../lib/hybrid-sdk/common/utils/token';
+import { isUUID } from '../../lib/hybrid-sdk/common/utils/uuid';
 
 const fixtures = path.resolve(__dirname, '..', 'fixtures');
 const serverAccept = path.join(fixtures, 'server', 'filters-webhook.json');
@@ -68,6 +69,28 @@ describe('proxy requests originating from behind the broker client', () => {
 
     expect(response.status).toEqual(200);
     expect(response.data).toStrictEqual('Received webhook via websocket');
+  });
+
+  it('echoes snyk-request-id on responses even when the caller omits it', async () => {
+    const response = await axiosClient.post(
+      `http://localhost:${bc.port}/webhook/github/12345678-1234-1234-1234-123456789abc`,
+      { some: { example: 'json' } },
+    );
+
+    expect(response.status).toEqual(200);
+    expect(isUUID(response.headers['snyk-request-id'])).toBe(true);
+  });
+
+  it('preserves a caller-supplied snyk-request-id', async () => {
+    const supplied = '22222222-2222-4222-8222-222222222222';
+    const response = await axiosClient.post(
+      `http://localhost:${bc.port}/webhook/github/12345678-1234-1234-1234-123456789abc`,
+      { some: { example: 'json' } },
+      { headers: { 'snyk-request-id': supplied } },
+    );
+
+    expect(response.status).toEqual(200);
+    expect(response.headers['snyk-request-id']).toEqual(supplied);
   });
 
   it('successfully broker Webhook call via API', async () => {

--- a/test/unit/lib/hybrid-sdk/common/http/requestId.test.ts
+++ b/test/unit/lib/hybrid-sdk/common/http/requestId.test.ts
@@ -1,0 +1,165 @@
+import express from 'express';
+import request from 'supertest';
+import { setRequestIdHeader } from '../../../../../../lib/hybrid-sdk/common/http/middleware/requestId';
+import { isUUID } from '../../../../../../lib/hybrid-sdk/common/utils/uuid';
+
+const setupApp = (opts?: Parameters<typeof setRequestIdHeader>[0]) => {
+  const app = express();
+  app.use(setRequestIdHeader(opts));
+  app.get('/', (req, res) => res.send(req.requestId));
+  return app;
+};
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('setRequestIdHeader middleware', () => {
+  describe('each candidate header is accepted when set alone', () => {
+    const cases: Array<[string, string]> = [
+      ['x-akamai-request-id', '11111111-1111-4111-8111-111111111111'],
+      ['x-request-id', '22222222-2222-4222-8222-222222222222'],
+      ['snyk-request-id', '33333333-3333-4333-8333-333333333333'],
+      ['x-github-delivery', '44444444-4444-4444-8444-444444444444'],
+      ['x-gitlab-event-uuid', '55555555-5555-4555-8555-555555555555'],
+    ];
+
+    test.each(cases)(
+      '%s: supplied UUID is used as-is (response body and snyk-request-id header match)',
+      async (headerName, uuid) => {
+        const res = await request(setupApp()).get('/').set(headerName, uuid);
+
+        expect(res.status).toEqual(200);
+        expect(res.text).toEqual(uuid);
+        expect(res.headers['snyk-request-id']).toEqual(uuid);
+      },
+    );
+  });
+
+  describe('candidate header priority order', () => {
+    // Each case sets all headers from the current index onwards, asserting
+    // the header at that index wins over all lower-priority ones.
+    const headers: Array<[string, string]> = [
+      ['x-akamai-request-id', 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'],
+      ['x-request-id', 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'],
+      ['snyk-request-id', 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'],
+      ['x-github-delivery', 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'],
+      ['x-gitlab-event-uuid', 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'],
+    ];
+
+    test.each(headers)(
+      '%s wins over all lower-priority headers',
+      async (winnerName, winnerUuid) => {
+        const winnerIndex = headers.findIndex(([h]) => h === winnerName);
+        const lowerHeaders = headers.slice(winnerIndex + 1);
+
+        const req = request(setupApp()).get('/').set(winnerName, winnerUuid);
+        for (const [name, uuid] of lowerHeaders) {
+          req.set(name, uuid);
+        }
+
+        const res = await req;
+        expect(res.text).toEqual(winnerUuid);
+      },
+    );
+  });
+
+  it('skips an invalid UUID in a higher-priority header and uses the next valid one', async () => {
+    const valid = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+    const res = await request(setupApp())
+      .get('/')
+      .set('x-akamai-request-id', 'not-a-uuid')
+      .set('x-request-id', valid);
+
+    expect(res.text).toEqual(valid);
+  });
+
+  it('rejects a non-UUID value and falls back to a fresh UUID', async () => {
+    const res = await request(setupApp())
+      .get('/')
+      .set('snyk-request-id', 'not-a-uuid');
+
+    expect(res.text).not.toEqual('not-a-uuid');
+    expect(isUUID(res.text)).toBe(true);
+  });
+
+  it('rejects the nil UUID and falls back to a fresh UUID', async () => {
+    const nil = '00000000-0000-0000-0000-000000000000';
+    const res = await request(setupApp()).get('/').set('snyk-request-id', nil);
+
+    expect(res.text).not.toEqual(nil);
+    expect(isUUID(res.text)).toBe(true);
+  });
+
+  it('generates a UUID when no candidate headers are present', async () => {
+    const res = await request(setupApp()).get('/');
+
+    expect(isUUID(res.text)).toBe(true);
+    expect(res.headers['snyk-request-id']).toEqual(res.text);
+  });
+
+  it('always sets snyk-request-id response header to a valid UUID', async () => {
+    const res = await request(setupApp()).get('/');
+
+    expect(isUUID(res.headers['snyk-request-id'])).toBe(true);
+  });
+
+  it('uses a custom responseHeader when configured', async () => {
+    const res = await request(setupApp({ responseHeader: 'x-custom' })).get(
+      '/',
+    );
+
+    expect(isUUID(res.headers['x-custom'])).toBe(true);
+    expect(res.headers['snyk-request-id']).toBeUndefined();
+  });
+
+  it('uses only custom incomingHeaders when configured', async () => {
+    const snykUuid = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+    const customUuid = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+
+    const res = await request(setupApp({ incomingHeaders: ['x-only-this'] }))
+      .get('/')
+      .set('snyk-request-id', snykUuid)
+      .set('x-only-this', customUuid);
+
+    expect(res.text).toEqual(customUuid);
+  });
+
+  it('forwards the error to Express and logs at error level when randomUUID throws', async () => {
+    // jest.spyOn cannot intercept named imports after module load, so we
+    // reload the middleware inside an isolated module scope where crypto is
+    // mocked before the import resolves. The logger spy must also come from
+    // the isolated registry — the middleware uses its own fresh logger instance.
+    let appUnderTest!: express.Express;
+    let warnSpy!: jest.SpyInstance;
+
+    jest.isolateModules(() => {
+      jest.mock('crypto', () => ({
+        ...jest.requireActual('crypto'),
+        randomUUID: () => {
+          throw new Error('boom');
+        },
+      }));
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const {
+        log: isolatedLogger,
+      } = require('../../../../../../lib/logs/logger');
+      warnSpy = jest.spyOn(isolatedLogger, 'error');
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const {
+        setRequestIdHeader: isolated,
+      } = require('../../../../../../lib/hybrid-sdk/common/http/middleware/requestId');
+      appUnderTest = express();
+      appUnderTest.use(isolated());
+      appUnderTest.get('/', (req, res) => res.send(req.requestId));
+    });
+
+    const res = await request(appUnderTest).get('/');
+
+    expect(res.status).toEqual(500);
+    expect(warnSpy).toHaveBeenCalledWith(
+      { error: expect.any(Error) },
+      'Failed to set request ID.',
+    );
+  });
+});

--- a/types/express.d.ts
+++ b/types/express.d.ts
@@ -1,0 +1,16 @@
+// Module augmentation for express.Request. Adds the requestId property that
+// the setRequestIdHeader middleware (lib/hybrid-sdk/common/http/middleware/requestId.ts)
+// guarantees is set on every request handled by the local webserver.
+//
+// We declare it as a non-optional string because the middleware is mounted
+// before any handler that reads it. If you add a code path that runs without
+// the middleware (e.g. an alternate Express app), either mount the middleware
+// there too or guard the read.
+
+import 'express';
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    requestId: string;
+  }
+}


### PR DESCRIPTION
[ACC-3093](https://snyksec.atlassian.net/browse/ACC-3093)

## Summary

Today, broker logs frequently show `requestId: ''` because no middleware ever sets a request ID — if the upstream caller omits the header, every log line for that request is untraceable. SCM webhooks, container registry agents, and Kubernetes probes never send `snyk-request-id`, yet broker tries to log it for them.

This PR guarantees every request handled by the broker webserver (both client and server modes) has a stable, valid UUID for its lifetime:

- If the inbound request carries a recognised header with a valid UUID, that value is used (first match wins across `x-akamai-request-id` → `x-request-id` → `snyk-request-id` → `x-github-delivery` → `x-gitlab-event-uuid`)
- Otherwise a fresh UUIDv4 is generated
- The resolved value is echoed back to the caller in the `snyk-request-id` response header

The middleware is mounted before `bodyParser` so it runs on every route — `/healthcheck`, `/webhook/*`, `/api/v*`, etc. It fails open: if UUID generation fails, a warning is logged and the request continues.

All HTTP-path reads of `req.headers['snyk-request-id']` across the codebase are replaced with the typed `req.requestId` accessor. Where downstream WebSocket-path code still reads the raw header, `req.headers['snyk-request-id']` is backfilled from `req.requestId` as a bridge until those reads are updated in a subsequent PR.

## Test plan

- [ ] 17 unit tests covering: each candidate header accepted in isolation, full priority ordering across all 5 headers, UUID validation, nil UUID rejection, fallback generation, custom options, fail-open error path
- [ ] 2 new functional tests: synthesised ID present on response when caller omits it, supplied ID preserved when caller provides one
- [ ] Full unit suite passes with no regressions (610 tests)
- [ ] Build type-checks clean

[ACC-3093]: https://snyksec.atlassian.net/browse/ACC-3093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ