### PR TITLE
refactor: preserve original Error on rethrow in 3 catch blocks

### DIFF
--- a/lib/hybrid-sdk/client/brokerClientPlugins/pluginManager.ts
+++ b/lib/hybrid-sdk/client/brokerClientPlugins/pluginManager.ts
@@ -9,6 +9,18 @@ import {
 import { PostFilterPreparedRequest } from '../../../broker-workload/prepareRequest';
 import { getConfigForIdentifier } from '../../common/config/universal';
 
+/**
+ * Loads broker plugins from the given folder into clientOpts.config.plugins.
+ *
+ * On failure, throws — either the original Error (with its message prefixed
+ * by "Error loading plugins from {path}: ") or, if the underlying throwable
+ * was not an Error, a fresh Error with the original preserved via
+ * `Error.cause`. The local catch deliberately does NOT log — callers must
+ * structurally log the thrown err so its stack, code, and cause survive
+ * (e.g. `logger.warn({ err }, '...')`, not `logger.warn('...: ' + err)`).
+ * The only caller today (lib/hybrid-sdk/client/index.ts main()) does this
+ * correctly; any new caller must follow the same shape.
+ */
 export const loadPlugins = async (pluginsFolderPath: string, clientOpts) => {
   clientOpts.config['plugins'] = new Map<string, unknown>();
   clientOpts.config.supportedBrokerTypes.forEach((type) => {
@@ -56,9 +68,14 @@ export const loadPlugins = async (pluginsFolderPath: string, clientOpts) => {
     }
     return clientOpts.config['plugins'];
   } catch (err) {
-    const errMsg = `Error loading plugins from ${pluginsFolderPath}`;
-    logger.error({ err }, `Error loading plugins from ${pluginsFolderPath}`);
-    throw new Error(errMsg);
+    if (err instanceof Error) {
+      err.message = `Error loading plugins from ${pluginsFolderPath}: ${err.message}`;
+      throw err;
+    }
+    throw new Error(
+      `Error loading plugins from ${pluginsFolderPath}: ${String(err)}`,
+      { cause: err },
+    );
   }
 };
 

--- a/lib/hybrid-sdk/client/checks/config/brokerClientUrlCheck.ts
+++ b/lib/hybrid-sdk/client/checks/config/brokerClientUrlCheck.ts
@@ -64,8 +64,12 @@ export async function validateBrokerClientUrl(
   } catch (error) {
     if (error instanceof Error) {
       error.message = `Error executing check with checkId ${checkOptions.id}: ${error.message}`;
+      throw error;
     }
-    throw error;
+    throw new Error(
+      `Error executing check with checkId ${checkOptions.id}: ${String(error)}`,
+      { cause: error },
+    );
   }
 }
 

--- a/lib/hybrid-sdk/client/checks/config/brokerServerUrlCheck.ts
+++ b/lib/hybrid-sdk/client/checks/config/brokerServerUrlCheck.ts
@@ -25,8 +25,13 @@ export async function validateBrokerServerUrl(
       output: 'config check: ok',
     } satisfies CheckResult;
   } catch (error) {
-    const errorMessage = `Error executing check with checkId ${checkOptions.id}`;
-    logger.debug({ error }, errorMessage);
-    throw new Error(errorMessage);
+    if (error instanceof Error) {
+      error.message = `Error executing check with checkId ${checkOptions.id}: ${error.message}`;
+      throw error;
+    }
+    throw new Error(
+      `Error executing check with checkId ${checkOptions.id}: ${String(error)}`,
+      { cause: error },
+    );
   }
 }

--- a/lib/hybrid-sdk/client/checks/config/workloadConfiguration.ts
+++ b/lib/hybrid-sdk/client/checks/config/workloadConfiguration.ts
@@ -68,7 +68,13 @@ function verifyClassAndHandler(className, filePath) {
 
     return handlerRegex.test(fileContent);
   } catch (error) {
-    const errorMessage = `Error validating Workload configuration. ${error}`;
-    throw new Error(errorMessage);
+    if (error instanceof Error) {
+      error.message = `Error validating Workload configuration. ${error.message}`;
+      throw error;
+    }
+    throw new Error(
+      `Error validating Workload configuration. ${String(error)}`,
+      { cause: error },
+    );
   }
 }

