### PR TITLE
fix: retry oauth token refresh

### DIFF
--- a/lib/hybrid-sdk/client/auth/oauth.ts
+++ b/lib/hybrid-sdk/client/auth/oauth.ts
@@ -1,3 +1,4 @@
+import { v4 as uuid } from 'uuid';
 import { PostFilterPreparedRequest } from '../../../broker-workload/prepareRequest';
 import { makeRequestToDownstream } from '../../http/request';
 import { log as logger } from '../../../logs/logger';
@@ -24,6 +25,7 @@ export async function fetchAndUpdateJwt(
   apiHostname: string,
   clientId: string,
   clientSecret: string,
+  requestId: string = uuid(),
 ) {
   try {
     const data = {
@@ -35,7 +37,10 @@ export async function fetchAndUpdateJwt(
 
     const request: PostFilterPreparedRequest = {
       url: `${apiHostname}/oauth2/token`,
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Snyk-Request-Id': requestId,
+      },
       method: 'POST',
       body: formData.toString(),
     };
@@ -59,9 +64,20 @@ export async function fetchAndUpdateJwt(
     });
     return { expiresIn: expiresIn, authHeader: `${type} ${jwt}` };
   } catch (err) {
-    logger.error({ err }, 'Unable to retrieve JWT');
+    logger.error({ err, requestId }, 'Unable to retrieve JWT');
   }
 }
