### PR TITLE
refactor(logs): rebalance network and forward-compat log levels (TDD)

### DIFF
--- a/lib/hybrid-sdk/client/index.ts
+++ b/lib/hybrid-sdk/client/index.ts
@@ -81,34 +81,9 @@ export const main = async (clientOpts: ClientOpts) => {
     // NOTE: If main() is called more than once, additional listeners will
     // accumulate after this point — each call registers a new handler on top.
     process.removeAllListeners('uncaughtException');
-    process.on('uncaughtException', (error) => {
-      const isEconnreset = error.message === 'read ECONNRESET';
-      metricsClient.recordUncaughtException(
-        (error as NodeJS.ErrnoException).code ?? error.message ?? 'unknown',
-      );
-      if (isEconnreset) {
-        logger.error(
-          { msg: error.message, stackTrace: error.stack },
-          'ECONNRESETs Catch all:',
-          error.message,
-        );
-      } else {
-        metricsClient.recordProcessExit('uncaught_exception');
-        logger.error(
-          { msg: error.message, stackTrace: error.stack },
-          'Uncaught exception:',
-          error.message,
-        );
-        const flushTimeout = new Promise<void>((resolve) =>
-          setTimeout(resolve, 2000),
-        );
-        Promise.race([metricsClient.forceFlush(), flushTimeout])
-          .catch((err) =>
-            logger.warn({ err }, 'Failed to flush metrics before exit.'),
-          )
-          .finally(() => process.exit(1));
-      }
-    });
+    process.on('uncaughtException', (error) =>
+      handleUncaughtException(error, metricsClient),
+    );
 
     clientOpts.config.API_BASE_URL =
       clientOpts.config.API_BASE_URL ??
@@ -295,5 +270,40 @@ export const main = async (clientOpts: ClientOpts) => {
   } catch (err) {
     logger.warn({ err }, `Shutting down client.`);
     throw err;
+  }
+};
+
+// Exported for unit testing — behaviour-identical to the inline body that
+// previously lived in the `process.on('uncaughtException', ...)` callback
+// registered inside main().
+export const handleUncaughtException = (
+  error: Error,
+  metricsClient: metrics.Client,
+) => {
+  const isEconnreset = error.message === 'read ECONNRESET';
+  metricsClient.recordUncaughtException(
+    (error as NodeJS.ErrnoException).code ?? error.message ?? 'unknown',
+  );
+  if (isEconnreset) {
+    logger.warn(
+      { msg: error.message, stackTrace: error.stack },
+      'ECONNRESETs Catch all:',
+      error.message,
+    );
+  } else {
+    metricsClient.recordProcessExit('uncaught_exception');
+    logger.error(
+      { msg: error.message, stackTrace: error.stack },
+      'Uncaught exception:',
+      error.message,
+    );
+    const flushTimeout = new Promise<void>((resolve) =>
+      setTimeout(resolve, 2000),
+    );
+    Promise.race([metricsClient.forceFlush(), flushTimeout])
+      .catch((err) =>
+        logger.warn({ err }, 'Failed to flush metrics before exit.'),
+      )
+      .finally(() => process.exit(1));
   }
 };

