### PR TITLE
refactor: rebalance lifecycle and polling log levels

### DIFF
--- a/lib/hybrid-sdk/client/brokerClientPlugins/pluginManager.ts
+++ b/lib/hybrid-sdk/client/brokerClientPlugins/pluginManager.ts
@@ -30,7 +30,7 @@ export const loadPlugins = async (pluginsFolderPath: string, clientOpts) => {
             !pluginInstance.isDisabled(clientOpts.config) &&
             pluginInstance.isPluginActive()
           ) {
-            logger.debug({}, `Loading plugin ${pluginInstance.pluginName}`);
+            logger.info({}, `Loading plugin ${pluginInstance.pluginName}`);
             const configPluginForCurrentType =
               clientOpts.config.plugins.get(applicableBrokerType);
             if (

--- a/lib/hybrid-sdk/client/connectionsManager/manager.ts
+++ b/lib/hybrid-sdk/client/connectionsManager/manager.ts
@@ -68,7 +68,7 @@ export const manageWebsocketConnections = async (
       handleTerminationSignal(cleanUpUniversalFile);
     } else {
       handleTerminationSignal(() => {
-        logger.debug({}, 'Received process termination signal.');
+        logger.info({}, 'Received process termination signal.');
       });
     }
 

--- a/lib/hybrid-sdk/client/connectionsManager/synchronizer.ts
+++ b/lib/hybrid-sdk/client/connectionsManager/synchronizer.ts
@@ -52,7 +52,7 @@ export const syncClientConfig = async (
     websocketConnections.length === 0;
 
   if (isPollingRequired) {
-    logger.info({}, `Waiting for connections (polling).`);
+    logger.debug({}, `Waiting for connections (polling).`);
     if (process.env.NODE_ENV != 'test') {
       setTimeout(
         () =>
@@ -98,7 +98,7 @@ export const syncClientConfig = async (
           integrationsKeys.indexOf(key),
         );
       } else {
-        logger.info(
+        logger.debug(
           {
             id: connectionConfig.id,
             name: connectionConfig.friendlyName,
@@ -175,7 +175,7 @@ export const syncClientConfig = async (
         !integrationsKeys.includes(friendlyName) &&
         !alreadyShutDownConnectionNames.includes(friendlyName)
       ) {
-        logger.debug({ friendlyName }, 'Shutting down connection');
+        logger.info({ friendlyName }, 'Shutting down connection');
         try {
           alreadyShutDownConnectionNames.push(friendlyName);
           syncStateByConnection.delete(friendlyName);

--- a/lib/hybrid-sdk/client/socketHandlers/serviceHandler.ts
+++ b/lib/hybrid-sdk/client/socketHandlers/serviceHandler.ts
@@ -23,7 +23,7 @@ export const serviceHandler = async (msg, cb) => {
   } else {
     switch (command) {
       case '/filters/reload':
-        logger.debug({}, 'Reloading filters.');
+        logger.info({}, 'Reloading filters.');
         cb({
           status: 200,
           headers: { requestId },
@@ -31,7 +31,7 @@ export const serviceHandler = async (msg, cb) => {
         });
         break;
       case '/config/reload':
-        logger.debug({}, 'Reloading config.');
+        logger.info({}, 'Reloading config.');
         if (clientOptions.config?.universalBrokerEnabled) {
           cb({
             status: 200,

--- a/lib/hybrid-sdk/common/filter/filter-rules-loading.ts
+++ b/lib/hybrid-sdk/common/filter/filter-rules-loading.ts
@@ -28,7 +28,7 @@ function nestedCopy(array) {
   return JSON.parse(JSON.stringify(array));
 }
 
-function injectRulesAtRuntime(
+export function injectRulesAtRuntime(
   filters: FiltersType,
   config: CONFIGURATION,
   ruleType?,
@@ -259,7 +259,7 @@ function injectRulesAtRuntime(
     process.env.ACCEPT_ESSENTIALS ||
     config.ACCEPT_ESSENTIALS;
   if (ACCEPT_APPRISK && ACCEPT_APPRISK != 'false') {
-    logger.debug(
+    logger.info(
       { accept: ACCEPT_APPRISK },
       `Injecting Accept rules for AppRisk`,
     );
@@ -289,7 +289,7 @@ function injectRulesAtRuntime(
         return !appRiskRulesMethodPattern.includes(`${x.method}|${x.path}`);
       });
       if (possibleOverlappingRules.length > 0) {
-        logger.debug(
+        logger.warn(
           { possibleOverlappingRules },
           `Caution, possible overlapping rules with apprisk rules extension.`,
         );
@@ -301,7 +301,7 @@ function injectRulesAtRuntime(
   const ACCEPT_CUSTOM_PR_TEMPLATES =
     process.env.ACCEPT_CUSTOM_PR_TEMPLATES || config.ACCEPT_CUSTOM_PR_TEMPLATES;
   if (ACCEPT_CUSTOM_PR_TEMPLATES && ACCEPT_CUSTOM_PR_TEMPLATES != 'false') {
-    logger.debug(
+    logger.info(
       { accept: ACCEPT_CUSTOM_PR_TEMPLATES },
       `Injecting accept rules for custom PR templates.`,
     );
@@ -335,7 +335,7 @@ function injectRulesAtRuntime(
         );
       });
       if (possibleOverlappingRules.length > 0) {
-        logger.debug(
+        logger.warn(
           { possibleOverlappingRules },
           `Caution, possible overlapping rules with custom PR templates.`,
         );

--- a/test/unit/client/socketHandlers/serviceHandler.test.ts
+++ b/test/unit/client/socketHandlers/serviceHandler.test.ts
@@ -1,0 +1,55 @@
+import { log as logger } from '../../../../lib/logs/logger';
+import { serviceHandler } from '../../../../lib/hybrid-sdk/client/socketHandlers/serviceHandler';
+
+jest.mock('../../../../lib/hybrid-sdk/client/config/configHelpers', () => ({
+  getClientOpts: jest.fn(() => ({ config: { universalBrokerEnabled: false } })),
+}));
+jest.mock(
+  '../../../../lib/hybrid-sdk/client/connectionsManager/synchronizer',
+  () => ({ syncClientConfig: jest.fn() }),
+);
+jest.mock(
+  '../../../../lib/hybrid-sdk/client/connectionsManager/manager',
+  () => ({
+    getGlobalIdentifyingMetadata: jest.fn(() => ({})),
+    getWebsocketConnections: jest.fn(() => []),
+  }),
+);
+
+describe('serviceHandler — log levels (PR 2 contract)', () => {
+  let infoSpy: jest.SpyInstance;
+  let debugSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => {});
+    debugSpy = jest.spyOn(logger, 'debug').mockImplementation(() => {});
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('logs "Reloading filters." at INFO, not DEBUG', async () => {
+    await serviceHandler({ url: '/filters/reload', headers: {} }, jest.fn());
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      'Reloading filters.',
+    );
+    expect(debugSpy).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'Reloading filters.',
+    );
+  });
+
+  it('logs "Reloading config." at INFO, not DEBUG', async () => {
+    await serviceHandler({ url: '/config/reload', headers: {} }, jest.fn());
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      'Reloading config.',
+    );
+    expect(debugSpy).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'Reloading config.',
+    );
+  });
+});

--- a/test/unit/connectionsManager/manager.test.ts
+++ b/test/unit/connectionsManager/manager.test.ts
@@ -4,6 +4,8 @@ import {
   Role,
 } from '../../../lib/hybrid-sdk/client/types/client';
 import { LoadedClientOpts } from '../../../lib/hybrid-sdk/common/types/options';
+import { log as logger } from '../../../lib/logs/logger';
+import * as signals from '../../../lib/hybrid-sdk/common/utils/signals';
 
 describe('Connections Manager', () => {
   it('Returns websocket connections empty array by default', async () => {
@@ -47,5 +49,75 @@ describe('Connections Manager', () => {
       globalIdentifyingMetadata,
     );
     expect(wsConnections).toHaveLength(0);
+  });
+
+  describe('log levels (PR 2 contract)', () => {
+    let infoSpy: jest.SpyInstance;
+    let debugSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => {});
+      debugSpy = jest.spyOn(logger, 'debug').mockImplementation(() => {});
+    });
+    afterEach(() => jest.restoreAllMocks());
+
+    it('logs "Received process termination signal." at INFO, not DEBUG', async () => {
+      process.env.SKIP_REMOTE_CONFIG = 'true';
+      let capturedCallback: (() => void) | undefined;
+      jest
+        .spyOn(signals, 'handleTerminationSignal')
+        .mockImplementation((cb) => {
+          capturedCallback = cb;
+        });
+
+      const config: LoadedClientOpts = {
+        loadedFilters: new Map<string, any>(),
+        port: 0,
+        config: {
+          supportedBrokerTypes: [],
+          filterRulesPaths: {},
+          brokerType: 'client',
+        },
+        filters: new Map<string, any>(),
+      };
+      const meta: IdentifyingMetadata = {
+        capabilities: [],
+        clientId: '',
+        filters: new Map(),
+        preflightChecks: undefined,
+        version: '',
+        id: '',
+        isDisabled: false,
+        clientConfig: {
+          brokerClientId: '123',
+          haMode: false,
+          debugMode: false,
+          bodyLogMode: false,
+          credPooling: false,
+          privateCa: false,
+          tlsReject: false,
+          proxy: false,
+          customAccept: false,
+          insecureDownstream: false,
+          universalBroker: false,
+          version: 'local',
+        },
+        role: Role.primary,
+      };
+
+      await manageWebsocketConnections(config, meta);
+
+      expect(capturedCallback).toBeDefined();
+      capturedCallback!();
+
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        'Received process termination signal.',
+      );
+      expect(debugSpy).not.toHaveBeenCalledWith(
+        expect.anything(),
+        'Received process termination signal.',
+      );
+    });
   });
 });

--- a/test/unit/connectionsManager/synchronizer.test.ts
+++ b/test/unit/connectionsManager/synchronizer.test.ts
@@ -11,6 +11,7 @@ import {
 import * as pluginManager from '../../../lib/hybrid-sdk/client/brokerClientPlugins/pluginManager';
 import * as socket from '../../../lib/hybrid-sdk/client/socket';
 import * as connectionHelpers from '../../../lib/hybrid-sdk/client/connectionsManager/connectionHelpers';
+import { log as logger } from '../../../lib/logs/logger';
 
 jest.mock(
   '../../../lib/hybrid-sdk/client/connectionsManager/remoteConnectionSync',
@@ -329,6 +330,70 @@ describe('syncClientConfig', () => {
     expect(
       mockedConnectionHelpers.shutDownConnectionPair,
     ).not.toHaveBeenCalled();
+  });
+
+  describe('log levels (PR 2 contract)', () => {
+    let infoSpy: jest.SpyInstance;
+    let debugSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => {});
+      debugSpy = jest.spyOn(logger, 'debug').mockImplementation(() => {});
+    });
+    afterEach(() => jest.restoreAllMocks());
+
+    it('logs "Waiting for connections (polling)." at DEBUG, not INFO', async () => {
+      const clientOpts = makeClientOpts(undefined);
+      await syncClientConfig(clientOpts, [], IDENTIFYING_METADATA);
+
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        'Waiting for connections (polling).',
+      );
+      expect(infoSpy).not.toHaveBeenCalledWith(
+        expect.anything(),
+        'Waiting for connections (polling).',
+      );
+    });
+
+    it('logs the "not in use by any orgs" message at DEBUG, not INFO', async () => {
+      const clientOpts = makeClientOpts({
+        'my-conn': {
+          type: 'github',
+          identifier: null,
+          friendlyName: 'my-conn',
+          id: 'conn-id',
+        },
+      });
+      await syncClientConfig(clientOpts, [], IDENTIFYING_METADATA);
+
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('not in use by any orgs'),
+      );
+      expect(infoSpy).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('not in use by any orgs'),
+      );
+    });
+
+    it('logs "Shutting down connection" at INFO, not DEBUG', async () => {
+      const clientOpts = makeClientOpts({});
+      const wsConns: WebSocketConnection[] = [
+        makeWsConn('removed-conn', 'token-1'),
+        makeWsConn('removed-conn', 'token-1'),
+      ];
+      await syncClientConfig(clientOpts, wsConns, IDENTIFYING_METADATA);
+
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ friendlyName: 'removed-conn' }),
+        'Shutting down connection',
+      );
+      expect(debugSpy).not.toHaveBeenCalledWith(
+        expect.anything(),
+        'Shutting down connection',
+      );
+    });
   });
 
   it('should re-run plugins when contexts change on an existing connection', async () => {

--- a/test/unit/lib/hybrid-sdk/common/filter/filter-rules-loading.test.ts
+++ b/test/unit/lib/hybrid-sdk/common/filter/filter-rules-loading.test.ts
@@ -1,0 +1,149 @@
+import path from 'path';
+import fs from 'fs';
+import { log as logger } from '../../../../../../lib/logs/logger';
+import { injectRulesAtRuntime } from '../../../../../../lib/hybrid-sdk/common/filter/filter-rules-loading';
+import { findProjectRoot } from '../../../../../../lib/hybrid-sdk/common/config/config';
+
+// Absolute paths the source builds at runtime via
+// `path.join(findProjectRoot(__dirname), 'defaultFilters/.../github.json')`.
+// We need them up-front so jest.doMock(..., { virtual: true }) can serve
+// fake module content under that exact key.
+const PROJECT_ROOT = findProjectRoot(__dirname) ?? process.cwd();
+const APPRISK_RULES_PATH = path.join(
+  PROJECT_ROOT,
+  'defaultFilters/apprisk/github.json',
+);
+const CUSTOM_PR_RULES_PATH = path.join(
+  PROJECT_ROOT,
+  'defaultFilters/customPrTemplates/github.json',
+);
+
+function makeFilters() {
+  return {
+    private: [
+      // a benign rule so possibleOverlappingRules.length > 0 when the inject
+      // path fires with an empty fixture rule list
+      {
+        method: 'GET',
+        path: '/repos/:owner/:name',
+        origin: 'https://{GITHUB_API}',
+      },
+    ],
+    public: [],
+  } as any;
+}
+
+function makeConfig(overrides: Record<string, any> = {}) {
+  return {
+    supportedBrokerTypes: ['github'],
+    ...overrides,
+  } as any;
+}
+
+describe('injectRulesAtRuntime — log levels (PR 2 contract)', () => {
+  let infoSpy: jest.SpyInstance;
+  let debugSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => {});
+    debugSpy = jest.spyOn(logger, 'debug').mockImplementation(() => {});
+    warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    delete process.env.ACCEPT_APPRISK;
+    delete process.env.ACCEPT_ESSENTIALS;
+    delete process.env.ACCEPT_CUSTOM_PR_TEMPLATES;
+    delete process.env.ACCEPT_IAC;
+    delete process.env.ACCEPT_CODE;
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+    process.env = { ...savedEnv };
+  });
+
+  it('logs "Injecting Accept rules for AppRisk" at INFO, not DEBUG', () => {
+    process.env.ACCEPT_APPRISK = 'true';
+    // existsSync returns false → the INFO line at the top of the apprisk
+    // block runs before the existsSync check, so we capture it without
+    // having to satisfy the require() that follows.
+    jest.spyOn(fs, 'existsSync').mockImplementation(() => false);
+
+    injectRulesAtRuntime(makeFilters(), makeConfig(), 'github');
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      'Injecting Accept rules for AppRisk',
+    );
+    expect(debugSpy).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'Injecting Accept rules for AppRisk',
+    );
+  });
+
+  it('logs "Injecting accept rules for custom PR templates." at INFO, not DEBUG', () => {
+    process.env.ACCEPT_CUSTOM_PR_TEMPLATES = 'true';
+    jest.spyOn(fs, 'existsSync').mockImplementation(() => false);
+
+    injectRulesAtRuntime(makeFilters(), makeConfig(), 'github');
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      'Injecting accept rules for custom PR templates.',
+    );
+    expect(debugSpy).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'Injecting accept rules for custom PR templates.',
+    );
+  });
+
+  it('logs "Caution, possible overlapping rules with apprisk rules extension." at WARN, not DEBUG', () => {
+    process.env.ACCEPT_APPRISK = 'true';
+    // Only return true for the specific fixture path so findProjectRoot
+    // (which uses fs.existsSync to walk for a marker) keeps working.
+    const realExistsSync = fs.existsSync;
+    jest
+      .spyOn(fs, 'existsSync')
+      .mockImplementation((p) =>
+        typeof p === 'string' && p.includes('apprisk')
+          ? true
+          : realExistsSync(p),
+      );
+    jest.doMock(APPRISK_RULES_PATH, () => [], { virtual: true });
+
+    injectRulesAtRuntime(makeFilters(), makeConfig(), 'github');
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      'Caution, possible overlapping rules with apprisk rules extension.',
+    );
+    expect(debugSpy).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'Caution, possible overlapping rules with apprisk rules extension.',
+    );
+  });
+
+  it('logs "Caution, possible overlapping rules with custom PR templates." at WARN, not DEBUG', () => {
+    process.env.ACCEPT_CUSTOM_PR_TEMPLATES = 'true';
+    const realExistsSync = fs.existsSync;
+    jest
+      .spyOn(fs, 'existsSync')
+      .mockImplementation((p) =>
+        typeof p === 'string' && p.includes('customPrTemplates')
+          ? true
+          : realExistsSync(p),
+      );
+    jest.doMock(CUSTOM_PR_RULES_PATH, () => [], { virtual: true });
+
+    injectRulesAtRuntime(makeFilters(), makeConfig(), 'github');
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      'Caution, possible overlapping rules with custom PR templates.',
+    );
+    expect(debugSpy).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'Caution, possible overlapping rules with custom PR templates.',
+    );
+  });
+});

--- a/test/unit/plugins/pluginManager.test.ts
+++ b/test/unit/plugins/pluginManager.test.ts
@@ -8,6 +8,7 @@ import {
   findProjectRoot,
   setConfig,
 } from '../../../lib/hybrid-sdk/common/config/config';
+import { log as logger } from '../../../lib/logs/logger';
 import {
   getPluginConfigParamByConnectionKey,
   getPluginConfigParamByConnectionKeyAndContextId,
@@ -547,6 +548,40 @@ describe('Plugin Manager', () => {
       // we should not error
       expect(err).toBeNull();
     }
+  });
+});
+
+describe('Plugin Manager — log levels (PR 2 contract)', () => {
+  const pluginsFolderPath = `${findProjectRoot(
+    __dirname,
+  )}/test/fixtures/plugins`;
+  let infoSpy: jest.SpyInstance;
+  let debugSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => {});
+    debugSpy = jest.spyOn(logger, 'debug').mockImplementation(() => {});
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('logs "Loading plugin X" at INFO, not DEBUG', async () => {
+    const clientOpts = {
+      config: {
+        universalBrokerEnabled: true,
+        supportedBrokerTypes: ['dummy'],
+        connections: { 'my connection': { type: 'dummy' } },
+      },
+    };
+    await loadPlugins(pluginsFolderPath, clientOpts);
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringMatching(/^Loading plugin /),
+    );
+    expect(debugSpy).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringMatching(/^Loading plugin /),
+    );
   });
 });
 


