### PR TITLE
fix: surface non-2xx SCM responses as WARN

### DIFF
--- a/lib/broker-workload/websocketRequests.ts
+++ b/lib/broker-workload/websocketRequests.ts
@@ -238,14 +238,18 @@ export class BrokerWorkload extends Workload<WorkloadType.remoteServer> {
               statusClass(response?.statusCode),
             );
             const status = (response && response.statusCode) || 500;
-            if (status > 404) {
+            // Threshold matches downstream-post-stream-to-server.ts: surface
+            // 401/403 and all 5xx (customer-actionable auth/scope/upstream
+            // issues) but skip 404, which is often a probe on the happy path.
+            // Prior `status > 404` accidentally also silenced 401/402/403.
+            if (status >= 400 && status !== 404) {
               logger.warn(
                 {
                   statusCode: response.statusCode,
                   url: preparedRequest.req.url,
                   requestId: logContext.requestId,
                 },
-                `[Websocket Flow][Inbound] Unexpected status code for relayed request.`,
+                `[Websocket Flow][Inbound] Non-2xx response from downstream SCM.`,
               );
             }
             responseHandler.sendDataResponse(response, logContext);

--- a/lib/hybrid-sdk/http/downstream-post-stream-to-server.ts
+++ b/lib/hybrid-sdk/http/downstream-post-stream-to-server.ts
@@ -52,6 +52,11 @@ interface Logger {
     context: Partial<ExtendedLogContext> & Record<string, any>,
     message: string,
   ): void;
+  warn(message: string): void;
+  warn(
+    context: Partial<ExtendedLogContext> & Record<string, any>,
+    message: string,
+  ): void;
   error(message: string): void;
   error(
     context: Partial<ExtendedLogContext> & Record<string, any>,
@@ -539,12 +544,29 @@ class BrokerServerPostResponseHandler {
         'downstream TCP connection details',
       );
       const status = response?.statusCode || 500;
-      this.#logger.debug(
-        {
-          responseStatus: status.toString(),
-        },
-        'response received, setting up stream to Broker Server',
-      );
+      // Promote non-2xx responses from the downstream SCM to WARN so they
+      // are visible at default log level. Without this, operators (and
+      // customers) had to enable LOG_LEVEL=debug to diagnose 401/403/5xx
+      // from their SCM — and then drown in TLS/TCP/chunk chatter.
+      // 404 is excluded because some SCM integrations rely on 404-as-probe
+      // (e.g. "does this repo exist?") on the happy path; emitting WARN for
+      // them would itself become noise.
+      if (status >= 400 && status !== 404) {
+        this.#logger.warn(
+          {
+            responseStatus: status.toString(),
+            streamingID,
+          },
+          'Non-2xx response from downstream SCM',
+        );
+      } else {
+        this.#logger.debug(
+          {
+            responseStatus: status.toString(),
+          },
+          'response received, setting up stream to Broker Server',
+        );
+      }
       const isResponseJson = isJson(response.headers);
       const ioData = JSON.stringify({
         status,

--- a/lib/hybrid-sdk/requestsHelper.ts
+++ b/lib/hybrid-sdk/requestsHelper.ts
@@ -71,13 +71,17 @@ export const makeLegacyRequest = async (
       const replaced = replaceUrlPartialChunk(response.body, null, options);
       response.body = replaced.newChunk;
     }
-    if (status > 404) {
+    // Threshold matches downstream-post-stream-to-server.ts: surface 401/403
+    // and all 5xx (customer-actionable auth/scope/upstream issues) but skip
+    // 404, which is often a probe on the happy path. Prior `status > 404`
+    // accidentally also silenced 401/402/403, hiding customer-ticket cases.
+    if (status >= 400 && status !== 404) {
       logger.warn(
         {
           statusCode: response.statusCode,
           url: req.url,
         },
-        `[Websocket Flow][Inbound] Unexpected status code for relayed request.`,
+        `[Websocket Flow][Inbound] Non-2xx response from downstream SCM.`,
       );
     }
     logResponse(logContext, status, response, options);

--- a/test/unit/lib/hybrid-sdk/http/downstream-post-stream-to-server.test.ts
+++ b/test/unit/lib/hybrid-sdk/http/downstream-post-stream-to-server.test.ts
@@ -17,6 +17,7 @@ interface CapturedLogCall {
 
 class TestLogger {
   errorCalls: CapturedLogCall[] = [];
+  warnCalls: CapturedLogCall[] = [];
   debugCalls: CapturedLogCall[] = [];
   context: Record<string, any> = {};
 
@@ -38,6 +39,30 @@ class TestLogger {
       });
     } else {
       this.errorCalls.push({
+        context: { ...this.context, ...contextOrMessage },
+        message: message || '',
+      });
+    }
+  }
+
+  warn(message: string): void;
+  warn(
+    context: Partial<ExtendedLogContext> & Record<string, any>,
+    message: string,
+  ): void;
+  warn(
+    contextOrMessage:
+      | string
+      | (Partial<ExtendedLogContext> & Record<string, any>),
+    message?: string,
+  ): void {
+    if (typeof contextOrMessage === 'string') {
+      this.warnCalls.push({
+        context: { ...this.context },
+        message: contextOrMessage,
+      });
+    } else {
+      this.warnCalls.push({
         context: { ...this.context, ...contextOrMessage },
         message: message || '',
       });
@@ -74,6 +99,7 @@ class TestLogger {
     const childLogger = new TestLogger();
     childLogger.context = { ...this.context, ...additionalContext };
     childLogger.errorCalls = this.errorCalls; // Share error calls array
+    childLogger.warnCalls = this.warnCalls; // Share warn calls array
     childLogger.debugCalls = this.debugCalls; // Share debug calls array
     return childLogger;
   }
@@ -1096,5 +1122,99 @@ describe('BrokerServerPostResponseHandler', () => {
 
       mockSocket.destroy();
     }, 30000);
+  });
+
+  /**
+   * Regression: the SCM-response status was previously logged only at DEBUG
+   * (`response received, setting up stream to Broker Server`), so customers
+   * hitting 401 / 403 / 5xx from their SCM had no visible signal at default
+   * log level. The fix splits the log by status — DEBUG for success and 404
+   * (commonly a probe pattern), WARN for any other non-2xx so it surfaces.
+   *
+   * These tests pin the routing so the silent-non-2xx regression cannot
+   * recur. They drive `forwardRequest` end-to-end with nock absorbing the
+   * downstream POST, then inspect the captured log calls.
+   */
+  describe('SCM response status logging', () => {
+    beforeEach(() => {
+      setConfig({
+        brokerServerUrl,
+        universalBrokerEnabled: false,
+        universalBrokerGa: false,
+      });
+    });
+
+    async function drive(scmStatus: number) {
+      nock(brokerServerUrl)
+        .post(`/response-data/${brokerToken}/${streamingId}`)
+        .query(true)
+        .reply(200, 'OK');
+
+      const handler = createHandler();
+      const mockSocket = new Socket();
+      const mockResponse = new http.IncomingMessage(mockSocket);
+      mockResponse.statusCode = scmStatus;
+      mockResponse.headers = { 'content-type': 'application/json' };
+
+      const forwardPromise = handler.forwardRequest(mockResponse, streamingId);
+      // push(null) signals end-of-stream so the readable side of the
+      // pipeline drains and forwardRequest resolves. Matches the working
+      // pattern used by the duration-tracking tests above.
+      process.nextTick(() => mockResponse.push(null));
+      await forwardPromise;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      mockSocket.destroy();
+    }
+
+    it.each([401, 403, 500, 502, 503])(
+      'logs WARN when SCM returns %d',
+      async (scmStatus) => {
+        await drive(scmStatus);
+
+        const warnCall = testLogger.warnCalls.find(
+          (c) => c.message === 'Non-2xx response from downstream SCM',
+        );
+        expect(warnCall).toBeDefined();
+        expect(warnCall?.context).toMatchObject({
+          responseStatus: String(scmStatus),
+          streamingID: streamingId,
+        });
+
+        // Regression guard: the success-path DEBUG must NOT also fire for
+        // a non-2xx status, otherwise the operator gets two log lines for
+        // one event.
+        const debugCall = testLogger.debugCalls.find(
+          (c) =>
+            c.message ===
+            'response received, setting up stream to Broker Server',
+        );
+        expect(debugCall).toBeUndefined();
+      },
+    );
+
+    it.each([200, 201, 204, 301, 302, 404])(
+      'logs DEBUG (not WARN) when SCM returns %d',
+      async (scmStatus) => {
+        await drive(scmStatus);
+
+        const debugCall = testLogger.debugCalls.find(
+          (c) =>
+            c.message ===
+            'response received, setting up stream to Broker Server',
+        );
+        expect(debugCall).toBeDefined();
+        expect(debugCall?.context).toMatchObject({
+          responseStatus: String(scmStatus),
+        });
+
+        // Regression guard: 404 is intentionally not WARN — common
+        // probe-pattern on the happy path. Same applies to 2xx/3xx.
+        const warnCall = testLogger.warnCalls.find(
+          (c) => c.message === 'Non-2xx response from downstream SCM',
+        );
+        expect(warnCall).toBeUndefined();
+      },
+    );
   });
 });