--- a/lib/hybrid-sdk/client/socketHandlers/errorHandler.ts
+++ b/lib/hybrid-sdk/client/socketHandlers/errorHandler.ts
@@ -2,7 +2,7 @@ import { log as logger } from '../../../logs/logger';
 
 export const errorHandler = ({ type, description }) => {
   if (type === 'TransportError') {
-    logger.error({ type, description }, 'Failed to connect to broker server.');
+    logger.warn({ type, description }, 'Failed to connect to broker server.');
   } else {
     logger.warn({ type, description }, 'Error on websocket connection.');
   }

--- a/lib/hybrid-sdk/client/socketHandlers/serviceHandler.ts
+++ b/lib/hybrid-sdk/client/socketHandlers/serviceHandler.ts
@@ -56,7 +56,7 @@ export const serviceHandler = async (msg, cb) => {
         }
         break;
       default:
-        logger.error(
+        logger.warn(
           { command, requestId },
           'Unknown service message received.',
         );

--- a/lib/hybrid-sdk/requestsHelper.ts
+++ b/lib/hybrid-sdk/requestsHelper.ts
@@ -97,7 +97,7 @@ export const makeLegacyRequest = async (
 export const legacyStreaming = (logContext, rqst, config, io, streamingID) => {
   let prevPartialChunk;
   let isResponseJson;
-  logger.warn(
+  logger.info(
     logContext,
     'Server did not advertise received-post-streams capability - falling back to legacy streaming.',
   );

--- a/test/unit/client/socketHandlers/errorHandler.test.ts
+++ b/test/unit/client/socketHandlers/errorHandler.test.ts
@@ -1,0 +1,26 @@
+import { log as logger } from '../../../../lib/logs/logger';
+import { errorHandler } from '../../../../lib/hybrid-sdk/client/socketHandlers/errorHandler';
+
+describe('errorHandler — log levels (PR 8 contract)', () => {
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('logs "Failed to connect to broker server." at WARN, not ERROR, on TransportError', () => {
+    errorHandler({ type: 'TransportError', description: 'connect timed out' });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'TransportError' }),
+      'Failed to connect to broker server.',
+    );
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'Failed to connect to broker server.',
+    );
+  });
+});

--- a/test/unit/client/socketHandlers/serviceHandler.test.ts
+++ b/test/unit/client/socketHandlers/serviceHandler.test.ts
@@ -53,3 +53,28 @@ describe('serviceHandler — log levels (PR 2 contract)', () => {
     );
   });
 });
+
+describe('serviceHandler — log levels (PR 8 contract)', () => {
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('logs "Unknown service message received." at WARN, not ERROR, on an unknown command', async () => {
+    await serviceHandler({ url: '/unknown/command', headers: {} }, jest.fn());
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ command: '/unknown/command' }),
+      'Unknown service message received.',
+    );
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'Unknown service message received.',
+    );
+  });
+});

--- a/test/unit/client/uncaughtExceptionHandler.test.ts
+++ b/test/unit/client/uncaughtExceptionHandler.test.ts
@@ -1,0 +1,40 @@
+import { log as logger } from '../../../lib/logs/logger';
+import { handleUncaughtException } from '../../../lib/hybrid-sdk/client/index';
+
+describe('handleUncaughtException — log levels (PR 8 contract)', () => {
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  // Minimal stub of the metrics client surface the handler touches.
+  const metricsClientStub: any = {
+    recordUncaughtException: jest.fn(),
+    recordProcessExit: jest.fn(),
+    forceFlush: jest.fn().mockResolvedValue(undefined),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('logs "ECONNRESETs Catch all:" at WARN, not ERROR, on a read ECONNRESET', () => {
+    const econnreset = new Error('read ECONNRESET');
+    handleUncaughtException(econnreset, metricsClientStub);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ msg: 'read ECONNRESET' }),
+      'ECONNRESETs Catch all:',
+      'read ECONNRESET',
+    );
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'ECONNRESETs Catch all:',
+      expect.anything(),
+    );
+    // Sanity: the metrics counter that already covers ECONNRESET observability
+    // still runs (we explicitly did NOT add a new counter — see plan).
+    expect(metricsClientStub.recordUncaughtException).toHaveBeenCalled();
+  });
+});

--- a/test/unit/lib/hybrid-sdk/requestsHelper.test.ts
+++ b/test/unit/lib/hybrid-sdk/requestsHelper.test.ts
@@ -13,7 +13,10 @@
 
 import { log as logger } from '../../../../lib/logs/logger';
 import { makeRequestToDownstream } from '../../../../lib/hybrid-sdk/http/request';