--- a/lib/hybrid-sdk/client/checks/http/http-executor.ts
+++ b/lib/hybrid-sdk/client/checks/http/http-executor.ts
@@ -53,8 +53,12 @@ export async function executeHttpRequest(
   } catch (error) {
     if (error instanceof Error) {
       error.message = `Error executing check with checkId ${checkOptions.id}: ${error.message}`;
+      throw error;
     }
-    throw error;
+    throw new Error(
+      `Error executing check with checkId ${checkOptions.id}: ${String(error)}`,
+      { cause: error },
+    );
   }
 }
 

--- a/lib/logs/logger.ts
+++ b/lib/logs/logger.ts
@@ -202,20 +202,38 @@ function sanitiseHeaders(headers) {
   return sanitiseObject(hdrs);
 }
 
-function serialiseError(error) {
+// Exported for unit testing. The bunyan serializers below pass this by
+// reference, so changing the export shape is observable in log output.
+//
+// Circular references in `cause` or any custom property copied below are
+// safe at the log-emission boundary: bunyan stringifies records via
+// `safe-json-stringify` (with a `safeCycles` fallback), which converts
+// any cycle to a "[Circular]" marker rather than throwing. So we copy
+// values by reference here without defensive cloning.
+export function serialiseError(
+  error: unknown,
+): Record<string, unknown> | undefined {
   if (!(error instanceof Error)) {
     return;
   }
 
   // part of Error.prototype
-  const result = {
+  const result: Record<string, unknown> = {
     name: error.name,
     message: error.message,
     stack: error.stack,
   };
 
   // collect any other fields that may have been added to the error
-  Object.keys(error).forEach((key) => (result[key] = error[key]));
+  Object.keys(error).forEach((key) => (result[key] = (error as any)[key]));
+
+  // Node sets the ES2022 `cause` property as non-enumerable, so the
+  // Object.keys() pass above doesn't catch it. Copy it explicitly so
+  // catches that wrap a non-Error throwable via `new Error(msg, { cause })`
+  // still surface the original value in the log record.
+  if ('cause' in error) {
+    result.cause = (error as { cause?: unknown }).cause;
+  }
 
   return result;
 }

--- a/test/unit/client/checks/config/brokerClientUrlCheck.test.ts
+++ b/test/unit/client/checks/config/brokerClientUrlCheck.test.ts
@@ -1,6 +1,7 @@
 import { aConfig } from '../../../../helpers/test-factories';
 import { validateBrokerClientUrl } from '../../../../../lib/hybrid-sdk/client/checks/config/brokerClientUrlCheck';
 import { log as logger } from '../../../../../lib/logs/logger';
+import * as urlValidator from '../../../../../lib/hybrid-sdk/common/utils/urlValidator';
 const nock = require('nock');
 
 describe('client/checks/config', () => {
@@ -217,6 +218,33 @@ describe('client/checks/config', () => {
           msg.startsWith('Failed to reach the BROKER_CLIENT_URL'),
       );
       expect(probeDebug).toBeUndefined();
+    });
+  });
+
+  describe('validateBrokerClientUrl() — rethrow preservation', () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    it('wraps a non-Error throwable in an Error, preserving the original via cause', async () => {
+      const original = 'not an Error instance';
+      jest.spyOn(urlValidator, 'isHttpUrl').mockImplementation(() => {
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
+        throw original;
+      });
+      const config = aConfig({
+        BROKER_CLIENT_URL: 'https://broker-client:8000',
+      });
+
+      let caught: unknown;
+      try {
+        await validateBrokerClientUrl({ id: 'check-cli', name: 'X' }, config);
+      } catch (e) {
+        caught = e;
+      }
+
+      expect(caught).toBeInstanceOf(Error);
+      expect((caught as Error).message).toContain('check-cli');
+      expect((caught as Error).message).toContain('not an Error instance');
+      expect((caught as Error).cause).toBe(original);
     });
   });
 });

--- a/test/unit/client/checks/config/brokerServerUrlCheck.test.ts
+++ b/test/unit/client/checks/config/brokerServerUrlCheck.test.ts
@@ -1,5 +1,7 @@
 import { aConfig } from '../../../../helpers/test-factories';
 import { validateBrokerServerUrl } from '../../../../../lib/hybrid-sdk/client/checks/config/brokerServerUrlCheck';