--- a/test/unit/lib/hybrid-sdk/requestsHelper.test.ts
+++ b/test/unit/lib/hybrid-sdk/requestsHelper.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression tests for the SCM-response status logging in
+ * `makeLegacyRequest` (lib/hybrid-sdk/requestsHelper.ts).
+ *
+ * The original code logged WARN only for `status > 404`, which silently
+ * dropped 401 / 402 / 403 / 404 — exactly the customer-ticket cases
+ * (token expired, scope wrong, repo gone). The fix is `status >= 400 &&
+ * status !== 404`, matching the threshold used in the streaming SCM
+ * path at downstream-post-stream-to-server.ts:541.
+ *
+ * These tests pin the new contract so the off-by-one cannot recur.
+ */
+
+import { log as logger } from '../../../../lib/logs/logger';
+import { makeRequestToDownstream } from '../../../../lib/hybrid-sdk/http/request';
+import { makeLegacyRequest } from '../../../../lib/hybrid-sdk/requestsHelper';
+
+jest.mock('../../../../lib/logs/logger');
+jest.mock('../../../../lib/hybrid-sdk/http/request', () => ({
+  makeRequestToDownstream: jest.fn(),
+}));
+
+const mockedDownstream = makeRequestToDownstream as jest.MockedFunction<
+  typeof makeRequestToDownstream
+>;
+
+const req: any = {
+  url: 'https://scm.example.com/repos/owner/name',
+  method: 'GET',
+  headers: {},
+};
+const options: any = {
+  socketMaxResponseLength: 20971520,
+};
+const logContext: any = { requestId: 'test-request' };
+
+describe('makeLegacyRequest — SCM response status logging', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([401, 403, 405, 500, 502, 503])(
+    'logs WARN when SCM returns %d',
+    async (statusCode) => {
+      mockedDownstream.mockResolvedValueOnce({
+        statusCode,
+        body: '',
+        headers: {},
+      } as any);
+      const emitCallback = jest.fn();
+
+      await makeLegacyRequest(req, emitCallback, logContext, options);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode,
+          url: req.url,
+        }),
+        expect.stringContaining(
+          '[Websocket Flow][Inbound] Non-2xx response from downstream SCM',
+        ),
+      );
+    },
+  );
+
+  it.each([200, 201, 204, 301, 302, 404])(
+    'does NOT log WARN when SCM returns %d',
+    async (statusCode) => {
+      mockedDownstream.mockResolvedValueOnce({
+        statusCode,
+        body: '',
+        headers: {},
+      } as any);
+      const emitCallback = jest.fn();
+
+      await makeLegacyRequest(req, emitCallback, logContext, options);
+
+      // Regression guard for the old `status > 404` threshold: 401/402/403
+      // used to be silenced because the old test was `> 404` not `>= 400`.
+      // 404 stays silent intentionally (common SCM probe pattern); the new
+      // threshold is `>= 400 && !== 404`. 2xx/3xx also stay silent.
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining(
+          '[Websocket Flow][Inbound] Non-2xx response from downstream SCM',
+        ),
+      );
+    },
+  );
+});


### PR DESCRIPTION
  ## Summary

  Non-2xx responses from the customer's SCM were invisible at default log level on the streaming path. Two parallel non-streaming sites used `status > 404`, silently dropping 401/402/403 — the most common customer-ticket cases.

  ## Changes

  - **`downstream-post-stream-to-server.ts`** — split log by status. WARN for `status >= 400 && status !== 404`; DEBUG for 2xx/3xx/404.
  - **`requestsHelper.ts`** + **`websocketRequests.ts`** — threshold corrected from `> 404` to `>= 400 && !== 404`. Message aligned across all three sites.

  **404 is intentionally excluded** — common SCM probe pattern ("does this repo exist?"). Easy to flip to just `>= 400` if prod data shows otherwise.

  ## Before / after

  Customer's PAT expires → SCM returns 401:

  - **Before:** silent at default log level; needs `LOG_LEVEL=debug` to diagnose, then drown in TLS/chunk chatter.
  - **After:** `WARN  Non-2xx response from downstream SCM   responseStatus: "401"`