-import { makeLegacyRequest } from '../../../../lib/hybrid-sdk/requestsHelper';
+import {
+  legacyStreaming,
+  makeLegacyRequest,
+} from '../../../../lib/hybrid-sdk/requestsHelper';
 
 jest.mock('../../../../lib/logs/logger');
 jest.mock('../../../../lib/hybrid-sdk/http/request', () => ({
@@ -87,4 +90,29 @@ describe('makeLegacyRequest — SCM response status logging', () => {
       );
     },
   );
+});
+
+describe('legacyStreaming — log levels (PR 8 contract)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('logs the capability-fallback line at INFO, not WARN — it is a negotiation outcome, not a degraded state', () => {
+    // Chainable stub: every `.on(event, cb)` returns `rqst` so the stream
+    // wiring after the log call doesn't blow up.
+    const rqst: any = {};
+    rqst.on = jest.fn(() => rqst);
+    const io: any = { send: jest.fn() };
+
+    legacyStreaming(logContext, rqst, {}, io, 'stream-1');
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.anything(),
+      'Server did not advertise received-post-streams capability - falling back to legacy streaming.',
+    );
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'Server did not advertise received-post-streams capability - falling back to legacy streaming.',
+    );
+  });
 });


### PR DESCRIPTION
  PR description

  ## Why

  Four log sites in the broker client were set to levels that would've/should've asked oncall to act when no action was warranted, or that flagged a benign outcome as "degraded":

  - `TransportError` on every websocket blip fired at ERROR. On a stable network these recover within milliseconds and the broker keeps working. The unrecoverable case (reconnect attempts exhausted) already escalates to ERROR + `process.exit(1)` in a different file, so the loud channel is preserved for the genuinely-broken case.
  - The `'ECONNRESETs Catch all:'` line lives inside an `uncaughtException` handler that **swallows** the error rather than crashing. That's an explicit admission that the event is expected and recoverable — yet it logged at ERROR. The metrics counter `metricsClient.recordUncaughtException(error.code)` two lines above already captures this for rate-based alerting.
  - `'Unknown service message received.'` fires when the broker server sends a command the client doesn't have a case for. That's the textbook forward-compat scenario (newer server, older client during a rollout). ERROR-per-unknown-command turns a fleet-wide rollout into a phantom incident.
  - `'Server did not advertise received-post-streams capability — falling back to legacy streaming.'` fires once per connection when capability negotiation chooses the legacy path. Both outcomes (advertise / don't advertise) are valid; neither is degraded. WARN was the wrong level pillar; INFO is the right one (lifecycle / state-change).

  Combined with the earlier PRs in this audit (per-request INFO trio demoted; lifecycle events promoted; plugin config redaction), the default-level log now reads as a coherent lifecycle/status narrative and ERROR carries meaningful "page me" weight again.

  ## What

  4 one-line level flips + 1 testability extraction.

  | File | Flip | Message |
  |---|---|---|
  | `lib/hybrid-sdk/client/socketHandlers/errorHandler.ts` | ERROR → WARN | `Failed to connect to broker server.` |
  | `lib/hybrid-sdk/client/index.ts` | ERROR → WARN | `ECONNRESETs Catch all:` |
  | `lib/hybrid-sdk/client/socketHandlers/serviceHandler.ts` | ERROR → WARN | `Unknown service message received.` |
  | `lib/hybrid-sdk/requestsHelper.ts` | WARN → INFO | `Server did not advertise received-post-streams capability - falling back to legacy streaming.` |

  Extraction: `lib/hybrid-sdk/client/index.ts` previously embedded the ECONNRESET-handling body inside an anonymous `process.on('uncaughtException', ...)` callback. Now extracted into a named export `handleUncaughtException(error, metricsClient)` and the `process.on` line calls it. No behaviour change — same code path, just reachable from a unit test. **Caveat**: the unit test verifies the extracted function's level,
  not that it's still wired up as the uncaughtException handler — a code-review concern but not something a unit test can reasonably cover.