### PR TITLE
feat: guarantee snyk-request-id end-to-end across the WebSocket hop

### DIFF
--- a/lib/broker-workload/websocketRequests.ts
+++ b/lib/broker-workload/websocketRequests.ts
@@ -99,15 +99,6 @@ export class BrokerWorkload extends Workload<WorkloadType.remoteServer> {
       ...correlationHeaders,
     };
 
-    if (!correlationHeaders.requestId) {
-      // This should be a warning but older clients won't send one
-      // TODO make this a warning when significant majority of clients are on latest version
-      logger.debug(
-        logContext,
-        'Header Snyk-Request-Id not included in headers passed through',
-      );
-    }
-
     const responseHandler = new HybridResponseHandler(
       {
         connectionIdentifier: this.connectionIdentifier,

--- a/lib/hybrid-sdk/clientRequestHelpers.ts
+++ b/lib/hybrid-sdk/clientRequestHelpers.ts
@@ -28,9 +28,9 @@ export class HybridClientRequestHandler {
     this.res = res;
     this.options = getConfig();
 
-    // Propagate the resolved request ID into req.headers so it is included in
-    // the WS payload sent to the broker server (headers: this.req.headers).
-    this.req.headers['snyk-request-id'] ||= this.req.requestId;
+    // Surface the middleware-validated request ID in the WS payload.
+    // req.headers may still hold the unvalidated inbound value.
+    this.req.headers['snyk-request-id'] = this.req.requestId;
     this.responseWantedOverWs = req.headers['x-broker-ws-response']
       ? true
       : false;

--- a/lib/hybrid-sdk/common/connectionToWorkloadInterface/forwardWebsocketRequest.ts
+++ b/lib/hybrid-sdk/common/connectionToWorkloadInterface/forwardWebsocketRequest.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'crypto';
+import { isUUID } from '../utils/uuid';
 import { RequestPayload } from '../types/http';
 import { LoadedClientOpts, LoadedServerOpts } from '../types/options';
 import { BrokerWorkload } from '../../../broker-workload/websocketRequests';
@@ -20,11 +22,17 @@ export const forwardWebSocketRequest = (
   // 4. Get response over HTTP conn (logged)
   // 5. Send response over websocket conn
 
-  return (connectionIdentifier) =>
+  return (connectionIdentifier: string) =>
     async (
       payload: RequestPayload,
       emit: (response: HybridResponse) => void,
     ) => {
+      // Old broker-clients on the inbound path may not set snyk-request-id.
+      payload.headers = payload.headers ?? {};
+      if (!isUUID(payload.headers['snyk-request-id'])) {
+        payload.headers['snyk-request-id'] = randomUUID();
+      }
+
       const workloadName = options.config.remoteWorkloadName;
       const workloadModulePath = options.config.remoteWorkloadModulePath;
       const workload = (await Workload.instantiate(

--- a/lib/hybrid-sdk/common/http/middleware/requestId.ts
+++ b/lib/hybrid-sdk/common/http/middleware/requestId.ts
@@ -45,8 +45,16 @@ export const setRequestIdHeader = (
 
   return (req: Request, res: Response, next: NextFunction) => {
     try {
-      req.requestId =
-        incomingHeaders.map((h) => req.header(h)).find(isUUID) ?? randomUUID();
+      const inherited = incomingHeaders.map((h) => req.header(h)).find(isUUID);
+      if (inherited) {
+        req.requestId = inherited;
+      } else {
+        req.requestId = randomUUID();
+        logger.debug(
+          { method: req.method, url: req.url },
+          'No valid request ID in inbound headers — new request ID generated',
+        );
+      }
       res.setHeader(responseHeader, req.requestId);
     } catch (error) {
       // Should never throw on Node 20+ — a failure here indicates a broken

--- a/test/unit/lib/broker-workload/websocketRequests.test.ts
+++ b/test/unit/lib/broker-workload/websocketRequests.test.ts
@@ -14,6 +14,9 @@ const mockFilterRequest = filterRequest as jest.MockedFunction<
   typeof filterRequest
 >;
 
+// snyk-request-id is pre-populated in fixtures to reflect production reality:
+// forwardWebSocketRequest guarantees the header is a valid UUID before
+// BrokerWorkload.handler is ever called.
 describe('BrokerWorkload', () => {
   const connectionIdentifier = 'test-connection-id';
   const options: BrokerWorkloadOptions = {
@@ -42,7 +45,10 @@ describe('BrokerWorkload', () => {
     const payload = {
       url: '/',
       method: 'GET',
-      headers: { 'x-snyk-broker-context-id': 'some-uuid' },
+      headers: {
+        'x-snyk-broker-context-id': 'some-uuid',
+        'snyk-request-id': '11111111-1111-4111-8111-111111111111',
+      },
       streamingID: 'stream-1',
     };
     const websocketHandler = jest.fn();
@@ -66,7 +72,7 @@ describe('BrokerWorkload', () => {
     const payload = {
       url: '/',
       method: 'GET',
-      headers: {},
+      headers: { 'snyk-request-id': '22222222-2222-4222-8222-222222222222' },
       streamingID: 'stream-1',
     };
     const websocketHandler = jest.fn();

--- a/test/unit/lib/hybrid-sdk/clientRequestHelpers.test.ts
+++ b/test/unit/lib/hybrid-sdk/clientRequestHelpers.test.ts
@@ -40,3 +40,43 @@ describe('HybridClientRequestHandler — [HTTP Flow] Received request log level'
     );
   });
 });
+
+describe('HybridClientRequestHandler — req.requestId propagation into req.headers', () => {
+  const RESOLVED_UUID = '11111111-1111-4111-8111-111111111111';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('overwrites snyk-request-id header with req.requestId even when the inbound header was already populated with junk', () => {
+    // This pins the contract: the middleware-resolved req.requestId is
+    // authoritative. The inbound header may have carried junk that the
+    // middleware chose not to use (because it failed isUUID); we must not
+    // forward that junk into the WS payload.
+    const req: any = {
+      url: '/some/path',
+      method: 'GET',
+      headers: { 'snyk-request-id': 'not-a-uuid' },
+      requestId: RESOLVED_UUID,
+    };
+    const res: any = {};
+
+    new HybridClientRequestHandler(req, res);
+
+    expect(req.headers['snyk-request-id']).toBe(RESOLVED_UUID);
+  });
+
+  it('writes req.requestId into snyk-request-id header when no inbound header was present', () => {
+    const req: any = {
+      url: '/some/path',
+      method: 'GET',
+      headers: {},
+      requestId: RESOLVED_UUID,
+    };
+    const res: any = {};
+
+    new HybridClientRequestHandler(req, res);
+
+    expect(req.headers['snyk-request-id']).toBe(RESOLVED_UUID);
+  });
+});

--- a/test/unit/lib/hybrid-sdk/common/connectionToWorkloadInterface/forwardWebsocketRequest.test.ts
+++ b/test/unit/lib/hybrid-sdk/common/connectionToWorkloadInterface/forwardWebsocketRequest.test.ts
@@ -1,0 +1,127 @@
+import { log as logger } from '../../../../../../lib/logs/logger';
+import { isUUID } from '../../../../../../lib/hybrid-sdk/common/utils/uuid';
+import { forwardWebSocketRequest } from '../../../../../../lib/hybrid-sdk/common/connectionToWorkloadInterface/forwardWebsocketRequest';
+
+jest.mock('../../../../../../lib/logs/logger');
+jest.mock('../../../../../../lib/hybrid-sdk/workloadFactory', () => ({
+  Workload: {
+    instantiate: jest.fn(),
+  },
+  WorkloadType: { remoteServer: 'remote-server' },
+}));
+
+import { Workload } from '../../../../../../lib/hybrid-sdk/workloadFactory';
+
+const mockWorkloadInstantiate = Workload.instantiate as jest.MockedFunction<
+  typeof Workload.instantiate
+>;
+
+const VALID_UUID = '00000000-0000-4000-8000-000000000000';
+
+function makeOptions() {
+  return {
+    config: {
+      remoteWorkloadName: 'broker',
+      remoteWorkloadModulePath: undefined,
+    },
+  } as any;
+}
+
+function makeWebsocketHandler() {
+  return {} as any;
+}
+
+async function runHandler(
+  payload: Record<string, any>,
+  connectionIdentifier = 'conn-123',
+) {
+  const mockHandler = jest.fn();
+  mockWorkloadInstantiate.mockResolvedValue({ handler: mockHandler } as any);
+
+  const emit = jest.fn();
+  await forwardWebSocketRequest(
+    makeOptions(),
+    makeWebsocketHandler(),
+  )(connectionIdentifier)(payload as any, emit);
+
+  return {
+    mockHandler,
+    capturedPayload: mockHandler.mock.calls[0]?.[0]?.payload,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('forwardWebSocketRequest — snyk-request-id backfill', () => {
+  it('synthesises a UUID when snyk-request-id is absent', async () => {
+    const payload = { url: '/foo', method: 'GET', headers: {} };
+    const { capturedPayload } = await runHandler(payload);
+
+    expect(isUUID(capturedPayload.headers['snyk-request-id'])).toBe(true);
+  });
+
+  it('leaves a valid UUID unchanged', async () => {
+    const payload = {
+      url: '/bar',
+      method: 'POST',
+      headers: { 'snyk-request-id': VALID_UUID },
+    };
+    const { capturedPayload } = await runHandler(payload);
+
+    expect(capturedPayload.headers['snyk-request-id']).toBe(VALID_UUID);
+  });
+
+  it('replaces a non-UUID string with a synthesised UUID', async () => {
+    const payload = {
+      url: '/baz',
+      method: 'DELETE',
+      headers: { 'snyk-request-id': 'not-a-uuid' },
+    };
+    const { capturedPayload } = await runHandler(payload);
+
+    const synthesised = capturedPayload.headers['snyk-request-id'];
+    expect(synthesised).not.toBe('not-a-uuid');
+    expect(isUUID(synthesised)).toBe(true);
+  });
+
+  it('handles undefined headers — creates headers object and synthesises UUID', async () => {
+    const payload = { url: '/qux', method: 'PUT', headers: undefined };
+    const { capturedPayload } = await runHandler(payload);
+
+    expect(capturedPayload.headers).toBeDefined();
+    expect(isUUID(capturedPayload.headers['snyk-request-id'])).toBe(true);
+  });
+
+  it('replaces the nil UUID with a synthesised UUID', async () => {
+    const NIL_UUID = '00000000-0000-0000-0000-000000000000';
+    const payload = {
+      url: '/nil',
+      method: 'GET',
+      headers: { 'snyk-request-id': NIL_UUID },
+    };
+    const { capturedPayload } = await runHandler(payload);
+
+    const synthesised = capturedPayload.headers['snyk-request-id'];
+    expect(synthesised).not.toBe(NIL_UUID);
+    expect(isUUID(synthesised)).toBe(true);
+  });
+
+  describe('regression guard: dead debug branch is removed', () => {
+    it('never logs the old "Header Snyk-Request-Id not included" debug message', async () => {
+      const payload = { url: '/', method: 'GET', headers: {} };
+      await runHandler(payload);
+
+      const debugCalls = (logger.debug as jest.Mock).mock.calls;
+      const oldMessage = debugCalls.some(
+        (args) =>
+          typeof args[args.length - 1] === 'string' &&
+          args[args.length - 1].includes(
+            'Header Snyk-Request-Id not included in headers passed through',
+          ),
+      );
+      expect(oldMessage).toBe(false);
+    });
+  });
+});

--- a/test/unit/lib/hybrid-sdk/common/http/requestId.test.ts
+++ b/test/unit/lib/hybrid-sdk/common/http/requestId.test.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import request from 'supertest';
 import { setRequestIdHeader } from '../../../../../../lib/hybrid-sdk/common/http/middleware/requestId';
 import { isUUID } from '../../../../../../lib/hybrid-sdk/common/utils/uuid';
+import { log as logger } from '../../../../../../lib/logs/logger';
 
 const setupApp = (opts?: Parameters<typeof setRequestIdHeader>[0]) => {
   const app = express();
@@ -123,6 +124,39 @@ describe('setRequestIdHeader middleware', () => {
       .set('x-only-this', customUuid);
 
     expect(res.text).toEqual(customUuid);
+  });
+
+  describe('synthesis logging', () => {
+    it('logs at debug level when no candidate headers are present', async () => {
+      const debugSpy = jest.spyOn(logger, 'debug');
+
+      await request(setupApp()).get('/test-path');
+
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'GET', url: '/test-path' }),
+        'No valid request ID in inbound headers — new request ID generated',
+      );
+    });
+
+    it('logs at debug level when all candidate headers contain invalid UUIDs', async () => {
+      const debugSpy = jest.spyOn(logger, 'debug');
+
+      await request(setupApp()).get('/').set('snyk-request-id', 'not-a-uuid');
+
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'GET', url: '/' }),
+        'No valid request ID in inbound headers — new request ID generated',
+      );
+    });
+
+    it('does not log when a valid UUID is resolved from an inbound header', async () => {
+      const debugSpy = jest.spyOn(logger, 'debug');
+      const validUuid = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+      await request(setupApp()).get('/').set('snyk-request-id', validUuid);
+
+      expect(debugSpy).not.toHaveBeenCalled();
+    });
   });
 
   it('forwards the error to Express and logs at error level when randomUUID throws', async () => {


### PR DESCRIPTION
## Why

When a request crosses the WebSocket hop between broker-server and broker-client, its \`snyk-request-id\` can disappear or change identity:

- Callers that don't send the header (older broker-client emitters on the inbound/webhook path) leave downstream logs with \`requestId: ''\`, so a request can't be traced past the WS boundary.
- Callers that send a non-UUID value (e.g. a free-form string) cause the HTTP response and the downstream call to surface **different** UUIDs for the same logical request, because the inbound junk is propagated into the WS payload truthily but rejected by the validating middleware on the response side. Log correlation breaks for the entire request.

## What this changes

Every request the broker handles — HTTP-inbound, WS-relayed, downstream-bound — carries the same valid UUID as \`snyk-request-id\`, end-to-end. There is no silent fallback to empty strings, and no divergence between what the caller sees on the response and what downstream systems receive.

Concretely: the WS chokepoint now treats \`snyk-request-id\` as guaranteed-valid by contract (synthesising one if the payload arrived without it), and the HTTP→WS bridge now propagates the middleware-validated UUID rather than whatever the inbound caller sent. The HTTP middleware also logs at debug when it synthesises a UUID, giving visibility into callers that don't send a valid request ID.

## Test plan

- [x] Unit tests cover five backfill scenarios (absent, valid, invalid, nil UUID, undefined headers) plus the contract that the validated UUID overwrites any inbound value at the WS bridge.
- [x] Synthesis logging tests confirm a debug log fires when no valid UUID is found in inbound headers, and does not fire when one is present.
- [x] \`npm run build\` clean.
- [x] End-to-end verified against this branch via broker-stack: 6 subtests crossing \`{HTTPPostResponse, WSResponse} × {NoHeader, ValidUUID, InvalidUUID}\` all green; e2e suite lives out-of-tree and will land separately.