### PR TITLE
fix(circleci): use semantic-release 25.0.3 by npm releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,7 +398,7 @@ jobs:
           no_output_timeout: 20m
           command: |
             export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
-            npm install --save-exact --save-dev semantic-release@22.0.12 @semantic-release/exec@6.0.3 pkg@5.8.1
+            npm install --save-exact --save-dev semantic-release@25.0.3 @semantic-release/exec@7.1.0 pkg@5.8.1
             npx semantic-release
 
 workflows:


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR uses semantic-release 25.0.3 to perform trusted publishing to NPM.

https://github.com/semantic-release/semantic-release/releases/tag/v25.0.1
