### PR TITLE
feat: [FAN-125] add graphql endpoint to gitlab broker ruleset

### DIFF
--- a/client-templates/gitlab/accept.json.sample
+++ b/client-templates/gitlab/accept.json.sample
@@ -1671,6 +1671,12 @@
       "method": "GET",
       "path": "/api/v4/projects/:project/repository/compare",
       "origin": "https://${GITLAB}"
+    },
+    {
+      "//": "used to proxy GraphQL requests to GitLab",
+      "method": "POST",
+      "path": "/api/graphql",
+      "origin": "https://${GITLAB}"
     }
   ]
 }

--- a/defaultFilters/gitlab.json
+++ b/defaultFilters/gitlab.json
@@ -1713,6 +1713,12 @@
         "method": "GET",
         "path": "/api/v4/projects/:project/repository/compare",
         "origin": "https://${GITLAB}"
+      },
+      {
+        "//": "used to proxy GraphQL requests to GitLab",
+        "method": "POST",
+        "path": "/api/graphql",
+        "origin": "https://${GITLAB}"
       }
     ]
   }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adding new Gitlab GraphQL endpoint to the broker ruleset

#### Any background context you want to provide?

A new generic GraphQL endpoint has been added to the `gitlab-agent` as part of [this PR](https://github.com/snyk/gitlab-agent/pull/1045), the current PR aims to acomodate brokered clients to have the possibility allowing the Snyk Broker to also forward requests to this endpoint.