+
+const JWT_REFRESH_RETRY_ON_FAILURE_MS = 30_000;
+
+let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+
+export const stopJwtRefresh = () => {
+  if (refreshTimer) {
+    clearTimeout(refreshTimer);
+    refreshTimer = null;
+  }
+};
 
 const refreshJwt = async (
   clientConfig,
@@ -69,12 +85,15 @@ const refreshJwt = async (
   clientSecret,
   metricsClient?: MetricsClient,
 ) => {
-  logger.debug({}, 'Refreshing oauth access token');
+  const requestId = uuid();
+  logger.debug({ requestId }, 'Refreshing oauth access token');
+  let nextDelayMs: number;
   try {
     const newJwt = await fetchAndUpdateJwt(
       clientConfig.apiHostname,
       clientId,
       clientSecret,
+      requestId,
     );
     if (!newJwt) {
       throw new Error('Error retrieving new JWT:undefined.');
@@ -83,13 +102,17 @@ const refreshJwt = async (
       expiresIn: newJwt.expiresIn,
       authHeader: newJwt.authHeader,
     });
-    setTimeout(async () => {
-      refreshJwt(clientConfig, clientId, clientSecret, metricsClient);
-    }, clientConfig.AUTH_EXPIRATION_OVERRIDE ?? (newJwt.expiresIn - 60) * 1000);
+    nextDelayMs =
+      clientConfig.AUTH_EXPIRATION_OVERRIDE ?? (newJwt.expiresIn - 60) * 1000;
   } catch (err) {
     metricsClient?.recordJwtRefreshFailure();
-    logger.error({ err }, 'Error retrieving new JWT');
+    logger.error({ err, requestId }, 'Error retrieving new JWT');
+    nextDelayMs =
+      clientConfig.AUTH_EXPIRATION_OVERRIDE ?? JWT_REFRESH_RETRY_ON_FAILURE_MS;
   }
+  refreshTimer = setTimeout(() => {
+    refreshJwt(clientConfig, clientId, clientSecret, metricsClient);
+  }, nextDelayMs);
 };
 
 export const setfetchAndUpdateJwt = async (
@@ -98,14 +121,17 @@ export const setfetchAndUpdateJwt = async (
   clientSecret,
   metricsClient?: MetricsClient,
 ) => {
+  stopJwtRefresh();
+  const requestId = uuid();
   const newJwt = await fetchAndUpdateJwt(
     clientConfig.apiHostname,
     clientId,
     clientSecret,
+    requestId,
   );
-  logger.debug({}, 'Setting auth updater.');
+  logger.debug({ requestId }, 'Setting auth updater.');
   if (newJwt) {
-    setTimeout(async () => {
+    refreshTimer = setTimeout(async () => {
       refreshJwt(clientConfig, clientId, clientSecret, metricsClient);
     }, clientConfig.AUTH_EXPIRATION_OVERRIDE ?? (newJwt.expiresIn - 60) * 1000);
   }

--- a/lib/hybrid-sdk/client/auth/oauth.ts
+++ b/lib/hybrid-sdk/client/auth/oauth.ts
@@ -1,8 +1,12 @@
+import { EventEmitter } from 'events';
 import { v4 as uuid } from 'uuid';
 import { PostFilterPreparedRequest } from '../../../broker-workload/prepareRequest';
 import { makeRequestToDownstream } from '../../http/request';
 import { log as logger } from '../../../logs/logger';
 import type { Client as MetricsClient } from '../metrics/client';
+
+export const OAUTH_TOKEN_REJECTED_EVENT = 'token-rejected';
+export const oauthEvents = new EventEmitter();
 
 interface tokenExchangeResponse {
   access_token: string;
@@ -71,12 +75,31 @@ export async function fetchAndUpdateJwt(
 const JWT_REFRESH_RETRY_ON_FAILURE_MS = 30_000;
 
 let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+let inflightRefresh: Promise<void> | null = null;
 
 export const stopJwtRefresh = () => {
   if (refreshTimer) {
     clearTimeout(refreshTimer);
     refreshTimer = null;
   }
+};
+
+const startRefreshJwt = (
+  clientConfig,
+  clientId,
+  clientSecret,
+  metricsClient?: MetricsClient,
+) => {
+  if (inflightRefresh) return;
+  stopJwtRefresh();
+  inflightRefresh = refreshJwt(
+    clientConfig,
+    clientId,
+    clientSecret,
+    metricsClient,
+  ).finally(() => {
+    inflightRefresh = null;
+  });
 };
 
 const refreshJwt = async (
@@ -111,7 +134,7 @@ const refreshJwt = async (
       clientConfig.AUTH_EXPIRATION_OVERRIDE ?? JWT_REFRESH_RETRY_ON_FAILURE_MS;
   }
   refreshTimer = setTimeout(() => {
-    refreshJwt(clientConfig, clientId, clientSecret, metricsClient);
+    startRefreshJwt(clientConfig, clientId, clientSecret, metricsClient);
   }, nextDelayMs);
 };
 
@@ -122,6 +145,10 @@ export const setfetchAndUpdateJwt = async (
   metricsClient?: MetricsClient,
 ) => {
   stopJwtRefresh();
+  oauthEvents.removeAllListeners(OAUTH_TOKEN_REJECTED_EVENT);
+  oauthEvents.on(OAUTH_TOKEN_REJECTED_EVENT, () => {
+    startRefreshJwt(clientConfig, clientId, clientSecret, metricsClient);
+  });
   const requestId = uuid();
   const newJwt = await fetchAndUpdateJwt(
     clientConfig.apiHostname,
@@ -131,8 +158,8 @@ export const setfetchAndUpdateJwt = async (
   );
   logger.debug({ requestId }, 'Setting auth updater.');
   if (newJwt) {
-    refreshTimer = setTimeout(async () => {
-      refreshJwt(clientConfig, clientId, clientSecret, metricsClient);
+    refreshTimer = setTimeout(() => {
+      startRefreshJwt(clientConfig, clientId, clientSecret, metricsClient);
     }, clientConfig.AUTH_EXPIRATION_OVERRIDE ?? (newJwt.expiresIn - 60) * 1000);
   }
 };

--- a/lib/hybrid-sdk/http/downstream-post-stream-to-server.ts
+++ b/lib/hybrid-sdk/http/downstream-post-stream-to-server.ts
@@ -9,7 +9,11 @@ import { bootstrap } from 'global-agent';
 import https from 'https';
 import http from 'http';
 
-import { getAuthConfig } from '../client/auth/oauth';
+import {
+  OAUTH_TOKEN_REJECTED_EVENT,
+  getAuthConfig,
+  oauthEvents,
+} from '../client/auth/oauth';
 import { addServerIdAndRoleQS } from './utils';
 import { getConfig } from '../common/config/config';
 import type { ExtendedLogContext } from '../common/types/log';
@@ -370,6 +374,16 @@ class BrokerServerPostResponseHandler {
               'Stream Response error in POST to Broker Server',
             );
           });
+          if (r.statusCode === 401 && this.#config.universalBrokerGa) {
+            logger.warn(
+              {
+                requestId: this.#requestId,
+                streamingId: this.#streamingId,
+              },
+              'Broker server rejected POST with 401; triggering OAuth token refresh',
+            );
+            oauthEvents.emit(OAUTH_TOKEN_REJECTED_EVENT);
+          }
           if (r.statusCode !== 200) {
             const body = await readBody(r).catch(() => '');
             logger.error(

--- a/test/unit/client/auth/oauth.test.ts
+++ b/test/unit/client/auth/oauth.test.ts
@@ -2,6 +2,7 @@ import {
   fetchAndUpdateJwt,
   setfetchAndUpdateJwt,
   getAuthConfig,
+  stopJwtRefresh,
 } from '../../../../lib/hybrid-sdk/client/auth/oauth';
 import { log as logger } from '../../../../lib/logs/logger';
 import type { Client as MetricsClient } from '../../../../lib/hybrid-sdk/client/metrics/client';
@@ -42,6 +43,7 @@ describe('client/auth/oauth — JWT refresh observability', () => {
   });
 
   afterEach(async () => {
+    stopJwtRefresh();
     nock.cleanAll();
     await new Promise((r) => setTimeout(r, 50));
     errorSpy.mockRestore();
@@ -83,6 +85,28 @@ describe('client/auth/oauth — JWT refresh observability', () => {
       expect(fields).toHaveProperty('err');
       expect(fields.err).toBeInstanceOf(Error);
       expect(message).toBe('Unable to retrieve JWT');
+    });
+
+    it('sends a Snyk-Request-Id header and logs the same id on failure', async () => {
+      let capturedReqId: string | undefined;
+      nock(API_HOST)
+        .post('/oauth2/token')
+        .reply(function (this: { req: { headers: Record<string, string> } }) {
+          capturedReqId = this.req.headers['snyk-request-id'];
+          return [
+            500,
+            JSON.stringify({ error: 'server_error', error_description: 'boom' }),
+          ];
+        });
+
+      await fetchAndUpdateJwt(API_HOST, 'cid', 'csecret');
+
+      expect(capturedReqId).toBeDefined();
+      expect(capturedReqId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+      const [fields] = errorSpy.mock.calls[0];
+      expect(fields.requestId).toBe(capturedReqId);
     });
 
     it('returns the parsed token on success', async () => {
@@ -181,6 +205,101 @@ describe('client/auth/oauth — JWT refresh observability', () => {
 
       expect(metricsClient.recordJwtRefreshFailure).not.toHaveBeenCalled();
       expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it('recovers and updates the token when a failed refresh is followed by a successful one', async () => {
+      const metricsClient = makeMockMetricsClient();
+
+      nock(API_HOST).post('/oauth2/token').reply(200, {
+        access_token: 'first',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        scope: 'broker',
+      });
+      nock(API_HOST)
+        .post('/oauth2/token')
+        .reply(
+          500,
+          JSON.stringify({
+            error: 'server_error',
+            error_description: 'transient',
+          }),
+        );
+      nock(API_HOST).post('/oauth2/token').reply(200, {
+        access_token: 'third',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        scope: 'broker',
+      });
+
+      await setfetchAndUpdateJwt(
+        { apiHostname: API_HOST, AUTH_EXPIRATION_OVERRIDE: 10 },
+        'cid',
+        'csecret',
+        metricsClient,
+      );
+
+      await waitFor(
+        () =>
+          (metricsClient.recordJwtRefreshFailure as jest.Mock).mock.calls
+            .length > 0,
+      );
+
+      await waitFor(
+        () => getAuthConfig().accessToken?.authHeader === 'Bearer third',
+      );
+
+      expect(metricsClient.recordJwtRefreshFailure).toHaveBeenCalledTimes(1);
+      expect(getAuthConfig().accessToken).toEqual({
+        expiresIn: 3600,
+        authHeader: 'Bearer third',
+      });
+    });
+
+    it('cancels the prior refresh chain when setfetchAndUpdateJwt is invoked again', async () => {
+      const metricsClient = makeMockMetricsClient();
+
+      // First chain: succeeds, then would keep failing (no further nock interceptors).
+      nock(API_HOST).post('/oauth2/token').reply(200, {
+        access_token: 'first',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        scope: 'broker',
+      });
+
+      await setfetchAndUpdateJwt(
+        { apiHostname: API_HOST, AUTH_EXPIRATION_OVERRIDE: 10 },
+        'cid',
+        'csecret',
+        metricsClient,
+      );
+
+      await waitFor(() => getAuthConfig().accessToken?.authHeader === 'Bearer first');
+
+      // Second chain: a fresh token. If the first chain's timer wasn't cancelled,
+      // it would race here and also call /oauth2/token without a matching interceptor,
+      // causing recordJwtRefreshFailure to fire.
+      nock(API_HOST).post('/oauth2/token').reply(200, {
+        access_token: 'second-chain',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        scope: 'broker',
+      });
+
+      await setfetchAndUpdateJwt(
+        { apiHostname: API_HOST, AUTH_EXPIRATION_OVERRIDE: 10 },
+        'cid',
+        'csecret',
+        metricsClient,
+      );
+
+      await waitFor(
+        () => getAuthConfig().accessToken?.authHeader === 'Bearer second-chain',
+      );
+
+      // The only failure metric we'd see is from a leaked first-chain timer hitting
+      // an unmatched nock — so assert it stayed silent.
+      expect(metricsClient.recordJwtRefreshFailure).not.toHaveBeenCalled();
     });
 
     it('does not crash when metricsClient is omitted (backwards compatibility)', async () => {

--- a/test/unit/client/auth/oauth.test.ts
+++ b/test/unit/client/auth/oauth.test.ts
@@ -1,5 +1,7 @@
 import {
+  OAUTH_TOKEN_REJECTED_EVENT,
   fetchAndUpdateJwt,
+  oauthEvents,
   setfetchAndUpdateJwt,
   getAuthConfig,
   stopJwtRefresh,
@@ -44,6 +46,7 @@ describe('client/auth/oauth — JWT refresh observability', () => {
 
   afterEach(async () => {
     stopJwtRefresh();
+    oauthEvents.removeAllListeners(OAUTH_TOKEN_REJECTED_EVENT);
     nock.cleanAll();
     await new Promise((r) => setTimeout(r, 50));
     errorSpy.mockRestore();
@@ -95,7 +98,10 @@ describe('client/auth/oauth — JWT refresh observability', () => {
           capturedReqId = this.req.headers['snyk-request-id'];
           return [
             500,
-            JSON.stringify({ error: 'server_error', error_description: 'boom' }),
+            JSON.stringify({
+              error: 'server_error',
+              error_description: 'boom',
+            }),
           ];
         });
 
@@ -274,7 +280,9 @@ describe('client/auth/oauth — JWT refresh observability', () => {
         metricsClient,
       );
 
-      await waitFor(() => getAuthConfig().accessToken?.authHeader === 'Bearer first');
+      await waitFor(
+        () => getAuthConfig().accessToken?.authHeader === 'Bearer first',
+      );
 
       // Second chain: a fresh token. If the first chain's timer wasn't cancelled,
       // it would race here and also call /oauth2/token without a matching interceptor,
@@ -300,6 +308,211 @@ describe('client/auth/oauth — JWT refresh observability', () => {
       // The only failure metric we'd see is from a leaked first-chain timer hitting
       // an unmatched nock — so assert it stayed silent.
       expect(metricsClient.recordJwtRefreshFailure).not.toHaveBeenCalled();
+    });
+
+    describe('OAUTH_TOKEN_REJECTED_EVENT', () => {
+      it('triggers a fresh /oauth2/token request and updates the stored token', async () => {
+        const metricsClient = makeMockMetricsClient();
+
+        nock(API_HOST).post('/oauth2/token').reply(200, {
+          access_token: 'initial',
+          token_type: 'Bearer',
+          expires_in: 3600,
+          scope: 'broker',
+        });
+        // Event-triggered refresh response (timer is huge so the scheduled chain won't fire).
+        nock(API_HOST).post('/oauth2/token').reply(200, {
+          access_token: 'forced',
+          token_type: 'Bearer',
+          expires_in: 3600,
+          scope: 'broker',
+        });
+
+        await setfetchAndUpdateJwt(
+          { apiHostname: API_HOST, AUTH_EXPIRATION_OVERRIDE: 60_000 },
+          'cid',
+          'csecret',
+          metricsClient,
+        );
+
+        expect(getAuthConfig().accessToken?.authHeader).toBe('Bearer initial');
+
+        oauthEvents.emit(OAUTH_TOKEN_REJECTED_EVENT);
+
+        await waitFor(
+          () => getAuthConfig().accessToken?.authHeader === 'Bearer forced',
+        );
+
+        expect(metricsClient.recordJwtRefreshFailure).not.toHaveBeenCalled();
+      });
+
+      it('coalesces token-rejected with an in-flight timer-scheduled refresh', async () => {
+        const metricsClient = makeMockMetricsClient();
+
+        nock(API_HOST).post('/oauth2/token').reply(200, {
+          access_token: 'initial',
+          token_type: 'Bearer',
+          expires_in: 3600,
+          scope: 'broker',
+        });
+
+        let releaseTimerRefresh!: () => void;
+        const timerRefreshGate = new Promise<void>((resolve) => {
+          releaseTimerRefresh = resolve;
+        });
+        let scheduledRefreshHits = 0;
+
+        // Single interceptor for the timer-driven refresh. If the event
+        // starts a parallel refresh, a second request would be unmatched.
+        nock(API_HOST)
+          .post('/oauth2/token')
+          .reply(async () => {
+            scheduledRefreshHits++;
+            await timerRefreshGate;
+            return [
+              200,
+              {
+                access_token: 'scheduled',
+                token_type: 'Bearer',
+                expires_in: 3600,
+                scope: 'broker',
+              },
+            ];
+          });
+
+        await setfetchAndUpdateJwt(
+          { apiHostname: API_HOST, AUTH_EXPIRATION_OVERRIDE: 10 },
+          'cid',
+          'csecret',
+          metricsClient,
+        );
+
+        await waitFor(() => scheduledRefreshHits > 0);
+
+        oauthEvents.emit(OAUTH_TOKEN_REJECTED_EVENT);
+        releaseTimerRefresh();
+
+        await waitFor(
+          () => getAuthConfig().accessToken?.authHeader === 'Bearer scheduled',
+        );
+
+        expect(scheduledRefreshHits).toBe(1);
+        expect(metricsClient.recordJwtRefreshFailure).not.toHaveBeenCalled();
+      });
+
+      it('coalesces a burst of emits into a single /oauth2/token request', async () => {
+        const metricsClient = makeMockMetricsClient();
+
+        nock(API_HOST).post('/oauth2/token').reply(200, {
+          access_token: 'initial',
+          token_type: 'Bearer',
+          expires_in: 3600,
+          scope: 'broker',
+        });
+
+        // Only ONE event-triggered interceptor — if coalescing fails, additional
+        // emits would hit an unmatched nock and the failure metric would fire.
+        let forcedHits = 0;
+        nock(API_HOST)
+          .post('/oauth2/token')
+          .reply(() => {
+            forcedHits++;
+            return [
+              200,
+              {
+                access_token: 'forced-shared',
+                token_type: 'Bearer',
+                expires_in: 3600,
+                scope: 'broker',
+              },
+            ];
+          });
+
+        await setfetchAndUpdateJwt(
+          { apiHostname: API_HOST, AUTH_EXPIRATION_OVERRIDE: 60_000 },
+          'cid',
+          'csecret',
+          metricsClient,
+        );
+
+        oauthEvents.emit(OAUTH_TOKEN_REJECTED_EVENT);
+        oauthEvents.emit(OAUTH_TOKEN_REJECTED_EVENT);
+        oauthEvents.emit(OAUTH_TOKEN_REJECTED_EVENT);
+
+        await waitFor(
+          () =>
+            getAuthConfig().accessToken?.authHeader === 'Bearer forced-shared',
+        );
+
+        expect(forcedHits).toBe(1);
+        expect(metricsClient.recordJwtRefreshFailure).not.toHaveBeenCalled();
+      });
+
+      it('replaces the listener so a second setfetchAndUpdateJwt does not double-fire', async () => {
+        const metricsClient = makeMockMetricsClient();
+
+        nock(API_HOST).post('/oauth2/token').reply(200, {
+          access_token: 'first-init',
+          token_type: 'Bearer',
+          expires_in: 3600,
+          scope: 'broker',
+        });
+        nock(API_HOST).post('/oauth2/token').reply(200, {
+          access_token: 'second-init',
+          token_type: 'Bearer',
+          expires_in: 3600,
+          scope: 'broker',
+        });
+        // Only ONE event-triggered interceptor. If both old and new listeners
+        // fire, the second listener would hit an unmatched nock.
+        let forcedHits = 0;
+        nock(API_HOST)
+          .post('/oauth2/token')
+          .reply(() => {
+            forcedHits++;
+            return [
+              200,
+              {
+                access_token: 'after-event',
+                token_type: 'Bearer',
+                expires_in: 3600,
+                scope: 'broker',
+              },
+            ];
+          });
+
+        await setfetchAndUpdateJwt(
+          { apiHostname: API_HOST, AUTH_EXPIRATION_OVERRIDE: 60_000 },
+          'cid',
+          'csecret',
+          metricsClient,
+        );
+        await waitFor(
+          () => getAuthConfig().accessToken?.authHeader === 'Bearer first-init',
+        );
+
+        await setfetchAndUpdateJwt(
+          { apiHostname: API_HOST, AUTH_EXPIRATION_OVERRIDE: 60_000 },
+          'cid',
+          'csecret',
+          metricsClient,
+        );
+        await waitFor(
+          () =>
+            getAuthConfig().accessToken?.authHeader === 'Bearer second-init',
+        );
+
+        expect(oauthEvents.listenerCount(OAUTH_TOKEN_REJECTED_EVENT)).toBe(1);
+
+        oauthEvents.emit(OAUTH_TOKEN_REJECTED_EVENT);
+        await waitFor(
+          () =>
+            getAuthConfig().accessToken?.authHeader === 'Bearer after-event',
+        );
+
+        expect(forcedHits).toBe(1);
+        expect(metricsClient.recordJwtRefreshFailure).not.toHaveBeenCalled();
+      });
     });
 
     it('does not crash when metricsClient is omitted (backwards compatibility)', async () => {

--- a/test/unit/lib/hybrid-sdk/http/downstream-post-stream-to-server.test.ts
+++ b/test/unit/lib/hybrid-sdk/http/downstream-post-stream-to-server.test.ts
@@ -9,6 +9,11 @@ import {
   getConfig,
 } from '../../../../../lib/hybrid-sdk/common/config/config';
 import { ExtendedLogContext } from '../../../../../lib/hybrid-sdk/common/types/log';
+import {
+  OAUTH_TOKEN_REJECTED_EVENT,
+  oauthEvents,
+  setAuthConfigKey,
+} from '../../../../../lib/hybrid-sdk/client/auth/oauth';
 
 interface CapturedLogCall {
   context: Record<string, any>;
@@ -145,6 +150,139 @@ describe('BrokerServerPostResponseHandler', () => {
 
   afterEach(() => {
     nock.cleanAll();
+  });
+
+  describe('401 OAuth token refresh trigger', () => {
+    let emitSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      // Authorization header is only attached when an accessToken exists.
+      setAuthConfigKey('accessToken', {
+        expiresIn: 3600,
+        authHeader: 'Bearer test-token',
+      });
+      // Suppress real listeners — we only care that the event was emitted.
+      oauthEvents.removeAllListeners(OAUTH_TOKEN_REJECTED_EVENT);
+      emitSpy = jest.spyOn(oauthEvents, 'emit');
+    });
+
+    afterEach(() => {
+      emitSpy.mockRestore();
+      setAuthConfigKey('accessToken', undefined);
+    });
+
+    const tokenRejectedEmits = () =>
+      emitSpy.mock.calls.filter(
+        ([eventName]) => eventName === OAUTH_TOKEN_REJECTED_EVENT,
+      ).length;
+
+    it('emits token-rejected exactly once on 401 when universalBrokerGa is enabled', async () => {
+      setConfig({
+        brokerServerUrl,
+        universalBrokerEnabled: true,
+        universalBrokerGa: true,
+      });
+
+      nock(brokerServerUrl)
+        .post(`/hidden/brokers/response-data/${brokerToken}/${streamingId}`)
+        .query(true)
+        .reply(401, 'Unauthorized', { 'content-type': 'text/plain' });
+
+      const handler = createHandler();
+      await handler.sendData(
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+          body: { test: 'data' },
+        },
+        streamingId,
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      expect(tokenRejectedEmits()).toBe(1);
+    });
+
+    it('does NOT emit token-rejected on 200', async () => {
+      setConfig({
+        brokerServerUrl,
+        universalBrokerEnabled: true,
+        universalBrokerGa: true,
+      });
+
+      nock(brokerServerUrl)
+        .post(`/hidden/brokers/response-data/${brokerToken}/${streamingId}`)
+        .query(true)
+        .reply(200, 'OK');
+
+      const handler = createHandler();
+      await handler.sendData(
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+          body: { test: 'data' },
+        },
+        streamingId,
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      expect(tokenRejectedEmits()).toBe(0);
+    });
+
+    it('does NOT emit token-rejected on 403 (only 401 triggers refresh)', async () => {
+      setConfig({
+        brokerServerUrl,
+        universalBrokerEnabled: true,
+        universalBrokerGa: true,
+      });
+
+      nock(brokerServerUrl)
+        .post(`/hidden/brokers/response-data/${brokerToken}/${streamingId}`)
+        .query(true)
+        .reply(403, 'Forbidden', { 'content-type': 'text/plain' });
+
+      const handler = createHandler();
+      await handler.sendData(
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+          body: { test: 'data' },
+        },
+        streamingId,
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      expect(tokenRejectedEmits()).toBe(0);
+    });
+
+    it('does NOT emit token-rejected on 401 when universalBrokerGa is disabled', async () => {
+      setConfig({
+        brokerServerUrl,
+        universalBrokerEnabled: false,
+        universalBrokerGa: false,
+      });
+
+      nock(brokerServerUrl)
+        .post(`/response-data/${brokerToken}/${streamingId}`)
+        .query(true)
+        .reply(401, 'Unauthorized', { 'content-type': 'text/plain' });
+
+      const handler = createHandler();
+      await handler.sendData(
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+          body: { test: 'data' },
+        },
+        streamingId,
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      expect(tokenRejectedEmits()).toBe(0);
+    });
   });
 
   describe('response errors', () => {


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Currently, if an oauth token fails to refresh, the broker client gets into a bad state that is only discovered when the token is attempted to be used - HTTP requests back to Snyk will continue to fail with a 401.

This implements a fix to trigger a refresh of the oauth token in two scenarios:
1. If auth refresh fails a retry is triggered.
2. If the HTTP request to Snyk fails with a 401, the request will fail but the auth refresh is triggered so a reattempt will succeed. Due to the nature of HTTP post streaming, it's best not to retry the HTTP request itself with a fresh token and risk the data being malformed.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