+import { log as logger } from '../../../../../lib/logs/logger';
+import * as urlValidator from '../../../../../lib/hybrid-sdk/common/utils/urlValidator';
 
 describe('client/checks/config', () => {
   describe('validateBrokerClientUrl()', () => {
@@ -48,6 +50,88 @@ describe('client/checks/config', () => {
 
       expect(checkResult.status).toEqual('passing');
       expect(checkResult.output).toContain('config check: ok');
+    });
+  });
+
+  describe('validateBrokerServerUrl() — rethrow preservation', () => {
+    let debugSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      debugSpy = jest.spyOn(logger, 'debug').mockImplementation(() => {});
+    });
+    afterEach(() => jest.restoreAllMocks());
+
+    it('preserves the original Error instance, message, and code on rethrow', async () => {
+      const original = new Error('ENOTFOUND broker.example.com') as Error & {
+        code?: string;
+      };
+      original.code = 'ENOTFOUND';
+      jest.spyOn(urlValidator, 'isHttpUrl').mockImplementation(() => {
+        throw original;
+      });
+
+      const config = aConfig({
+        BROKER_SERVER_URL: 'https://broker.example.com',
+      });
+
+      let caught: unknown;
+      try {
+        await validateBrokerServerUrl({ id: 'check-srv', name: 'X' }, config);
+      } catch (e) {
+        caught = e;
+      }
+
+      expect(caught).toBe(original);
+      expect((caught as Error).message).toContain('check-srv');
+      expect((caught as Error).message).toContain(
+        'ENOTFOUND broker.example.com',
+      );
+      expect((caught as any).code).toBe('ENOTFOUND');
+    });
+
+    it('wraps a non-Error throwable in an Error, preserving the original via cause', async () => {
+      const original = 'not an Error instance';
+      jest.spyOn(urlValidator, 'isHttpUrl').mockImplementation(() => {
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
+        throw original;
+      });
+
+      const config = aConfig({
+        BROKER_SERVER_URL: 'https://broker.example.com',
+      });
+
+      let caught: unknown;
+      try {
+        await validateBrokerServerUrl({ id: 'check-srv', name: 'X' }, config);
+      } catch (e) {
+        caught = e;
+      }
+
+      expect(caught).toBeInstanceOf(Error);
+      expect((caught as Error).message).toContain('check-srv');
+      expect((caught as Error).message).toContain('not an Error instance');
+      expect((caught as Error).cause).toBe(original);
+    });
+
+    it('does not log at the local catch site (upstream catch logs structurally)', async () => {
+      jest.spyOn(urlValidator, 'isHttpUrl').mockImplementation(() => {
+        throw new Error('boom');
+      });
+      const config = aConfig({
+        BROKER_SERVER_URL: 'https://broker.example.com',
+      });
+
+      try {
+        await validateBrokerServerUrl({ id: 'check-srv', name: 'X' }, config);
+      } catch {
+        // expected
+      }
+
+      expect(debugSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({ error: expect.anything() }),
+        expect.stringContaining('Error executing check with checkId'),
+      );
     });
   });
 });

