### PR TITLE
refactor: better diagnostics for JWT refresh and preflight checks

### DIFF
--- a/lib/hybrid-sdk/client/auth/oauth.ts
+++ b/lib/hybrid-sdk/client/auth/oauth.ts
@@ -1,6 +1,7 @@
 import { PostFilterPreparedRequest } from '../../../broker-workload/prepareRequest';
 import { makeRequestToDownstream } from '../../http/request';
 import { log as logger } from '../../../logs/logger';
+import type { Client as MetricsClient } from '../metrics/client';
 
 interface tokenExchangeResponse {
   access_token: string;
@@ -62,7 +63,12 @@ export async function fetchAndUpdateJwt(
   }
 }
 
-const refreshJwt = async (clientConfig, clientId, clientSecret) => {
+const refreshJwt = async (
+  clientConfig,
+  clientId,
+  clientSecret,
+  metricsClient?: MetricsClient,
+) => {
   logger.debug({}, 'Refreshing oauth access token');
   try {
     const newJwt = await fetchAndUpdateJwt(
@@ -78,10 +84,11 @@ const refreshJwt = async (clientConfig, clientId, clientSecret) => {
       authHeader: newJwt.authHeader,
     });
     setTimeout(async () => {
-      refreshJwt(clientConfig, clientId, clientSecret);
+      refreshJwt(clientConfig, clientId, clientSecret, metricsClient);
     }, clientConfig.AUTH_EXPIRATION_OVERRIDE ?? (newJwt.expiresIn - 60) * 1000);
   } catch (err) {
-    logger.error(`Error retrieving new JWT ${err}`);
+    metricsClient?.recordJwtRefreshFailure();
+    logger.error({ err }, 'Error retrieving new JWT');
   }
 };
 
@@ -89,6 +96,7 @@ export const setfetchAndUpdateJwt = async (
   clientConfig,
   clientId,
   clientSecret,
+  metricsClient?: MetricsClient,
 ) => {
   const newJwt = await fetchAndUpdateJwt(
     clientConfig.apiHostname,
@@ -98,7 +106,7 @@ export const setfetchAndUpdateJwt = async (
   logger.debug({}, 'Setting auth updater.');
   if (newJwt) {
     setTimeout(async () => {
-      refreshJwt(clientConfig, clientId, clientSecret);
+      refreshJwt(clientConfig, clientId, clientSecret, metricsClient);
     }, clientConfig.AUTH_EXPIRATION_OVERRIDE ?? (newJwt.expiresIn - 60) * 1000);
   }
 };

--- a/lib/hybrid-sdk/client/checks/config/brokerClientUrlCheck.ts
+++ b/lib/hybrid-sdk/client/checks/config/brokerClientUrlCheck.ts
@@ -28,16 +28,22 @@ export async function validateBrokerClientUrl(
       } satisfies CheckResult;
     }
 
-    if (
-      isHttpsWithoutCertificates(config) &&
-      !(await isBrokerClientUrlTLSTerminated(config))
-    ) {
-      return {
-        id: checkOptions.id,
-        name: checkOptions.name,
-        status: 'error',
-        output: `Broker Client URL uses the HTTPS protocol: ${brokerClientUrl}, but HTTPS_CERT and HTTPS_KEY environment variables are missing.`,
-      } satisfies CheckResult;
+    if (isHttpsWithoutCertificates(config)) {
+      const tls = await checkTLSTermination(config);
+      if (!tls.terminated) {
+        return {
+          id: checkOptions.id,
+          name: checkOptions.name,
+          status: 'error',
+          output:
+            `Broker Client URL uses the HTTPS protocol: ${brokerClientUrl}, ` +
+            `but the broker could not verify how TLS is being terminated. ` +
+            `Probe to ${brokerClientUrl}/healthcheck failed: ${tls.probeError}. ` +
+            `Either configure HTTPS_CERT and HTTPS_KEY so the broker terminates TLS itself, ` +
+            `or set BROKER_CLIENT_URL_TLS_TERMINATED=true if TLS is already terminated upstream ` +
+            `(e.g. behind a reverse proxy).`,
+        } satisfies CheckResult;
+      }
     }
 
     if (brokerClientUrl && isHostnameLocalhost(brokerClientUrl)) {
@@ -56,9 +62,10 @@ export async function validateBrokerClientUrl(
       output: 'config check: ok',
     } satisfies CheckResult;
   } catch (error) {
-    const errorMessage = `Error executing check with checkId ${checkOptions.id}`;
-    logger.debug({ error }, errorMessage);
-    throw new Error(errorMessage);
+    if (error instanceof Error) {
+      error.message = `Error executing check with checkId ${checkOptions.id}: ${error.message}`;
+    }
+    throw error;
   }
 }
 
@@ -86,38 +93,39 @@ function isHttpsWithoutCertificates(config: Config): boolean {
   }
 }
 
-async function isBrokerClientUrlTLSTerminated(
-  config: Config,
-): Promise<boolean> {
-  let isTLSTerminated = false;
-  if (config.BROKER_CLIENT_URL_TLS_TERMINATED) {
-    isTLSTerminated = true;
-  } else {
-    const request = {
-      url: `${config.BROKER_CLIENT_URL}/healthcheck`,
-      method: 'GET',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-    };
-    try {
-      const response: HttpResponse = await retry<HttpResponse>(
-        () => makeSingleRawRequestToDownstream(request),
-        { retries: 3, operation: 'config check broker-client-url-validation' },
-      );
-      logger.trace({ response: response }, 'config check raw response data');
-      isTLSTerminated = true;
-    } catch (err) {
-      logger.debug(
-        { err },
-        'Failed to reach the BROKER_CLIENT_URL from the broker client.',
-      );
-      isTLSTerminated = false;
-    }
-  }
+type TLSTerminationCheck =
+  | { terminated: true }
+  | { terminated: false; probeError: string };
 
-  return isTLSTerminated;
+async function checkTLSTermination(
+  config: Config,
+): Promise<TLSTerminationCheck> {
+  if (config.BROKER_CLIENT_URL_TLS_TERMINATED) {
+    return { terminated: true };
+  }
+  const request = {
+    url: `${config.BROKER_CLIENT_URL}/healthcheck`,
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+  };
+  try {
+    const response: HttpResponse = await retry<HttpResponse>(
+      () => makeSingleRawRequestToDownstream(request),
+      { retries: 3, operation: 'config check broker-client-url-validation' },
+    );
+    logger.trace({ response: response }, 'config check raw response data');
+    return { terminated: true };
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    logger.warn(
+      { err, url: request.url },
+      `Failed to reach the BROKER_CLIENT_URL during TLS-termination probe: ${cause}.`,
+    );
+    return { terminated: false, probeError: cause };
+  }
 }
 
 function isHostnameLocalhost(brokerClientUrl: string): boolean {

--- a/lib/hybrid-sdk/client/checks/http/http-executor.ts
+++ b/lib/hybrid-sdk/client/checks/http/http-executor.ts
@@ -51,9 +51,10 @@ export async function executeHttpRequest(
     );
     return Promise.resolve(checkResult);
   } catch (error) {
-    const errorMessage = `Error executing check with checkId ${checkOptions.id}`;
-    logger.debug({ error }, errorMessage);
-    throw new Error(errorMessage);
+    if (error instanceof Error) {
+      error.message = `Error executing check with checkId ${checkOptions.id}: ${error.message}`;
+    }
+    throw error;
   }
 }
 

--- a/lib/hybrid-sdk/client/connectionsManager/manager.ts
+++ b/lib/hybrid-sdk/client/connectionsManager/manager.ts
@@ -53,6 +53,7 @@ export const manageWebsocketConnections = async (
         clientOpts.config,
         clientOpts.config.brokerClientConfiguration.common.oauth.clientId,
         clientOpts.config.brokerClientConfiguration.common.oauth.clientSecret,
+        clientOpts.metricsClient,
       );
 
       await retrieveConnectionsForDeployment(

--- a/lib/hybrid-sdk/client/metrics/client.ts
+++ b/lib/hybrid-sdk/client/metrics/client.ts
@@ -33,6 +33,14 @@ export interface Client {
   /** Increment broker.client.auth_renewal_failure.total for non-2xx auth renewal responses. */
   recordAuthRenewalFailure(statusCode: number): void;
 
+  /**
+   * Increment broker.client.jwt_refresh_failure.total when the OAuth JWT exchange
+   * against the Snyk API fails. Distinct from recordAuthRenewalFailure (which is for
+   * broker-server credentials renewal): this counter tracks the OAuth bearer-token
+   * lifecycle. Sustained failures break Universal Broker silently.
+   */
+  recordJwtRefreshFailure(): void;
+
   /** Increment broker.client.uncaught_exception.total. */
   recordUncaughtException(errorCode: string): void;
 

--- a/lib/hybrid-sdk/client/metrics/noopClient.ts
+++ b/lib/hybrid-sdk/client/metrics/noopClient.ts
@@ -13,6 +13,7 @@ export class NoopClient implements Client {
   recordReconnect(): void {}
   recordProcessExit(): void {}
   recordAuthRenewalFailure(): void {}
+  recordJwtRefreshFailure(): void {}
   recordUncaughtException(): void {}
 
   recordRequest(): void {}

--- a/lib/hybrid-sdk/client/metrics/otelClient.ts
+++ b/lib/hybrid-sdk/client/metrics/otelClient.ts
@@ -50,6 +50,7 @@ export class OtelClient implements Client {
   private readonly reconnectCounter: Counter;
   private readonly processExitCounter: Counter;
   private readonly authRenewalFailureCounter: Counter;
+  private readonly jwtRefreshFailureCounter: Counter;
   private readonly uncaughtExceptionCounter: Counter;
 
   // Request Flow
@@ -141,6 +142,15 @@ export class OtelClient implements Client {
       'broker.client.auth_renewal_failure.total',
       {
         description: 'Auth renewal HTTP failures by status code.',
+        valueType: ValueType.INT,
+      },
+    );
+
+    this.jwtRefreshFailureCounter = meter.createCounter(
+      'broker.client.jwt_refresh_failure.total',
+      {
+        description:
+          'OAuth JWT refresh failures. Sustained non-zero values mean Universal Broker is losing or has lost its bearer token and will stop processing traffic.',
         valueType: ValueType.INT,
       },
     );
@@ -302,6 +312,10 @@ export class OtelClient implements Client {
     this.authRenewalFailureCounter.add(1, {
       status_code: String(statusCode),
     });
+  }
+
+  recordJwtRefreshFailure(): void {
+    this.jwtRefreshFailureCounter.add(1);
   }
 
   recordUncaughtException(errorCode: string): void {

--- a/test/unit/client/auth/oauth.test.ts
+++ b/test/unit/client/auth/oauth.test.ts
@@ -1,0 +1,213 @@
+import {
+  fetchAndUpdateJwt,
+  setfetchAndUpdateJwt,
+  getAuthConfig,
+} from '../../../../lib/hybrid-sdk/client/auth/oauth';
+import { log as logger } from '../../../../lib/logs/logger';
+import type { Client as MetricsClient } from '../../../../lib/hybrid-sdk/client/metrics/client';
+
+const nock = require('nock');
+
+const API_HOST = 'https://api.example.test';
+
+function makeMockMetricsClient(): jest.Mocked<MetricsClient> {
+  return {
+    incrementBrokerClientMetric: jest.fn(),
+    shutdown: jest.fn().mockResolvedValue(undefined),
+    forceFlush: jest.fn().mockResolvedValue(undefined),
+    setConnectionState: jest.fn(),
+    recordReconnect: jest.fn(),
+    recordProcessExit: jest.fn(),
+    recordAuthRenewalFailure: jest.fn(),
+    recordJwtRefreshFailure: jest.fn(),
+    recordUncaughtException: jest.fn(),
+    recordRequest: jest.fn(),
+    recordDownstreamRequest: jest.fn(),
+    recordDownstreamDuration: jest.fn(),
+    recordDownstreamStatus: jest.fn(),
+    recordConnectionDuration: jest.fn(),
+    recordUpstreamResponseBytes: jest.fn(),
+    incrementInflight: jest.fn(),
+    decrementInflight: jest.fn(),
+    recordPingLatency: jest.fn(),
+  } as unknown as jest.Mocked<MetricsClient>;
+}
+
+describe('client/auth/oauth — JWT refresh observability', () => {
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    nock.cleanAll();
+    errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => logger);
+  });
+
+  afterEach(async () => {
+    nock.cleanAll();
+    await new Promise((r) => setTimeout(r, 50));
+    errorSpy.mockRestore();
+  });
+
+  async function waitFor(
+    predicate: () => boolean,
+    timeoutMs = 2000,
+    intervalMs = 10,
+  ): Promise<void> {
+    const start = Date.now();
+    while (!predicate()) {
+      if (Date.now() - start > timeoutMs) {
+        throw new Error(`waitFor: timed out after ${timeoutMs}ms`);
+      }
+      await new Promise((r) => setTimeout(r, intervalMs));
+    }
+  }
+
+  describe('fetchAndUpdateJwt', () => {
+    it('logs failures with a structured {err} field (not a template string)', async () => {
+      nock(API_HOST)
+        .post('/oauth2/token')
+        .reply(
+          500,
+          JSON.stringify({
+            error: 'server_error',
+            error_description: 'kaboom',
+          }),
+        );
+
+      const result = await fetchAndUpdateJwt(API_HOST, 'cid', 'csecret');
+
+      expect(result).toBeUndefined();
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+
+      const [fields, message] = errorSpy.mock.calls[0];
+      expect(typeof fields).toBe('object');
+      expect(fields).toHaveProperty('err');
+      expect(fields.err).toBeInstanceOf(Error);
+      expect(message).toBe('Unable to retrieve JWT');
+    });
+
+    it('returns the parsed token on success', async () => {
+      nock(API_HOST).post('/oauth2/token').reply(200, {
+        access_token: 'tok-123',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        scope: 'broker',
+      });
+
+      const result = await fetchAndUpdateJwt(API_HOST, 'cid', 'csecret');
+
+      expect(result).toEqual({
+        expiresIn: 3600,
+        authHeader: 'Bearer tok-123',
+      });
+      expect(getAuthConfig().accessToken).toEqual(result);
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('refreshJwt failure path (via setfetchAndUpdateJwt + timers)', () => {
+    it('fires recordJwtRefreshFailure and logs structured {err} when refresh fails', async () => {
+      const metricsClient = makeMockMetricsClient();
+
+      nock(API_HOST).post('/oauth2/token').reply(200, {
+        access_token: 'first',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        scope: 'broker',
+      });
+      nock(API_HOST)
+        .post('/oauth2/token')
+        .reply(
+          500,
+          JSON.stringify({
+            error: 'server_error',
+            error_description: 'still down',
+          }),
+        );
+
+      await setfetchAndUpdateJwt(
+        { apiHostname: API_HOST, AUTH_EXPIRATION_OVERRIDE: 10 },
+        'cid',
+        'csecret',
+        metricsClient,
+      );
+
+      expect(metricsClient.recordJwtRefreshFailure).not.toHaveBeenCalled();
+      await waitFor(
+        () =>
+          (metricsClient.recordJwtRefreshFailure as jest.Mock).mock.calls
+            .length > 0,
+      );
+
+      expect(metricsClient.recordJwtRefreshFailure).toHaveBeenCalledTimes(1);
+      const refreshErrorCall = errorSpy.mock.calls.find(
+        ([, msg]) => msg === 'Error retrieving new JWT',
+      );
+      expect(refreshErrorCall).toBeDefined();
+      const [fields] = refreshErrorCall!;
+      expect(typeof fields).toBe('object');
+      expect(fields).toHaveProperty('err');
+      expect(fields.err).toBeInstanceOf(Error);
+      expect(refreshErrorCall![1]).toBe('Error retrieving new JWT');
+    });
+
+    it('does NOT fire recordJwtRefreshFailure when refresh succeeds', async () => {
+      const metricsClient = makeMockMetricsClient();
+
+      // Both calls succeed.
+      nock(API_HOST).post('/oauth2/token').reply(200, {
+        access_token: 'first',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        scope: 'broker',
+      });
+      nock(API_HOST).post('/oauth2/token').reply(200, {
+        access_token: 'second',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        scope: 'broker',
+      });
+
+      await setfetchAndUpdateJwt(
+        { apiHostname: API_HOST, AUTH_EXPIRATION_OVERRIDE: 10 },
+        'cid',
+        'csecret',
+        metricsClient,
+      );
+
+      // Wait for the refresh setTimeout to fire and the second token to land.
+      await waitFor(
+        () => getAuthConfig().accessToken?.authHeader === 'Bearer second',
+      );
+
+      expect(metricsClient.recordJwtRefreshFailure).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not crash when metricsClient is omitted (backwards compatibility)', async () => {
+      nock(API_HOST).post('/oauth2/token').reply(200, {
+        access_token: 'first',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        scope: 'broker',
+      });
+      nock(API_HOST).post('/oauth2/token').reply(500, '{}');
+
+      // No fourth argument — exercises the optional-chaining call site.
+      await expect(
+        setfetchAndUpdateJwt(
+          { apiHostname: API_HOST, AUTH_EXPIRATION_OVERRIDE: 10 },
+          'cid',
+          'csecret',
+        ),
+      ).resolves.toBeUndefined();
+
+      // Wait long enough for the scheduled refresh to fire and fail.
+      // The assertion is structural: the catch block ran without throwing.
+      await waitFor(() =>
+        errorSpy.mock.calls.some(
+          ([, msg]) => msg === 'Error retrieving new JWT',
+        ),
+      );
+    });
+  });
+});

--- a/test/unit/client/checks/config/brokerClientUrlCheck.test.ts
+++ b/test/unit/client/checks/config/brokerClientUrlCheck.test.ts
@@ -1,5 +1,6 @@
 import { aConfig } from '../../../../helpers/test-factories';
 import { validateBrokerClientUrl } from '../../../../../lib/hybrid-sdk/client/checks/config/brokerClientUrlCheck';
+import { log as logger } from '../../../../../lib/logs/logger';
 const nock = require('nock');
 
 describe('client/checks/config', () => {
@@ -38,7 +39,7 @@ describe('client/checks/config', () => {
       );
     });
 
-    it('should return error check result for https protocol without certificate and key', async () => {
+    it('should return error check result mentioning both remediation paths when probe fails', async () => {
       const id = `check_${Date.now()}`;
       const config = aConfig({
         BROKER_CLIENT_URL: 'https://broker-client:8000',
@@ -50,8 +51,10 @@ describe('client/checks/config', () => {
       );
 
       expect(checkResult.status).toEqual('error');
-      expect(checkResult.output).toContain(
-        'HTTPS_CERT and HTTPS_KEY environment variables are missing',
+      expect(checkResult.output).toContain('HTTPS_CERT and HTTPS_KEY');
+      expect(checkResult.output).toContain('BROKER_CLIENT_URL_TLS_TERMINATED');
+      expect(checkResult.output).toMatch(
+        /Probe to https:\/\/broker-client:8000\/healthcheck failed/,
       );
     });
 
@@ -139,6 +142,81 @@ describe('client/checks/config', () => {
 
       expect(checkResult.status).toEqual('passing');
       expect(checkResult.output).toContain('config check: ok');
+    });
+  });
+
+  /**
+   * Regression: the `isBrokerClientUrlTLSTerminated` catch at
+   * brokerClientUrlCheck.ts:112 used to log at DEBUG, hiding the underlying
+   * network failure at default log level. The customer-visible check output
+   * ("HTTPS_CERT and HTTPS_KEY environment variables are missing") is
+   * potentially misleading when the real cause is DNS / connection refused /
+   * TLS handshake / timeout — so the log must be visible by default (WARN).
+   *
+   * The test below drives the catch by failing the /healthcheck probe and
+   * asserts:
+   *  - logger.warn fires (NOT logger.debug)
+   *  - the log carries the original err for the operator to triage
+   *  - the log carries the probe url so the operator knows what failed
+   */
+  describe('BROKER_CLIENT_URL probe failure logging', () => {
+    let warnSpy: jest.SpyInstance;
+    let debugSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      nock.cleanAll();
+      warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => logger);
+      debugSpy = jest.spyOn(logger, 'debug').mockImplementation(() => logger);
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+      debugSpy.mockRestore();
+      nock.cleanAll();
+    });
+
+    it('logs at WARN with {err, url} when the BROKER_CLIENT_URL probe fails', async () => {
+      nock('https://broker-client:8000')
+        .persist()
+        .get('/healthcheck')
+        .replyWithError(
+          Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:443'), {
+            code: 'ECONNREFUSED',
+          }),
+        );
+
+      const config = aConfig({
+        BROKER_CLIENT_URL: 'https://broker-client:8000',
+      });
+
+      const checkResult = await validateBrokerClientUrl(
+        { id: 'broker-client-url-validation', name: 'check' },
+        config,
+      );
+
+      expect(checkResult.status).toEqual('error');
+      expect(checkResult.output).toContain('ECONNREFUSED');
+      expect(checkResult.output).toContain('HTTPS_CERT and HTTPS_KEY');
+      expect(checkResult.output).toContain('BROKER_CLIENT_URL_TLS_TERMINATED');
+      const probeWarn = warnSpy.mock.calls.find(
+        ([, msg]) =>
+          typeof msg === 'string' &&
+          msg.startsWith('Failed to reach the BROKER_CLIENT_URL'),
+      );
+
+      expect(probeWarn).toBeDefined();
+      const [fields, message] = probeWarn!;
+      expect(typeof fields).toBe('object');
+      expect(fields).toHaveProperty('err');
+      expect(fields).toHaveProperty('url');
+      expect(fields.url).toBe('https://broker-client:8000/healthcheck');
+      expect(message).toContain('ECONNREFUSED'); // from the nock-mocked err
+      const probeDebug = debugSpy.mock.calls.find(
+        ([, msg]) =>
+          typeof msg === 'string' &&
+          msg.startsWith('Failed to reach the BROKER_CLIENT_URL'),
+      );
+      expect(probeDebug).toBeUndefined();
     });
   });
 });

--- a/test/unit/client/checks/http/http-executor.error-handling.test.ts
+++ b/test/unit/client/checks/http/http-executor.error-handling.test.ts
@@ -1,0 +1,102 @@
+jest.mock(
+  '../../../../../lib/hybrid-sdk/client/retry/exponential-backoff',
+  () => ({
+    retry: async <T>(fn: () => Promise<T> | T) => fn(),
+  }),
+);
+
+// Replace the downstream HTTP call with a jest.fn we can drive per test.
+jest.mock('../../../../../lib/hybrid-sdk/http/request', () => ({
+  makeSingleRawRequestToDownstream: jest.fn(),
+}));
+
+import { executeHttpRequest } from '../../../../../lib/hybrid-sdk/client/checks/http/http-executor';
+import { makeSingleRawRequestToDownstream } from '../../../../../lib/hybrid-sdk/http/request';
+
+const mockedRequest = makeSingleRawRequestToDownstream as jest.MockedFunction<
+  typeof makeSingleRawRequestToDownstream
+>;
+
+const httpOptions = {
+  url: 'http://example.test/healthcheck',
+  method: 'GET' as const,
+  timeoutMs: 5000,
+};
+
+describe('executeHttpRequest — error-handling regression', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('preserves the original Error instance, message, and stack on rethrow', async () => {
+    const original = new Error('ECONNREFUSED 127.0.0.1:443');
+    // Capture the original stack so we can confirm it survives the rethrow.
+    const originalStack = original.stack;
+    (original as any).code = 'ECONNREFUSED';
+
+    mockedRequest.mockRejectedValueOnce(original);
+
+    let caught: unknown;
+    try {
+      await executeHttpRequest(
+        { id: 'broker-server-status', name: 'Broker Server Healthcheck' },
+        httpOptions,
+      );
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeDefined();
+    expect(caught).toBeInstanceOf(Error);
+
+    expect((caught as Error).message).toContain('broker-server-status');
+    expect((caught as Error).message).toContain('ECONNREFUSED 127.0.0.1:443');
+
+    expect((caught as Error).stack).toBe(
+      originalStack?.replace(original.message, (caught as Error).message) ??
+        expect.any(String),
+    );
+
+    expect(caught).toBe(original);
+    expect((caught as any).code).toBe('ECONNREFUSED');
+  });
+
+  it('lets non-Error throwables pass through unchanged', async () => {
+    mockedRequest.mockRejectedValueOnce('not an Error instance');
+
+    let caught: unknown;
+    try {
+      await executeHttpRequest(
+        { id: 'broker-server-status', name: 'Broker Server Healthcheck' },
+        httpOptions,
+      );
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBe('not an Error instance');
+  });
+
+  it('does not double-prefix when called twice with different check ids', async () => {
+    const err1 = new Error('boom');
+    const err2 = new Error('boom');
+    mockedRequest.mockRejectedValueOnce(err1).mockRejectedValueOnce(err2);
+
+    let caught1: any, caught2: any;
+    try {
+      await executeHttpRequest({ id: 'check-a', name: 'A' }, httpOptions);
+    } catch (e) {
+      caught1 = e;
+    }
+    try {
+      await executeHttpRequest({ id: 'check-b', name: 'B' }, httpOptions);
+    } catch (e) {
+      caught2 = e;
+    }
+
+    expect(caught1.message).toContain('check-a');
+    expect(caught1.message).not.toContain('check-b');
+    expect(caught2.message).toContain('check-b');
+    expect(caught2.message).not.toContain('check-a');
+  });
+});

--- a/test/unit/client/metrics/metricsClient.test.ts
+++ b/test/unit/client/metrics/metricsClient.test.ts
@@ -148,6 +148,7 @@ describe('client/metrics', () => {
       ['recordReconnect', []],
       ['recordProcessExit', ['reconnect_exhaustion']],
       ['recordAuthRenewalFailure', [503]],
+      ['recordJwtRefreshFailure', []],
       ['recordUncaughtException', ['ECONNRESET']],
       ['recordRequest', ['broker-server', true]],
       ['recordDownstreamRequest', [false]],
@@ -298,6 +299,17 @@ describe('client/metrics', () => {
       );
       expect(metric!.dataPoints[0].value).toBe(1);
       expect(metric!.dataPoints[0].attributes['status_code']).toBe('503');
+    });
+
+    it('records broker.client.jwt_refresh_failure.total', async () => {
+      client.recordJwtRefreshFailure();
+      client.recordJwtRefreshFailure();
+      const metric = await findMetric(
+        'broker.client.jwt_refresh_failure.total',
+      );
+      expect(metric).toBeDefined();
+      expect(metric!.dataPointType).toBe(DataPointType.SUM);
+      expect(metric!.dataPoints[0].value).toBe(2);
     });
 
     it('records broker.client.uncaught_exception.total with error_code', async () => {


### PR DESCRIPTION
  ## Summary

  Three loosely-related diagnostic improvements to the Broker Client, surfaced during a log-levels audit. No breaking API changes; one customer-visible wording change in preflight check output (improved, not regressed).

  ## Changes

  ### JWT refresh — make the silent-death path observable

  `refreshJwt` logged failures with `` logger.error(`...${err}`) ``, which bypassed bunyan's `err` serializer and dropped the stack. When Universal Broker lost its bearer token in production, operators had no diagnostic.

  - Switched to structured `logger.error({ err }, '...')` form.
  - Added metric `broker.client.jwt_refresh_failure.total` so the failure is detectable from monitoring alone.
  - Wired through `setfetchAndUpdateJwt` via a new **optional** `metricsClient` argument — back-compatible.

  ### Preflight checks — preserve original Error on rethrow

  `executeHttpRequest` and `validateBrokerClientUrl` rethrew caught errors with `throw new Error(errorMessage)`, discarding stack, `code`, and underlying cause. Upstream `logger.error` in `checks/index.ts` only saw the generic wrapped message.

  Now mutates the original `Error`'s message to prefix the check id and rethrows the same instance — stack and custom fields survive for the upstream handler.

  ### `BROKER_CLIENT_URL` preflight — stop blaming the certs

  When the HTTPS probe failed (DNS, ECONNREFUSED, TLS handshake, timeout, …) the check used to report:

  > Broker Client URL uses the HTTPS protocol: https://…, but HTTPS_CERT and HTTPS_KEY environment variables are missing.

  — sending customers down the wrong remediation path when they actually had upstream TLS termination but a connectivity issue.

  It now reports:

  > Broker Client URL uses the HTTPS protocol: https://…, but the broker could not verify how TLS is being terminated. Probe to https://…/healthcheck failed: `connect ECONNREFUSED 127.0.0.1:443`. Either configure `HTTPS_CERT` and `HTTPS_KEY` so the broker terminates TLS itself, or set `BROKER_CLIENT_URL_TLS_TERMINATED=true` if TLS is already terminated upstream (e.g. behind a reverse proxy).

  Refactored `isBrokerClientUrlTLSTerminated` → `checkTLSTermination`, returning a discriminated union carrying the probe cause. Probe-failure log promoted DEBUG → WARN with `err.message` inlined for one-line operator triage.

  ## Test plan

  - [x] New / extended unit tests pin all three contracts:
    - `test/unit/client/auth/oauth.test.ts` (new)
    - `test/unit/client/checks/http/http-executor.error-handling.test.ts` (new)
    - `test/unit/client/checks/config/brokerClientUrlCheck.test.ts` (extended)
    - `test/unit/client/metrics/metricsClient.test.ts` (extended)
  - [x] `npm run lint` clean on changed files
  - [x] No regressions in existing tests

  ## Notes for reviewers

  - The customer-facing preflight output wording change is the only behaviour that downstream tooling could notice. If any customer CI scripts grep for the literal `"HTTPS_CERT and HTTPS_KEY environment variables are missing"`, those will need updating — but the new message is more correct and still contains `HTTPS_CERT and HTTPS_KEY` as a substring.
  - The new `metricsClient` parameter on `setfetchAndUpdateJwt` is optional, so no internal callers break.