### PR DESCRIPTION
  ## Why

  The default-level broker log was simultaneously too quiet about lifecycle (config/filter reload, plugin load, signal received, connection teardown — all at DEBUG and therefore invisible) and too noisy about steady-state polling (two messages at INFO, repeating every poll interval). Two "possible overlapping rules" warnings sat at DEBUG even though they describe a degraded configuration that operators should be told
  about.

  This PR rebalances those levels so an operator or support engineer reading the default-level log can see what the broker is doing without being drowned in polling noise. Combined with PR 1 (which removed the per-request INFO trio), the default-level stream is now a lifecycle narrative.

  ## What

  11 one-line level flips across 5 files. No message changes, no new helpers, no API changes.

  | Direction | Count | Examples |
  |---|---|---|
  | DEBUG → INFO | 7 | `Reloading filters.`, `Reloading config.`, `Received process termination signal.`, `Shutting down connection`, `Loading plugin X`, `Injecting Accept rules for AppRisk`, `Injecting accept rules for custom PR templates.` |
  | DEBUG → WARN | 2 | `Caution, possible overlapping rules with apprisk rules extension.`, `Caution, possible overlapping rules with custom PR templates.` |
  | INFO → DEBUG | 2 | `Waiting for connections (polling).`, `Connection (...) not in use by any orgs…` |

  One minor structural change: `injectRulesAtRuntime` in `filter-rules-loading.ts` is now exported so the unit test can reach it directly. No behaviour change.