--- a/test/unit/client/checks/config/workloadConfiguration.test.ts
+++ b/test/unit/client/checks/config/workloadConfiguration.test.ts
@@ -1,0 +1,64 @@
+import { validateWorkloadConfig } from '../../../../../lib/hybrid-sdk/client/checks/config/workloadConfiguration';
+import * as configModule from '../../../../../lib/hybrid-sdk/common/config/config';
+
+describe('validateWorkloadConfig — rethrow preservation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  // Config with enough _WORKLOAD_ keys to pass the early-return guard and
+  // reach the inner verifyClassAndHandler() call where the catch lives.
+  const config = {
+    REMOTE_WORKLOAD_NAME: 'Foo',
+    REMOTE_WORKLOAD_MODULE_PATH: 'remote/foo',
+    CLIENT_WORKLOAD_NAME: 'Bar',
+    CLIENT_WORKLOAD_MODULE_PATH: 'client/bar',
+  } as any;
+
+  it('preserves the original Error instance, message, and code on rethrow', () => {
+    const original = new Error('EACCES /factory/root') as Error & {
+      code?: string;
+    };
+    original.code = 'EACCES';
+    jest.spyOn(configModule, 'findFactoryRoot').mockImplementation(() => {
+      throw original;
+    });
+
+    let caught: unknown;
+    try {
+      validateWorkloadConfig({ id: 'check-wl', name: 'Workload' }, config);
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBe(original);
+    expect((caught as Error).message).toContain(
+      'Error validating Workload configuration',
+    );
+    expect((caught as Error).message).toContain('EACCES /factory/root');
+    expect((caught as any).code).toBe('EACCES');
+  });
+
+  it('wraps a non-Error throwable in an Error, preserving the original via cause', () => {
+    const original = 'not an Error instance';
+    jest.spyOn(configModule, 'findFactoryRoot').mockImplementation(() => {
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
+      throw original;
+    });
+
+    let caught: unknown;
+    try {
+      validateWorkloadConfig({ id: 'check-wl', name: 'Workload' }, config);
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain(
+      'Error validating Workload configuration',
+    );
+    expect((caught as Error).message).toContain('not an Error instance');
+    expect((caught as Error).cause).toBe(original);
+  });
+});

--- a/test/unit/client/checks/http/http-executor.error-handling.test.ts
+++ b/test/unit/client/checks/http/http-executor.error-handling.test.ts
@@ -61,7 +61,7 @@ describe('executeHttpRequest — error-handling regression', () => {
     expect((caught as any).code).toBe('ECONNREFUSED');
   });
 
-  it('lets non-Error throwables pass through unchanged', async () => {
+  it('wraps a non-Error string throwable in an Error, preserving the original via cause', async () => {
     mockedRequest.mockRejectedValueOnce('not an Error instance');
 
     let caught: unknown;
@@ -74,7 +74,47 @@ describe('executeHttpRequest — error-handling regression', () => {
       caught = e;
     }
 
-    expect(caught).toBe('not an Error instance');
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain('broker-server-status');
+    expect((caught as Error).message).toContain('not an Error instance');
+    expect((caught as Error).cause).toBe('not an Error instance');
+  });
+
+  it('wraps a non-Error object throwable, preserving it via cause', async () => {
+    const original = { code: 'X', detail: { reason: 'bad' } };
+    mockedRequest.mockRejectedValueOnce(original);
+
+    let caught: unknown;
+    try {
+      await executeHttpRequest(
+        { id: 'broker-server-status', name: 'Broker Server Healthcheck' },
+        httpOptions,
+      );
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain('broker-server-status');
+    expect((caught as Error).cause).toBe(original);
+  });
+
+  it('wraps null / undefined throwables without crashing', async () => {
+    mockedRequest.mockRejectedValueOnce(null);
+
+    let caught: unknown;
+    try {
+      await executeHttpRequest(
+        { id: 'broker-server-status', name: 'Broker Server Healthcheck' },
+        httpOptions,
+      );
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain('broker-server-status');
+    expect((caught as Error).cause).toBeNull();
   });
 
   it('does not double-prefix when called twice with different check ids', async () => {

--- a/test/unit/client/socketHandlers/errorHandler.test.ts
+++ b/test/unit/client/socketHandlers/errorHandler.test.ts
@@ -1,7 +1,7 @@
 import { log as logger } from '../../../../lib/logs/logger';
 import { errorHandler } from '../../../../lib/hybrid-sdk/client/socketHandlers/errorHandler';
 
-describe('errorHandler — log levels (PR 8 contract)', () => {
+describe('errorHandler — log levels', () => {
   let warnSpy: jest.SpyInstance;
   let errorSpy: jest.SpyInstance;
 

--- a/test/unit/client/socketHandlers/serviceHandler.test.ts
+++ b/test/unit/client/socketHandlers/serviceHandler.test.ts
@@ -16,7 +16,7 @@ jest.mock(
   }),
 );
 
-describe('serviceHandler — log levels (PR 2 contract)', () => {
+describe('serviceHandler — config / filter reload log levels', () => {
   let infoSpy: jest.SpyInstance;
   let debugSpy: jest.SpyInstance;
 
@@ -54,7 +54,7 @@ describe('serviceHandler — log levels (PR 2 contract)', () => {
   });
 });
 
-describe('serviceHandler — log levels (PR 8 contract)', () => {
+describe('serviceHandler — unknown-command log level', () => {
   let warnSpy: jest.SpyInstance;
   let errorSpy: jest.SpyInstance;
 

--- a/test/unit/client/uncaughtExceptionHandler.test.ts
+++ b/test/unit/client/uncaughtExceptionHandler.test.ts
@@ -1,7 +1,7 @@
 import { log as logger } from '../../../lib/logs/logger';
 import { handleUncaughtException } from '../../../lib/hybrid-sdk/client/index';
 
-describe('handleUncaughtException — log levels (PR 8 contract)', () => {
+describe('handleUncaughtException — log levels', () => {
   let warnSpy: jest.SpyInstance;
   let errorSpy: jest.SpyInstance;
 

--- a/test/unit/connectionsManager/manager.test.ts
+++ b/test/unit/connectionsManager/manager.test.ts
@@ -51,7 +51,7 @@ describe('Connections Manager', () => {
     expect(wsConnections).toHaveLength(0);
   });
 
-  describe('log levels (PR 2 contract)', () => {
+  describe('log levels', () => {
     let infoSpy: jest.SpyInstance;
     let debugSpy: jest.SpyInstance;
 

--- a/test/unit/connectionsManager/synchronizer.test.ts
+++ b/test/unit/connectionsManager/synchronizer.test.ts
@@ -332,7 +332,7 @@ describe('syncClientConfig', () => {
     ).not.toHaveBeenCalled();
   });
 
-  describe('log levels (PR 2 contract)', () => {
+  describe('log levels', () => {
     let infoSpy: jest.SpyInstance;
     let debugSpy: jest.SpyInstance;
 

--- a/test/unit/lib/hybrid-sdk/common/filter/filter-rules-loading.test.ts
+++ b/test/unit/lib/hybrid-sdk/common/filter/filter-rules-loading.test.ts
@@ -40,7 +40,7 @@ function makeConfig(overrides: Record<string, any> = {}) {
   } as any;
 }
 
-describe('injectRulesAtRuntime — log levels (PR 2 contract)', () => {
+describe('injectRulesAtRuntime — log levels', () => {
   let infoSpy: jest.SpyInstance;
   let debugSpy: jest.SpyInstance;
   let warnSpy: jest.SpyInstance;

--- a/test/unit/lib/hybrid-sdk/requestsHelper.test.ts
+++ b/test/unit/lib/hybrid-sdk/requestsHelper.test.ts
@@ -92,7 +92,7 @@ describe('makeLegacyRequest — SCM response status logging', () => {
   );
 });
 
-describe('legacyStreaming — log levels (PR 8 contract)', () => {
+describe('legacyStreaming — capability-fallback log level', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/test/unit/plugins/brokerPlugins/redaction.test.ts
+++ b/test/unit/plugins/brokerPlugins/redaction.test.ts
@@ -102,7 +102,7 @@ describe('plugin call-site redaction', () => {
 
   it('abstractBrokerPlugin.preRequest does not leak credentials at trace level', async () => {
     // Container-registry plugin does not override preRequest, so it inherits
-    // the abstract default — the call site PR 4 patched.
+    // the abstract default — that's the call site this test exercises.
     const plugin = new ContainerRegistryPlugin({});
     await plugin.preRequest(
       crConnectionConfig,

--- a/test/unit/plugins/pluginManager.test.ts
+++ b/test/unit/plugins/pluginManager.test.ts
@@ -551,7 +551,7 @@ describe('Plugin Manager', () => {
   });
 });
 
-describe('Plugin Manager — log levels (PR 2 contract)', () => {
+describe('Plugin Manager — log levels', () => {
   const pluginsFolderPath = `${findProjectRoot(
     __dirname,
   )}/test/fixtures/plugins`;
@@ -604,5 +604,96 @@ describe('Plugin Manager', () => {
     } catch (err) {
       expect(err).not.toBeNull();
     }
+  });
+});
+
+describe('loadPlugins — rethrow preservation', () => {
+  const pluginsFolderPath = `${findProjectRoot(
+    __dirname,
+  )}/test/fixtures/plugins`;
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const fsPromises = require('fs/promises');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('preserves the original Error instance, message, and code on rethrow', async () => {
+    const original = new Error('EACCES /plugins') as Error & {
+      code?: string;
+    };
+    original.code = 'EACCES';
+    jest.spyOn(fsPromises, 'readdir').mockRejectedValue(original);
+
+    const clientOpts = {
+      config: {
+        universalBrokerEnabled: true,
+        supportedBrokerTypes: ['dummy'],
+        connections: { 'my connection': { type: 'dummy' } },
+      },
+    };
+
+    let caught: unknown;
+    try {
+      await loadPlugins(pluginsFolderPath, clientOpts);
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBe(original);
+    expect((caught as Error).message).toContain('Error loading plugins from');
+    expect((caught as Error).message).toContain('EACCES /plugins');
+    expect((caught as any).code).toBe('EACCES');
+  });
+
+  it('wraps a non-Error throwable in an Error, preserving the original via cause', async () => {
+    const original = 'not an Error instance';
+    jest.spyOn(fsPromises, 'readdir').mockRejectedValue(original);
+
+    const clientOpts = {
+      config: {
+        universalBrokerEnabled: true,
+        supportedBrokerTypes: ['dummy'],
+        connections: { 'my connection': { type: 'dummy' } },
+      },
+    };
+
+    let caught: unknown;
+    try {
+      await loadPlugins(pluginsFolderPath, clientOpts);
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain('Error loading plugins from');
+    expect((caught as Error).message).toContain('not an Error instance');
+    expect((caught as Error).cause).toBe(original);
+  });
+
+  it('does not log at the local catch site (upstream catch logs structurally)', async () => {
+    const original = new Error('EACCES');
+    jest.spyOn(fsPromises, 'readdir').mockRejectedValue(original);
+    const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+
+    const clientOpts = {
+      config: {
+        universalBrokerEnabled: true,
+        supportedBrokerTypes: ['dummy'],
+        connections: { 'my connection': { type: 'dummy' } },
+      },
+    };
+
+    try {
+      await loadPlugins(pluginsFolderPath, clientOpts);
+    } catch {
+      // expected
+    }
+
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.anything() }),
+      expect.stringContaining('Error loading plugins from'),
+    );
   });
 });

--- a/test/unit/serialiseError.test.ts
+++ b/test/unit/serialiseError.test.ts
@@ -1,0 +1,64 @@
+import { serialiseError } from '../../lib/logs/logger';
+
+// Test-local helper: serialiseError returns `undefined` for non-Error
+// input. Tests below pass real Errors and want a non-null result; this
+// asserts that and narrows the type.
+function serialise(error: Error): Record<string, unknown> {
+  const out = serialiseError(error);
+  expect(out).toBeDefined();
+  return out as Record<string, unknown>;
+}
+
+describe('serialiseError', () => {
+  it('returns undefined for non-Error input', () => {
+    expect(serialiseError('not an Error')).toBeUndefined();
+    expect(serialiseError(null)).toBeUndefined();
+    expect(serialiseError({ message: 'plain object' })).toBeUndefined();
+  });
+
+  it('serialises a plain Error to {name, message, stack}', () => {
+    const out = serialise(new Error('boom'));
+
+    expect(out.name).toBe('Error');
+    expect(out.message).toBe('boom');
+    expect(out.stack).toContain('Error: boom');
+  });
+
+  it('copies enumerable own properties (e.g. code) onto the result', () => {
+    const err = new Error('boom') as Error & { code?: string };
+    err.code = 'EBOOM';
+
+    expect(serialise(err).code).toBe('EBOOM');
+  });
+
+  it('renders a primitive-string cause inline', () => {
+    const out = serialise(
+      new Error('wrapper', { cause: 'original-string-cause' }),
+    );
+
+    expect(out.message).toBe('wrapper');
+    expect(out.cause).toBe('original-string-cause');
+  });
+
+  it('renders an object cause as the object', () => {
+    const cause = { code: 'X', detail: 'payload' };
+    const out = serialise(new Error('wrapper', { cause }));
+
+    expect(out.cause).toEqual(cause);
+  });
+
+  it('renders a null cause as null (not dropped)', () => {
+    const out = serialise(new Error('wrapper', { cause: null }));
+
+    expect(out.cause).toBeNull();
+  });
+
+  it('does not crash on a circular cause (bunyan stringifies cycles to [Circular])', () => {
+    const circular: any = { id: 1 };
+    circular.self = circular;
+
+    expect(() =>
+      serialise(new Error('wrapper', { cause: circular })),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Mirrors the pattern applied to http-executor.ts and brokerClientUrlCheck.ts earlier this session: instead of `throw new Error(`wrap: ${err.message}`)`, mutate the original error's message in place and rethrow the same instance.

This preserves the original stack trace (pointing at the actual fault, not the wrapper), the original error type (so upstream `instanceof` checks still match), and any custom properties such as `err.code`. The local log call is removed where present so the upstream catch handles logging once.
