### PR TITLE
refactor: log levels for ws/requests

### DIFF
--- a/lib/broker-workload/websocketRequests.ts
+++ b/lib/broker-workload/websocketRequests.ts
@@ -122,7 +122,7 @@ export class BrokerWorkload extends Workload<WorkloadType.remoteServer> {
 
     const simplifiedContext = structuredClone(logContext);
     delete simplifiedContext.requestHeaders;
-    logger.info(
+    logger.debug(
       simplifiedContext,
       `[Websocket Flow] Received request from ${
         process.env.BROKER_TYPE == 'client' ? 'client' : 'server'

--- a/lib/hybrid-sdk/clientRequestHelpers.ts
+++ b/lib/hybrid-sdk/clientRequestHelpers.ts
@@ -55,7 +55,7 @@ export class HybridClientRequestHandler {
 
     this.simplifiedContext = this.logContext;
     delete this.simplifiedContext.requestHeaders;
-    logger.info(this.simplifiedContext, '[HTTP Flow] Received request.');
+    logger.debug(this.simplifiedContext, '[HTTP Flow] Received request.');
   }
 
   private makeWebsocketRequestWithStreamingResponse() {

--- a/lib/logs/log.ts
+++ b/lib/logs/log.ts
@@ -5,7 +5,7 @@ export const logResponse = (logContext, status, response, config) => {
   logContext.responseBody =
     config && config.LOG_ENABLE_BODY === 'true' ? response.body : null;
 
-  logger.info(logContext, 'Sending response back to websocket connection.');
+  logger.debug(logContext, 'Sending response back to websocket connection.');
 };
 
 export const logError = (logContext, error) => {

--- a/test/unit/lib/broker-workload/websocketRequests.test.ts
+++ b/test/unit/lib/broker-workload/websocketRequests.test.ts
@@ -49,7 +49,7 @@ describe('BrokerWorkload', () => {
 
     await workload.handler({ payload, websocketHandler });
 
-    expect(logger.info).toHaveBeenCalledWith(
+    expect(logger.debug).toHaveBeenCalledWith(
       expect.objectContaining({
         contextId: 'some-uuid',
       }),
@@ -73,7 +73,7 @@ describe('BrokerWorkload', () => {
 
     await workload.handler({ payload, websocketHandler });
 
-    expect(logger.info).toHaveBeenCalledWith(
+    expect(logger.debug).toHaveBeenCalledWith(
       expect.objectContaining({
         contextId: undefined,
       }),

--- a/test/unit/lib/hybrid-sdk/clientRequestHelpers.test.ts
+++ b/test/unit/lib/hybrid-sdk/clientRequestHelpers.test.ts
@@ -1,0 +1,42 @@
+import { log as logger } from '../../../../lib/logs/logger';
+import { HybridClientRequestHandler } from '../../../../lib/hybrid-sdk/clientRequestHelpers';
+
+jest.mock('../../../../lib/logs/logger');
+jest.mock('../../../../lib/hybrid-sdk/common/config/config', () => ({
+  getConfig: jest.fn(() => ({})),
+}));
+
+// Silence the side-effecting transitive imports (NodeCache init + axios) —
+// they have nothing to do with the log-level under test.
+jest.mock('../../../../lib/hybrid-sdk/http/server-post-stream-handler', () => ({
+  streamsStore: { set: jest.fn(), get: jest.fn(), del: jest.fn() },
+}));
+jest.mock('../../../../lib/hybrid-sdk/http/request', () => ({
+  makeRequestToDownstream: jest.fn(),
+}));
+
+describe('HybridClientRequestHandler — [HTTP Flow] Received request log level', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('logs the per-request "Received request" line at DEBUG (not INFO)', () => {
+    const req: any = {
+      url: '/some/path',
+      method: 'GET',
+      headers: {},
+    };
+    const res: any = {};
+
+    new HybridClientRequestHandler(req, res);
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.any(Object),
+      '[HTTP Flow] Received request.',
+    );
+    expect(logger.info).not.toHaveBeenCalledWith(
+      expect.anything(),
+      '[HTTP Flow] Received request.',
+    );
+  });
+});

--- a/test/unit/lib/logs/log.test.ts
+++ b/test/unit/lib/logs/log.test.ts
@@ -1,0 +1,26 @@
+import { log as logger } from '../../../../lib/logs/logger';
+import { logResponse } from '../../../../lib/logs/log';
+
+jest.mock('../../../../lib/logs/logger');
+
+describe('logResponse — log level', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('logs the per-response "Sending response back" line at DEBUG (not INFO)', () => {
+    const logContext: any = { requestId: 'test-request' };
+    const response: any = { body: 'irrelevant' };
+
+    logResponse(logContext, 200, response, undefined);
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({ responseStatus: 200 }),
+      'Sending response back to websocket connection.',
+    );
+    expect(logger.info).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'Sending response back to websocket connection.',
+    );
+  });
+});


### PR DESCRIPTION
Changes
  - lib/hybrid-sdk/clientRequestHelpers.ts:58 — [HTTP Flow] Received request. → DEBUG
  - lib/broker-workload/websocketRequests.ts:125 — [Websocket Flow] Received request from … → DEBUG
  - lib/logs/log.ts:8 — logResponse "Sending response back…" → DEBUG 
  - test/unit/lib/broker-workload/websocketRequests.test.ts — regression tests
  - New: test/unit/lib/hybrid-sdk/clientRequestHelpers.test.ts and test/unit/lib/logs/log.test.ts pinning the new DEBUG level
