### PR TITLE
fix(client): prevent ENOENT race during shutdown

### DIFF
--- a/lib/hybrid-sdk/client/config/remoteConfig.ts
+++ b/lib/hybrid-sdk/client/config/remoteConfig.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { makeRequestToDownstream } from '../../http/request';
 import { ClientOpts } from '../../common/types/options';
 import { isJson } from '../../common/utils/json';
@@ -7,11 +7,19 @@ import { capitalizeKeys } from '../utils/configurations';
 import version from '../../common/utils/version';
 import { getAuthConfig } from '../auth/oauth';
 import { PostFilterPreparedRequest } from '../../../broker-workload/prepareRequest';
+import { log as logger } from '../../../logs/logger';
 
 export const retrieveConnectionsForDeployment = async (
   clientOpts: ClientOpts,
   universalFilePath: string,
 ) => {
+  if (!existsSync(universalFilePath)) {
+    logger.warn(
+      { universalFilePath },
+      'config.universal.json missing during sync; skipping',
+    );
+    return;
+  }
   const deploymentId = clientOpts.config.deploymentId;
   const apiVersion = clientOpts.config.apiVersion;
   const request: PostFilterPreparedRequest = {

--- a/lib/hybrid-sdk/client/connectionsManager/remoteConnectionSync.ts
+++ b/lib/hybrid-sdk/client/connectionsManager/remoteConnectionSync.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { findProjectRoot } from '../../common/config/config';
 import { LoadedClientOpts } from '../../common/types/options';
 import { log as logger } from '../../../logs/logger';
@@ -17,6 +18,17 @@ export const retrieveAndLoadRemoteConfigSync = async (
       __dirname,
     )}/config.universal.json`;
     await retrieveConnectionsForDeployment(clientOpts, universalFilePath);
+    // The retrieve step is a no-op when the file is missing.
+    // Skip validation/reload instead of letting the validator's
+    // readFileSync throw ENOENT into the catch below — that path produces a
+    // misleading "sync failed" warning every tick.
+    if (!existsSync(universalFilePath)) {
+      logger.debug(
+        { universalFilePath },
+        'config.universal.json missing; skipping validation and reload',
+      );
+      return;
+    }
     validateUniversalConnectionsRemoteConfig(universalFilePath);
     await reloadConfig(clientOpts);
   } catch (err) {

--- a/lib/hybrid-sdk/client/connectionsManager/remoteConnectionSync.ts
+++ b/lib/hybrid-sdk/client/connectionsManager/remoteConnectionSync.ts
@@ -1,5 +1,7 @@
 import { findProjectRoot } from '../../common/config/config';
 import { LoadedClientOpts } from '../../common/types/options';
+import { log as logger } from '../../../logs/logger';
+import { isShuttingDown } from '../../common/utils/signals';
 import { reloadConfig } from '../config/configHelpers';
 import { retrieveConnectionsForDeployment } from '../config/remoteConfig';
 import { validateUniversalConnectionsRemoteConfig } from './validator';
@@ -7,12 +9,17 @@ import { validateUniversalConnectionsRemoteConfig } from './validator';
 export const retrieveAndLoadRemoteConfigSync = async (
   clientOpts: LoadedClientOpts,
 ): Promise<void> => {
-  await retrieveConnectionsForDeployment(
-    clientOpts,
-    `${findProjectRoot(__dirname)}/config.universal.json`,
-  );
-  validateUniversalConnectionsRemoteConfig(
-    `${findProjectRoot(__dirname)}/config.universal.json`,
-  );
-  await reloadConfig(clientOpts);
+  if (isShuttingDown()) {
+    return;
+  }
+  try {
+    const universalFilePath = `${findProjectRoot(
+      __dirname,
+    )}/config.universal.json`;
+    await retrieveConnectionsForDeployment(clientOpts, universalFilePath);
+    validateUniversalConnectionsRemoteConfig(universalFilePath);
+    await reloadConfig(clientOpts);
+  } catch (err) {
+    logger.warn({ err }, 'Remote config sync failed; will retry on next cycle');
+  }
 };

--- a/lib/hybrid-sdk/client/connectionsManager/synchronizer.ts
+++ b/lib/hybrid-sdk/client/connectionsManager/synchronizer.ts
@@ -8,7 +8,10 @@ import {
   IdentifyingMetadata,
   WebSocketConnection,
 } from '../types/client';
-import { addTimerToTerminalHandlers } from '../../common/utils/signals';
+import {
+  addTimerToTerminalHandlers,
+  isShuttingDown,
+} from '../../common/utils/signals';
 import { isWebsocketConnOpen } from '../utils/socketHelpers';
 
 /** Internal bookkeeping written by the synchronizer to detect config changes
@@ -34,6 +37,9 @@ export const syncClientConfig = async (
   websocketConnections: WebSocketConnection[],
   globalIdentifyingMetadata: IdentifyingMetadata,
 ): Promise<void> => {
+  if (isShuttingDown()) {
+    return;
+  }
   if (
     !process.env.SKIP_REMOTE_CONFIG &&
     !process.env.REMOTE_CONFIG_POLLING_MODE
@@ -54,14 +60,16 @@ export const syncClientConfig = async (
   if (isPollingRequired) {
     logger.debug({}, `Waiting for connections (polling).`);
     if (process.env.NODE_ENV != 'test') {
-      setTimeout(
-        () =>
-          syncClientConfig(
-            clientOpts,
-            websocketConnections,
-            globalIdentifyingMetadata,
-          ),
-        clientOpts.config.connectionsManager.watcher.interval,
+      addTimerToTerminalHandlers(
+        setTimeout(
+          () =>
+            syncClientConfig(
+              clientOpts,
+              websocketConnections,
+              globalIdentifyingMetadata,
+            ),
+          clientOpts.config.connectionsManager.watcher.interval,
+        ),
       );
     }
   } else {

--- a/lib/hybrid-sdk/client/connectionsManager/synchronizer.ts
+++ b/lib/hybrid-sdk/client/connectionsManager/synchronizer.ts
@@ -10,6 +10,7 @@ import {
 } from '../types/client';
 import {
   addIntervalToTerminalHandlers,
+  clearAndRemoveInterval,
   isShuttingDown,
 } from '../../common/utils/signals';
 import { isWebsocketConnOpen } from '../utils/socketHelpers';
@@ -41,7 +42,7 @@ let resyncPending = false;
  *  trigger the polling branch need to clear it between cases. */
 export const __resetSynchronizerStateForTests = () => {
   if (pollingIntervalId) {
-    clearInterval(pollingIntervalId);
+    clearAndRemoveInterval(pollingIntervalId);
   }
   pollingIntervalId = null;
   isSyncing = false;
@@ -128,7 +129,7 @@ const runSyncCycle = async (
   } else {
     logger.debug({}, 'Disabling polling in favor of server notification.');
     if (pollingIntervalId) {
-      clearInterval(pollingIntervalId);
+      clearAndRemoveInterval(pollingIntervalId);
       pollingIntervalId = null;
     }
   }

--- a/lib/hybrid-sdk/client/connectionsManager/synchronizer.ts
+++ b/lib/hybrid-sdk/client/connectionsManager/synchronizer.ts
@@ -24,10 +24,11 @@ interface SyncState {
  *  so we can detect changes (e.g. context updates) between sync cycles. */
 export const syncStateByConnection = new Map<string, SyncState>();
 
-/** Whether the singleton polling interval has been registered. The interval
- *  drives recurring syncClientConfig ticks; registering once avoids unbounded
- *  growth of the signals timer registry. */
-let pollingIntervalRegistered = false;
+/** Handle of the active polling interval, or null when polling is not running.
+ *  At most one interval exists at a time: registering only when null avoids
+ *  unbounded growth of the signals timer registry, and clearing it when
+ *  polling is no longer required stops the recurring sync cycles. */
+let pollingIntervalId: NodeJS.Timeout | null = null;
 
 /** Re-entrancy guard. Polling, backup-watcher, and RPC-triggered calls can
  *  race. We coalesce instead of drop: at most one extra cycle is queued, so
@@ -39,7 +40,10 @@ let resyncPending = false;
 /** Test-only reset. The registration flag is module-level state; tests that
  *  trigger the polling branch need to clear it between cases. */
 export const __resetSynchronizerStateForTests = () => {
-  pollingIntervalRegistered = false;
+  if (pollingIntervalId) {
+    clearInterval(pollingIntervalId);
+  }
+  pollingIntervalId = null;
   isSyncing = false;
   resyncPending = false;
 };
@@ -109,22 +113,24 @@ const runSyncCycle = async (
 
   if (isPollingRequired) {
     logger.debug({}, `Waiting for connections (polling).`);
-    if (process.env.NODE_ENV != 'test' && !pollingIntervalRegistered) {
-      pollingIntervalRegistered = true;
-      addIntervalToTerminalHandlers(
-        setInterval(
-          () =>
-            syncClientConfig(
-              clientOpts,
-              websocketConnections,
-              globalIdentifyingMetadata,
-            ),
-          clientOpts.config.connectionsManager.watcher.interval,
-        ),
+    if (process.env.NODE_ENV != 'test' && !pollingIntervalId) {
+      pollingIntervalId = setInterval(
+        () =>
+          syncClientConfig(
+            clientOpts,
+            websocketConnections,
+            globalIdentifyingMetadata,
+          ),
+        clientOpts.config.connectionsManager.watcher.interval,
       );
+      addIntervalToTerminalHandlers(pollingIntervalId);
     }
   } else {
     logger.debug({}, 'Disabling polling in favor of server notification.');
+    if (pollingIntervalId) {
+      clearInterval(pollingIntervalId);
+      pollingIntervalId = null;
+    }
   }
 
   for (const key of integrationsKeys) {

--- a/lib/hybrid-sdk/client/connectionsManager/synchronizer.ts
+++ b/lib/hybrid-sdk/client/connectionsManager/synchronizer.ts
@@ -9,7 +9,7 @@ import {
   WebSocketConnection,
 } from '../types/client';
 import {
-  addTimerToTerminalHandlers,
+  addIntervalToTerminalHandlers,
   isShuttingDown,
 } from '../../common/utils/signals';
 import { isWebsocketConnOpen } from '../utils/socketHelpers';
@@ -23,6 +23,23 @@ interface SyncState {
 /** Synchronizer bookkeeping — tracks the last-seen config per connection
  *  so we can detect changes (e.g. context updates) between sync cycles. */
 export const syncStateByConnection = new Map<string, SyncState>();
+
+/** Whether the singleton polling interval has been registered. The interval
+ *  drives recurring syncClientConfig ticks; registering once avoids unbounded
+ *  growth of the signals timer registry. */
+let pollingIntervalRegistered = false;
+
+/** Re-entrancy guard. Polling, backup-watcher, and RPC-triggered calls can
+ *  race; we drop overlapping calls because the in-flight sync already covers
+ *  the latest state. */
+let isSyncing = false;
+
+/** Test-only reset. The registration flag is module-level state; tests that
+ *  trigger the polling branch need to clear it between cases. */
+export const __resetSynchronizerStateForTests = () => {
+  pollingIntervalRegistered = false;
+  isSyncing = false;
+};
 
 /**
  * Keeps WebSocket connections and plugins in sync with configured integrations. For each
@@ -40,162 +57,175 @@ export const syncClientConfig = async (
   if (isShuttingDown()) {
     return;
   }
-  if (
-    !process.env.SKIP_REMOTE_CONFIG &&
-    !process.env.REMOTE_CONFIG_POLLING_MODE
-  ) {
-    // Done at startup only. RPC calls trigger this instead of polling
-    await retrieveAndLoadRemoteConfigSync(clientOpts);
+  if (isSyncing) {
+    logger.debug({}, 'syncClientConfig already in progress, skipping tick.');
+    return;
   }
-
-  const integrationsKeys = clientOpts.config.connections
-    ? Object.keys(clientOpts.config.connections)
-    : [];
-
-  const isPollingRequired =
-    clientOpts.config.UNIVERSAL_BROKER_GA !== 'true' ||
-    integrationsKeys.length < 1 ||
-    websocketConnections.length === 0;
-
-  if (isPollingRequired) {
-    logger.debug({}, `Waiting for connections (polling).`);
-    if (process.env.NODE_ENV != 'test') {
-      addTimerToTerminalHandlers(
-        setTimeout(
-          () =>
-            syncClientConfig(
-              clientOpts,
-              websocketConnections,
-              globalIdentifyingMetadata,
-            ),
-          clientOpts.config.connectionsManager.watcher.interval,
-        ),
-      );
+  isSyncing = true;
+  try {
+    if (
+      !process.env.SKIP_REMOTE_CONFIG &&
+      !process.env.REMOTE_CONFIG_POLLING_MODE
+    ) {
+      // Done at startup only. RPC calls trigger this instead of polling
+      await retrieveAndLoadRemoteConfigSync(clientOpts);
     }
-  } else {
-    logger.debug({}, 'Disabling polling in favor of server notification.');
-  }
 
-  for (const key of integrationsKeys) {
-    const connectionConfig = clientOpts.config.connections[key];
+    const integrationsKeys = clientOpts.config.connections
+      ? Object.keys(clientOpts.config.connections)
+      : [];
 
-    const currentWebsocketConnectionIndex = websocketConnections.findIndex(
-      (conn) => conn.friendlyName === key,
-    );
-    if (connectionConfig.isDisabled) {
-      logger.error(
-        {
-          id: connectionConfig.id,
-          name: connectionConfig.friendlyName,
-        },
-        `Connection is disabled due to (a) missing environment variable(s). Please provide the value and restart the broker client.`,
-      );
-      continue;
+    const isPollingRequired =
+      clientOpts.config.UNIVERSAL_BROKER_GA !== 'true' ||
+      integrationsKeys.length < 1 ||
+      websocketConnections.length === 0;
+
+    if (isPollingRequired) {
+      logger.debug({}, `Waiting for connections (polling).`);
+      if (process.env.NODE_ENV != 'test' && !pollingIntervalRegistered) {
+        pollingIntervalRegistered = true;
+        addIntervalToTerminalHandlers(
+          setInterval(
+            () =>
+              syncClientConfig(
+                clientOpts,
+                websocketConnections,
+                globalIdentifyingMetadata,
+              ),
+            clientOpts.config.connectionsManager.watcher.interval,
+          ),
+        );
+      }
+    } else {
+      logger.debug({}, 'Disabling polling in favor of server notification.');
     }
-    if (!connectionConfig.identifier) {
-      if (currentWebsocketConnectionIndex > -1) {
-        logger.info(
+
+    for (const key of integrationsKeys) {
+      const connectionConfig = clientOpts.config.connections[key];
+
+      const currentWebsocketConnectionIndex = websocketConnections.findIndex(
+        (conn) => conn.friendlyName === key,
+      );
+      if (connectionConfig.isDisabled) {
+        logger.error(
           {
             id: connectionConfig.id,
             name: connectionConfig.friendlyName,
           },
-          `Shutting down unused connection.`,
+          `Connection is disabled due to (a) missing environment variable(s). Please provide the value and restart the broker client.`,
         );
+        continue;
+      }
+      if (!connectionConfig.identifier) {
+        if (currentWebsocketConnectionIndex > -1) {
+          logger.info(
+            {
+              id: connectionConfig.id,
+              name: connectionConfig.friendlyName,
+            },
+            `Shutting down unused connection.`,
+          );
+          shutDownConnectionPair(
+            websocketConnections,
+            integrationsKeys.indexOf(key),
+          );
+        } else {
+          logger.debug(
+            {
+              id: connectionConfig.id,
+              name: connectionConfig.friendlyName,
+            },
+            `Connection (${connectionConfig.friendlyName}) not in use by any orgs. Will check periodically and create connection when in use.`,
+          );
+        }
+        continue;
+      }
+
+      // If connection doesn't exist, create it
+      if (currentWebsocketConnectionIndex < 0) {
+        logger.info({ connectionName: key }, 'Creating configured connection.');
+        await runStartupPlugins(clientOpts, key);
+
+        const [primary, secondary] = await createWebSocketConnectionPairs(
+          clientOpts,
+          globalIdentifyingMetadata,
+          key,
+          clientOpts.metricsClient,
+        );
+        websocketConnections.push(primary, secondary);
+      } else if (
+        // Token rotation for the connection at hand
+        connectionConfig.identifier !=
+        websocketConnections[currentWebsocketConnectionIndex].identifier
+      ) {
+        logger.info(
+          { connectionName: key },
+          'Updating configured connection for new identifier.',
+        );
+        // shut down previous tunnels
         shutDownConnectionPair(
           websocketConnections,
           integrationsKeys.indexOf(key),
         );
-      } else {
-        logger.debug(
-          {
-            id: connectionConfig.id,
-            name: connectionConfig.friendlyName,
-          },
-          `Connection (${connectionConfig.friendlyName}) not in use by any orgs. Will check periodically and create connection when in use.`,
-        );
-      }
-      continue;
-    }
 
-    // If connection doesn't exist, create it
-    if (currentWebsocketConnectionIndex < 0) {
-      logger.info({ connectionName: key }, 'Creating configured connection.');
-      await runStartupPlugins(clientOpts, key);
-
-      const [primary, secondary] = await createWebSocketConnectionPairs(
-        clientOpts,
-        globalIdentifyingMetadata,
-        key,
-        clientOpts.metricsClient,
-      );
-      websocketConnections.push(primary, secondary);
-    } else if (
-      // Token rotation for the connection at hand
-      connectionConfig.identifier !=
-      websocketConnections[currentWebsocketConnectionIndex].identifier
-    ) {
-      logger.info(
-        { connectionName: key },
-        'Updating configured connection for new identifier.',
-      );
-      // shut down previous tunnels
-      shutDownConnectionPair(
-        websocketConnections,
-        integrationsKeys.indexOf(key),
-      );
-
-      // setup new tunnels
-      await runStartupPlugins(clientOpts, key);
-
-      const [primary, secondary] = await createWebSocketConnectionPairs(
-        clientOpts,
-        globalIdentifyingMetadata,
-        key,
-        clientOpts.metricsClient,
-      );
-      websocketConnections.push(primary, secondary);
-    } else {
-      // If contexts have changed, re-run plugins for the connection
-      const contextsChanged =
-        JSON.stringify(connectionConfig.contexts ?? {}) !==
-        JSON.stringify(syncStateByConnection.get(key)?.contexts ?? {});
-      if (contextsChanged) {
-        logger.info(
-          { connectionName: key },
-          'Contexts changed, re-running plugins.',
-        );
+        // setup new tunnels
         await runStartupPlugins(clientOpts, key);
+
+        const [primary, secondary] = await createWebSocketConnectionPairs(
+          clientOpts,
+          globalIdentifyingMetadata,
+          key,
+          clientOpts.metricsClient,
+        );
+        websocketConnections.push(primary, secondary);
       } else {
-        logger.debug({ connectionName: key }, 'Connection already configured.');
-      }
-    }
-
-    syncStateByConnection.set(key, { contexts: connectionConfig.contexts });
-  }
-
-  // Shut down connections that are no longer configured
-  if (integrationsKeys.length != websocketConnections.length) {
-    const alreadyShutDownConnectionNames: string[] = [];
-    for (let i = 0; i < websocketConnections.length; i++) {
-      const friendlyName = websocketConnections[i].friendlyName;
-      if (
-        friendlyName &&
-        !integrationsKeys.includes(friendlyName) &&
-        !alreadyShutDownConnectionNames.includes(friendlyName)
-      ) {
-        logger.info({ friendlyName }, 'Shutting down connection');
-        try {
-          alreadyShutDownConnectionNames.push(friendlyName);
-          syncStateByConnection.delete(friendlyName);
-          shutDownConnectionPair(websocketConnections, i);
-        } catch (err) {
-          logger.error(
-            { err },
-            `Error shutting down connection ${friendlyName}`,
+        // If contexts have changed, re-run plugins for the connection
+        const contextsChanged =
+          JSON.stringify(connectionConfig.contexts ?? {}) !==
+          JSON.stringify(syncStateByConnection.get(key)?.contexts ?? {});
+        if (contextsChanged) {
+          logger.info(
+            { connectionName: key },
+            'Contexts changed, re-running plugins.',
+          );
+          await runStartupPlugins(clientOpts, key);
+        } else {
+          logger.debug(
+            { connectionName: key },
+            'Connection already configured.',
           );
         }
       }
+
+      syncStateByConnection.set(key, { contexts: connectionConfig.contexts });
     }
+
+    // Shut down connections that are no longer configured
+    if (integrationsKeys.length != websocketConnections.length) {
+      const alreadyShutDownConnectionNames: string[] = [];
+      for (let i = 0; i < websocketConnections.length; i++) {
+        const friendlyName = websocketConnections[i].friendlyName;
+        if (
+          friendlyName &&
+          !integrationsKeys.includes(friendlyName) &&
+          !alreadyShutDownConnectionNames.includes(friendlyName)
+        ) {
+          logger.info({ friendlyName }, 'Shutting down connection');
+          try {
+            alreadyShutDownConnectionNames.push(friendlyName);
+            syncStateByConnection.delete(friendlyName);
+            shutDownConnectionPair(websocketConnections, i);
+          } catch (err) {
+            logger.error(
+              { err },
+              `Error shutting down connection ${friendlyName}`,
+            );
+          }
+        }
+      }
+    }
+  } finally {
+    isSyncing = false;
   }
 };
 
@@ -205,7 +235,7 @@ export const setBackupWatcher = async (
   globalIdentifyingMetadata: IdentifyingMetadata,
 ) => {
   if (process.env.NODE_ENV != 'test') {
-    addTimerToTerminalHandlers(
+    addIntervalToTerminalHandlers(
       setInterval(async () => {
         for (let i = 0; i < websocketConnections.length; i++) {
           if (isWebsocketConnOpen(websocketConnections[i])) {

--- a/lib/hybrid-sdk/client/connectionsManager/synchronizer.ts
+++ b/lib/hybrid-sdk/client/connectionsManager/synchronizer.ts
@@ -30,15 +30,18 @@ export const syncStateByConnection = new Map<string, SyncState>();
 let pollingIntervalRegistered = false;
 
 /** Re-entrancy guard. Polling, backup-watcher, and RPC-triggered calls can
- *  race; we drop overlapping calls because the in-flight sync already covers
- *  the latest state. */
+ *  race. We coalesce instead of drop: at most one extra cycle is queued, so
+ *  an RPC reload arriving mid-sync still triggers a follow-up pass to pick
+ *  up the latest state. */
 let isSyncing = false;
+let resyncPending = false;
 
 /** Test-only reset. The registration flag is module-level state; tests that
  *  trigger the polling branch need to clear it between cases. */
 export const __resetSynchronizerStateForTests = () => {
   pollingIntervalRegistered = false;
   isSyncing = false;
+  resyncPending = false;
 };
 
 /**
@@ -58,174 +61,192 @@ export const syncClientConfig = async (
     return;
   }
   if (isSyncing) {
-    logger.debug({}, 'syncClientConfig already in progress, skipping tick.');
+    // Coalesce: queue exactly one follow-up cycle so the latest state is
+    // observed without stacking concurrent syncs.
+    resyncPending = true;
+    logger.debug(
+      {},
+      'syncClientConfig already in progress, queuing follow-up cycle.',
+    );
     return;
   }
   isSyncing = true;
   try {
-    if (
-      !process.env.SKIP_REMOTE_CONFIG &&
-      !process.env.REMOTE_CONFIG_POLLING_MODE
-    ) {
-      // Done at startup only. RPC calls trigger this instead of polling
-      await retrieveAndLoadRemoteConfigSync(clientOpts);
-    }
-
-    const integrationsKeys = clientOpts.config.connections
-      ? Object.keys(clientOpts.config.connections)
-      : [];
-
-    const isPollingRequired =
-      clientOpts.config.UNIVERSAL_BROKER_GA !== 'true' ||
-      integrationsKeys.length < 1 ||
-      websocketConnections.length === 0;
-
-    if (isPollingRequired) {
-      logger.debug({}, `Waiting for connections (polling).`);
-      if (process.env.NODE_ENV != 'test' && !pollingIntervalRegistered) {
-        pollingIntervalRegistered = true;
-        addIntervalToTerminalHandlers(
-          setInterval(
-            () =>
-              syncClientConfig(
-                clientOpts,
-                websocketConnections,
-                globalIdentifyingMetadata,
-              ),
-            clientOpts.config.connectionsManager.watcher.interval,
-          ),
-        );
-      }
-    } else {
-      logger.debug({}, 'Disabling polling in favor of server notification.');
-    }
-
-    for (const key of integrationsKeys) {
-      const connectionConfig = clientOpts.config.connections[key];
-
-      const currentWebsocketConnectionIndex = websocketConnections.findIndex(
-        (conn) => conn.friendlyName === key,
+    do {
+      resyncPending = false;
+      await runSyncCycle(
+        clientOpts,
+        websocketConnections,
+        globalIdentifyingMetadata,
       );
-      if (connectionConfig.isDisabled) {
-        logger.error(
+    } while (resyncPending && !isShuttingDown());
+  } finally {
+    isSyncing = false;
+  }
+};
+
+const runSyncCycle = async (
+  clientOpts,
+  websocketConnections: WebSocketConnection[],
+  globalIdentifyingMetadata: IdentifyingMetadata,
+): Promise<void> => {
+  if (
+    !process.env.SKIP_REMOTE_CONFIG &&
+    !process.env.REMOTE_CONFIG_POLLING_MODE
+  ) {
+    // Done at startup only. RPC calls trigger this instead of polling
+    await retrieveAndLoadRemoteConfigSync(clientOpts);
+  }
+
+  const integrationsKeys = clientOpts.config.connections
+    ? Object.keys(clientOpts.config.connections)
+    : [];
+
+  const isPollingRequired =
+    clientOpts.config.UNIVERSAL_BROKER_GA !== 'true' ||
+    integrationsKeys.length < 1 ||
+    websocketConnections.length === 0;
+
+  if (isPollingRequired) {
+    logger.debug({}, `Waiting for connections (polling).`);
+    if (process.env.NODE_ENV != 'test' && !pollingIntervalRegistered) {
+      pollingIntervalRegistered = true;
+      addIntervalToTerminalHandlers(
+        setInterval(
+          () =>
+            syncClientConfig(
+              clientOpts,
+              websocketConnections,
+              globalIdentifyingMetadata,
+            ),
+          clientOpts.config.connectionsManager.watcher.interval,
+        ),
+      );
+    }
+  } else {
+    logger.debug({}, 'Disabling polling in favor of server notification.');
+  }
+
+  for (const key of integrationsKeys) {
+    const connectionConfig = clientOpts.config.connections[key];
+
+    const currentWebsocketConnectionIndex = websocketConnections.findIndex(
+      (conn) => conn.friendlyName === key,
+    );
+    if (connectionConfig.isDisabled) {
+      logger.error(
+        {
+          id: connectionConfig.id,
+          name: connectionConfig.friendlyName,
+        },
+        `Connection is disabled due to (a) missing environment variable(s). Please provide the value and restart the broker client.`,
+      );
+      continue;
+    }
+    if (!connectionConfig.identifier) {
+      if (currentWebsocketConnectionIndex > -1) {
+        logger.info(
           {
             id: connectionConfig.id,
             name: connectionConfig.friendlyName,
           },
-          `Connection is disabled due to (a) missing environment variable(s). Please provide the value and restart the broker client.`,
+          `Shutting down unused connection.`,
         );
-        continue;
-      }
-      if (!connectionConfig.identifier) {
-        if (currentWebsocketConnectionIndex > -1) {
-          logger.info(
-            {
-              id: connectionConfig.id,
-              name: connectionConfig.friendlyName,
-            },
-            `Shutting down unused connection.`,
-          );
-          shutDownConnectionPair(
-            websocketConnections,
-            integrationsKeys.indexOf(key),
-          );
-        } else {
-          logger.debug(
-            {
-              id: connectionConfig.id,
-              name: connectionConfig.friendlyName,
-            },
-            `Connection (${connectionConfig.friendlyName}) not in use by any orgs. Will check periodically and create connection when in use.`,
-          );
-        }
-        continue;
-      }
-
-      // If connection doesn't exist, create it
-      if (currentWebsocketConnectionIndex < 0) {
-        logger.info({ connectionName: key }, 'Creating configured connection.');
-        await runStartupPlugins(clientOpts, key);
-
-        const [primary, secondary] = await createWebSocketConnectionPairs(
-          clientOpts,
-          globalIdentifyingMetadata,
-          key,
-          clientOpts.metricsClient,
-        );
-        websocketConnections.push(primary, secondary);
-      } else if (
-        // Token rotation for the connection at hand
-        connectionConfig.identifier !=
-        websocketConnections[currentWebsocketConnectionIndex].identifier
-      ) {
-        logger.info(
-          { connectionName: key },
-          'Updating configured connection for new identifier.',
-        );
-        // shut down previous tunnels
         shutDownConnectionPair(
           websocketConnections,
           integrationsKeys.indexOf(key),
         );
-
-        // setup new tunnels
-        await runStartupPlugins(clientOpts, key);
-
-        const [primary, secondary] = await createWebSocketConnectionPairs(
-          clientOpts,
-          globalIdentifyingMetadata,
-          key,
-          clientOpts.metricsClient,
-        );
-        websocketConnections.push(primary, secondary);
       } else {
-        // If contexts have changed, re-run plugins for the connection
-        const contextsChanged =
-          JSON.stringify(connectionConfig.contexts ?? {}) !==
-          JSON.stringify(syncStateByConnection.get(key)?.contexts ?? {});
-        if (contextsChanged) {
-          logger.info(
-            { connectionName: key },
-            'Contexts changed, re-running plugins.',
-          );
-          await runStartupPlugins(clientOpts, key);
-        } else {
-          logger.debug(
-            { connectionName: key },
-            'Connection already configured.',
+        logger.debug(
+          {
+            id: connectionConfig.id,
+            name: connectionConfig.friendlyName,
+          },
+          `Connection (${connectionConfig.friendlyName}) not in use by any orgs. Will check periodically and create connection when in use.`,
+        );
+      }
+      continue;
+    }
+
+    // If connection doesn't exist, create it
+    if (currentWebsocketConnectionIndex < 0) {
+      logger.info({ connectionName: key }, 'Creating configured connection.');
+      await runStartupPlugins(clientOpts, key);
+
+      const [primary, secondary] = await createWebSocketConnectionPairs(
+        clientOpts,
+        globalIdentifyingMetadata,
+        key,
+        clientOpts.metricsClient,
+      );
+      websocketConnections.push(primary, secondary);
+    } else if (
+      // Token rotation for the connection at hand
+      connectionConfig.identifier !=
+      websocketConnections[currentWebsocketConnectionIndex].identifier
+    ) {
+      logger.info(
+        { connectionName: key },
+        'Updating configured connection for new identifier.',
+      );
+      // shut down previous tunnels
+      shutDownConnectionPair(
+        websocketConnections,
+        integrationsKeys.indexOf(key),
+      );
+
+      // setup new tunnels
+      await runStartupPlugins(clientOpts, key);
+
+      const [primary, secondary] = await createWebSocketConnectionPairs(
+        clientOpts,
+        globalIdentifyingMetadata,
+        key,
+        clientOpts.metricsClient,
+      );
+      websocketConnections.push(primary, secondary);
+    } else {
+      // If contexts have changed, re-run plugins for the connection
+      const contextsChanged =
+        JSON.stringify(connectionConfig.contexts ?? {}) !==
+        JSON.stringify(syncStateByConnection.get(key)?.contexts ?? {});
+      if (contextsChanged) {
+        logger.info(
+          { connectionName: key },
+          'Contexts changed, re-running plugins.',
+        );
+        await runStartupPlugins(clientOpts, key);
+      } else {
+        logger.debug({ connectionName: key }, 'Connection already configured.');
+      }
+    }
+
+    syncStateByConnection.set(key, { contexts: connectionConfig.contexts });
+  }
+
+  // Shut down connections that are no longer configured
+  if (integrationsKeys.length != websocketConnections.length) {
+    const alreadyShutDownConnectionNames: string[] = [];
+    for (let i = 0; i < websocketConnections.length; i++) {
+      const friendlyName = websocketConnections[i].friendlyName;
+      if (
+        friendlyName &&
+        !integrationsKeys.includes(friendlyName) &&
+        !alreadyShutDownConnectionNames.includes(friendlyName)
+      ) {
+        logger.info({ friendlyName }, 'Shutting down connection');
+        try {
+          alreadyShutDownConnectionNames.push(friendlyName);
+          syncStateByConnection.delete(friendlyName);
+          shutDownConnectionPair(websocketConnections, i);
+        } catch (err) {
+          logger.error(
+            { err },
+            `Error shutting down connection ${friendlyName}`,
           );
         }
       }
-
-      syncStateByConnection.set(key, { contexts: connectionConfig.contexts });
     }
-
-    // Shut down connections that are no longer configured
-    if (integrationsKeys.length != websocketConnections.length) {
-      const alreadyShutDownConnectionNames: string[] = [];
-      for (let i = 0; i < websocketConnections.length; i++) {
-        const friendlyName = websocketConnections[i].friendlyName;
-        if (
-          friendlyName &&
-          !integrationsKeys.includes(friendlyName) &&
-          !alreadyShutDownConnectionNames.includes(friendlyName)
-        ) {
-          logger.info({ friendlyName }, 'Shutting down connection');
-          try {
-            alreadyShutDownConnectionNames.push(friendlyName);
-            syncStateByConnection.delete(friendlyName);
-            shutDownConnectionPair(websocketConnections, i);
-          } catch (err) {
-            logger.error(
-              { err },
-              `Error shutting down connection ${friendlyName}`,
-            );
-          }
-        }
-      }
-    }
-  } finally {
-    isSyncing = false;
   }
 };
 

--- a/lib/hybrid-sdk/common/utils/signals.ts
+++ b/lib/hybrid-sdk/common/utils/signals.ts
@@ -43,6 +43,26 @@ export const addTimeoutToTerminalHandlers = (timeoutId: NodeJS.Timeout) => {
   timeouts.push(timeoutId);
 };
 
+/** Clear an interval and remove its handle from the registry. Paired so
+ *  callers can't clear-without-remove, which previously caused the registry
+ *  to grow with dead references whenever a timer was toggled at runtime. */
+export const clearAndRemoveInterval = (intervalId: NodeJS.Timeout) => {
+  clearInterval(intervalId);
+  const i = intervals.indexOf(intervalId);
+  if (i !== -1) {
+    intervals.splice(i, 1);
+  }
+};
+
+/** Clear a timeout and remove its handle from the registry. */
+export const clearAndRemoveTimeout = (timeoutId: NodeJS.Timeout) => {
+  clearTimeout(timeoutId);
+  const i = timeouts.indexOf(timeoutId);
+  if (i !== -1) {
+    timeouts.splice(i, 1);
+  }
+};
+
 const signalTerminationToServer = (signal) => {
   const [websocket] = getWebsocketConnections();
   if (websocket) {

--- a/lib/hybrid-sdk/common/utils/signals.ts
+++ b/lib/hybrid-sdk/common/utils/signals.ts
@@ -3,9 +3,18 @@ import { log as logger } from '../../../logs/logger';
 
 const timers: NodeJS.Timeout[] = [];
 const GRACE_PERIOD_MS = 12000;
+
+let shuttingDown = false;
+export const isShuttingDown = (): boolean => shuttingDown;
+
+const clearAllTimers = () => {
+  timers.forEach((timer) => clearTimeout(timer));
+};
+
 export const handleTerminationSignal = (callback: () => void) => {
   process.on('SIGINT', () => {
-    timers.forEach((timer) => clearInterval(timer));
+    shuttingDown = true;
+    clearAllTimers();
     callback();
     signalTerminationToServer('SIGINT');
     setTimeout(() => {
@@ -14,7 +23,8 @@ export const handleTerminationSignal = (callback: () => void) => {
   });
 
   process.on('SIGTERM', async () => {
-    timers.forEach((timer) => clearInterval(timer));
+    shuttingDown = true;
+    clearAllTimers();
     callback();
     signalTerminationToServer('SIGTERM');
     setTimeout(() => {

--- a/lib/hybrid-sdk/common/utils/signals.ts
+++ b/lib/hybrid-sdk/common/utils/signals.ts
@@ -1,14 +1,16 @@
 import { getWebsocketConnections } from '../../client';
 import { log as logger } from '../../../logs/logger';
 
-const timers: NodeJS.Timeout[] = [];
+const intervals: NodeJS.Timeout[] = [];
+const timeouts: NodeJS.Timeout[] = [];
 const GRACE_PERIOD_MS = 12000;
 
 let shuttingDown = false;
 export const isShuttingDown = (): boolean => shuttingDown;
 
 const clearAllTimers = () => {
-  timers.forEach((timer) => clearTimeout(timer));
+  intervals.forEach((id) => clearInterval(id));
+  timeouts.forEach((id) => clearTimeout(id));
 };
 
 export const handleTerminationSignal = (callback: () => void) => {
@@ -33,8 +35,12 @@ export const handleTerminationSignal = (callback: () => void) => {
   });
 };
 
-export const addTimerToTerminalHandlers = (timerId: NodeJS.Timeout) => {
-  timers.push(timerId);
+export const addIntervalToTerminalHandlers = (intervalId: NodeJS.Timeout) => {
+  intervals.push(intervalId);
+};
+
+export const addTimeoutToTerminalHandlers = (timeoutId: NodeJS.Timeout) => {
+  timeouts.push(timeoutId);
 };
 
 const signalTerminationToServer = (signal) => {

--- a/test/unit/client/config/remoteConfig.test.ts
+++ b/test/unit/client/config/remoteConfig.test.ts
@@ -1,0 +1,65 @@
+jest.mock('fs');
+jest.mock('../../../../lib/hybrid-sdk/http/request');
+jest.mock('../../../../lib/hybrid-sdk/client/auth/oauth', () => ({
+  getAuthConfig: () => ({ accessToken: { authHeader: 'Bearer test' } }),
+}));
+
+import * as fs from 'fs';
+import { retrieveConnectionsForDeployment } from '../../../../lib/hybrid-sdk/client/config/remoteConfig';
+import * as httpRequest from '../../../../lib/hybrid-sdk/http/request';
+import { log as logger } from '../../../../lib/logs/logger';
+import { ClientOpts } from '../../../../lib/hybrid-sdk/common/types/options';
+
+const mockedFs = jest.mocked(fs);
+const mockedHttpRequest = jest.mocked(httpRequest);
+
+const baseClientOpts = {
+  config: {
+    deploymentId: 'dep-1',
+    apiVersion: '2024-01-01',
+    API_BASE_URL: 'https://api.example.com',
+    brokerClientId: 'client-1',
+  },
+} as unknown as ClientOpts;
+
+describe('retrieveConnectionsForDeployment — file-missing guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedHttpRequest.makeRequestToDownstream.mockResolvedValue({
+      statusCode: 200,
+      headers: {},
+      body: JSON.stringify({ data: [] }),
+    } as any);
+  });
+
+  it('returns early — skips network and file I/O — when universal file is missing', async () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    mockedFs.existsSync.mockReturnValue(false);
+
+    await expect(
+      retrieveConnectionsForDeployment(baseClientOpts, '/tmp/missing.json'),
+    ).resolves.toBeUndefined();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ universalFilePath: '/tmp/missing.json' }),
+      expect.stringContaining('missing during sync'),
+    );
+    expect(mockedHttpRequest.makeRequestToDownstream).not.toHaveBeenCalled();
+    expect(mockedFs.readFileSync).not.toHaveBeenCalled();
+    expect(mockedFs.writeFileSync).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('proceeds to read+write when the file exists', async () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue(
+      Buffer.from(JSON.stringify({ CONNECTIONS: {} })),
+    );
+
+    await retrieveConnectionsForDeployment(baseClientOpts, '/tmp/present.json');
+
+    expect(mockedFs.readFileSync).toHaveBeenCalledWith('/tmp/present.json');
+    expect(mockedFs.writeFileSync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/connectionsManager/remoteConnectionSync.test.ts
+++ b/test/unit/connectionsManager/remoteConnectionSync.test.ts
@@ -14,6 +14,8 @@ jest.mock('../../../lib/hybrid-sdk/common/utils/signals', () => ({
   isShuttingDown: jest.fn(() => false),
   addIntervalToTerminalHandlers: jest.fn(),
   addTimeoutToTerminalHandlers: jest.fn(),
+  clearAndRemoveInterval: jest.fn(),
+  clearAndRemoveTimeout: jest.fn(),
 }));
 jest.mock('node:fs', () => ({
   ...jest.requireActual('node:fs'),

--- a/test/unit/connectionsManager/remoteConnectionSync.test.ts
+++ b/test/unit/connectionsManager/remoteConnectionSync.test.ts
@@ -3,6 +3,7 @@ import * as remoteConfig from '../../../lib/hybrid-sdk/client/config/remoteConfi
 import * as configHelpers from '../../../lib/hybrid-sdk/client/config/configHelpers';
 import * as validator from '../../../lib/hybrid-sdk/client/connectionsManager/validator';
 import * as signals from '../../../lib/hybrid-sdk/common/utils/signals';
+import * as fs from 'node:fs';
 import { log as logger } from '../../../lib/logs/logger';
 import { LoadedClientOpts } from '../../../lib/hybrid-sdk/common/types/options';
 
@@ -14,11 +15,16 @@ jest.mock('../../../lib/hybrid-sdk/common/utils/signals', () => ({
   addIntervalToTerminalHandlers: jest.fn(),
   addTimeoutToTerminalHandlers: jest.fn(),
 }));
+jest.mock('node:fs', () => ({
+  ...jest.requireActual('node:fs'),
+  existsSync: jest.fn(),
+}));
 
 const mockedRemoteConfig = jest.mocked(remoteConfig);
 const mockedConfigHelpers = jest.mocked(configHelpers);
 const mockedValidator = jest.mocked(validator);
 const mockedSignals = jest.mocked(signals);
+const mockedExistsSync = jest.mocked(fs.existsSync);
 
 const clientOpts = {} as LoadedClientOpts;
 
@@ -26,6 +32,8 @@ describe('retrieveAndLoadRemoteConfigSync', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedSignals.isShuttingDown.mockReturnValue(false);
+    // Default: file exists, so validator/reloadConfig are reached.
+    mockedExistsSync.mockReturnValue(true);
   });
 
   it('returns early without doing any I/O when isShuttingDown() is true', async () => {
@@ -103,5 +111,29 @@ describe('retrieveAndLoadRemoteConfigSync', () => {
       mockedValidator.validateUniversalConnectionsRemoteConfig,
     ).toHaveBeenCalledTimes(1);
     expect(mockedConfigHelpers.reloadConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips validation and reload (no warn) when the universal config file is missing after retrieve', async () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    const debugSpy = jest.spyOn(logger, 'debug').mockImplementation(() => {});
+    mockedRemoteConfig.retrieveConnectionsForDeployment.mockResolvedValueOnce(
+      undefined,
+    );
+    mockedExistsSync.mockReturnValue(false);
+
+    await retrieveAndLoadRemoteConfigSync(clientOpts);
+
+    expect(
+      mockedValidator.validateUniversalConnectionsRemoteConfig,
+    ).not.toHaveBeenCalled();
+    expect(mockedConfigHelpers.reloadConfig).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ universalFilePath: expect.any(String) }),
+      expect.stringContaining('missing'),
+    );
+
+    warnSpy.mockRestore();
+    debugSpy.mockRestore();
   });
 });

--- a/test/unit/connectionsManager/remoteConnectionSync.test.ts
+++ b/test/unit/connectionsManager/remoteConnectionSync.test.ts
@@ -11,7 +11,8 @@ jest.mock('../../../lib/hybrid-sdk/client/config/configHelpers');
 jest.mock('../../../lib/hybrid-sdk/client/connectionsManager/validator');
 jest.mock('../../../lib/hybrid-sdk/common/utils/signals', () => ({
   isShuttingDown: jest.fn(() => false),
-  addTimerToTerminalHandlers: jest.fn(),
+  addIntervalToTerminalHandlers: jest.fn(),
+  addTimeoutToTerminalHandlers: jest.fn(),
 }));
 
 const mockedRemoteConfig = jest.mocked(remoteConfig);

--- a/test/unit/connectionsManager/remoteConnectionSync.test.ts
+++ b/test/unit/connectionsManager/remoteConnectionSync.test.ts
@@ -1,0 +1,106 @@
+import { retrieveAndLoadRemoteConfigSync } from '../../../lib/hybrid-sdk/client/connectionsManager/remoteConnectionSync';
+import * as remoteConfig from '../../../lib/hybrid-sdk/client/config/remoteConfig';
+import * as configHelpers from '../../../lib/hybrid-sdk/client/config/configHelpers';
+import * as validator from '../../../lib/hybrid-sdk/client/connectionsManager/validator';
+import * as signals from '../../../lib/hybrid-sdk/common/utils/signals';
+import { log as logger } from '../../../lib/logs/logger';
+import { LoadedClientOpts } from '../../../lib/hybrid-sdk/common/types/options';
+
+jest.mock('../../../lib/hybrid-sdk/client/config/remoteConfig');
+jest.mock('../../../lib/hybrid-sdk/client/config/configHelpers');
+jest.mock('../../../lib/hybrid-sdk/client/connectionsManager/validator');
+jest.mock('../../../lib/hybrid-sdk/common/utils/signals', () => ({
+  isShuttingDown: jest.fn(() => false),
+  addTimerToTerminalHandlers: jest.fn(),
+}));
+
+const mockedRemoteConfig = jest.mocked(remoteConfig);
+const mockedConfigHelpers = jest.mocked(configHelpers);
+const mockedValidator = jest.mocked(validator);
+const mockedSignals = jest.mocked(signals);
+
+const clientOpts = {} as LoadedClientOpts;
+
+describe('retrieveAndLoadRemoteConfigSync', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedSignals.isShuttingDown.mockReturnValue(false);
+  });
+
+  it('returns early without doing any I/O when isShuttingDown() is true', async () => {
+    mockedSignals.isShuttingDown.mockReturnValue(true);
+
+    await retrieveAndLoadRemoteConfigSync(clientOpts);
+
+    expect(
+      mockedRemoteConfig.retrieveConnectionsForDeployment,
+    ).not.toHaveBeenCalled();
+    expect(
+      mockedValidator.validateUniversalConnectionsRemoteConfig,
+    ).not.toHaveBeenCalled();
+    expect(mockedConfigHelpers.reloadConfig).not.toHaveBeenCalled();
+  });
+
+  it('catches errors from retrieveConnectionsForDeployment and emits logger.warn instead of rethrowing', async () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    const boom = new Error('ENOENT: simulated');
+    mockedRemoteConfig.retrieveConnectionsForDeployment.mockRejectedValueOnce(
+      boom,
+    );
+
+    await expect(
+      retrieveAndLoadRemoteConfigSync(clientOpts),
+    ).resolves.toBeUndefined();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ err: boom }),
+      expect.stringContaining('Remote config sync failed'),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('catches errors from validateUniversalConnectionsRemoteConfig and emits logger.warn', async () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    mockedRemoteConfig.retrieveConnectionsForDeployment.mockResolvedValueOnce(
+      undefined,
+    );
+    const boom = new Error('validator boom');
+    mockedValidator.validateUniversalConnectionsRemoteConfig.mockImplementationOnce(
+      () => {
+        throw boom;
+      },
+    );
+
+    await expect(
+      retrieveAndLoadRemoteConfigSync(clientOpts),
+    ).resolves.toBeUndefined();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ err: boom }),
+      expect.any(String),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('runs the full happy path when not shutting down and no errors thrown', async () => {
+    mockedRemoteConfig.retrieveConnectionsForDeployment.mockResolvedValueOnce(
+      undefined,
+    );
+    mockedValidator.validateUniversalConnectionsRemoteConfig.mockReturnValueOnce(
+      undefined as any,
+    );
+    mockedConfigHelpers.reloadConfig.mockResolvedValueOnce(undefined as any);
+
+    await retrieveAndLoadRemoteConfigSync(clientOpts);
+
+    expect(
+      mockedRemoteConfig.retrieveConnectionsForDeployment,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      mockedValidator.validateUniversalConnectionsRemoteConfig,
+    ).toHaveBeenCalledTimes(1);
+    expect(mockedConfigHelpers.reloadConfig).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/connectionsManager/synchronizer.test.ts
+++ b/test/unit/connectionsManager/synchronizer.test.ts
@@ -28,6 +28,8 @@ jest.mock('../../../lib/hybrid-sdk/common/utils/signals', () => ({
   isShuttingDown: jest.fn(() => false),
   addIntervalToTerminalHandlers: jest.fn(),
   addTimeoutToTerminalHandlers: jest.fn(),
+  clearAndRemoveInterval: jest.fn(),
+  clearAndRemoveTimeout: jest.fn(),
 }));
 
 const mockedPluginManager = jest.mocked(pluginManager);
@@ -472,7 +474,6 @@ describe('syncClientConfig', () => {
 
     it('clears the polling interval once polling is no longer required', async () => {
       process.env.NODE_ENV = 'production';
-      const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
 
       // Cycle 1: no connections → polling required → interval registered.
       const pollingOpts = makeClientOpts(undefined);
@@ -485,7 +486,7 @@ describe('syncClientConfig', () => {
         .calls[0][0] as NodeJS.Timeout;
 
       // Cycle 2: configured connection with matching ws conns → polling
-      // not required → interval cleared.
+      // not required → interval cleared and removed from registry.
       const steadyOpts = makeClientOpts({
         'my-conn': {
           type: 'github',
@@ -499,8 +500,12 @@ describe('syncClientConfig', () => {
       ];
       await syncClientConfig(steadyOpts, wsConns, IDENTIFYING_METADATA);
 
-      expect(clearIntervalSpy).toHaveBeenCalledWith(registeredTimer);
-      clearIntervalSpy.mockRestore();
+      expect(mockedSignals.clearAndRemoveInterval).toHaveBeenCalledWith(
+        registeredTimer,
+      );
+      // Defensive: the bare clearInterval is not called from production code;
+      // the paired helper is the only path that removes from the registry.
+      clearInterval(registeredTimer);
     });
 
     it('re-arms a fresh interval after a clear if polling becomes required again', async () => {

--- a/test/unit/connectionsManager/synchronizer.test.ts
+++ b/test/unit/connectionsManager/synchronizer.test.ts
@@ -469,6 +469,84 @@ describe('syncClientConfig', () => {
         mockedSignals.addIntervalToTerminalHandlers.mock.calls[0]?.[0];
       if (registeredTimer) clearInterval(registeredTimer as NodeJS.Timeout);
     });
+
+    it('clears the polling interval once polling is no longer required', async () => {
+      process.env.NODE_ENV = 'production';
+      const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+
+      // Cycle 1: no connections → polling required → interval registered.
+      const pollingOpts = makeClientOpts(undefined);
+      await syncClientConfig(pollingOpts, [], IDENTIFYING_METADATA);
+
+      expect(mockedSignals.addIntervalToTerminalHandlers).toHaveBeenCalledTimes(
+        1,
+      );
+      const registeredTimer = mockedSignals.addIntervalToTerminalHandlers.mock
+        .calls[0][0] as NodeJS.Timeout;
+
+      // Cycle 2: configured connection with matching ws conns → polling
+      // not required → interval cleared.
+      const steadyOpts = makeClientOpts({
+        'my-conn': {
+          type: 'github',
+          identifier: 'token-1',
+          friendlyName: 'my-conn',
+        },
+      });
+      const wsConns: WebSocketConnection[] = [
+        makeWsConn('my-conn', 'token-1'),
+        makeWsConn('my-conn', 'token-1'),
+      ];
+      await syncClientConfig(steadyOpts, wsConns, IDENTIFYING_METADATA);
+
+      expect(clearIntervalSpy).toHaveBeenCalledWith(registeredTimer);
+      clearIntervalSpy.mockRestore();
+    });
+
+    it('re-arms a fresh interval after a clear if polling becomes required again', async () => {
+      process.env.NODE_ENV = 'production';
+
+      // Cycle 1: register.
+      await syncClientConfig(
+        makeClientOpts(undefined),
+        [],
+        IDENTIFYING_METADATA,
+      );
+      const firstTimer = mockedSignals.addIntervalToTerminalHandlers.mock
+        .calls[0][0] as NodeJS.Timeout;
+
+      // Cycle 2: clear (polling not required).
+      const wsConns: WebSocketConnection[] = [
+        makeWsConn('my-conn', 'token-1'),
+        makeWsConn('my-conn', 'token-1'),
+      ];
+      await syncClientConfig(
+        makeClientOpts({
+          'my-conn': {
+            type: 'github',
+            identifier: 'token-1',
+            friendlyName: 'my-conn',
+          },
+        }),
+        wsConns,
+        IDENTIFYING_METADATA,
+      );
+
+      // Cycle 3: polling required again → fresh interval registered.
+      await syncClientConfig(
+        makeClientOpts(undefined),
+        [],
+        IDENTIFYING_METADATA,
+      );
+
+      expect(mockedSignals.addIntervalToTerminalHandlers).toHaveBeenCalledTimes(
+        2,
+      );
+      const secondTimer = mockedSignals.addIntervalToTerminalHandlers.mock
+        .calls[1][0] as NodeJS.Timeout;
+      expect(secondTimer).not.toBe(firstTimer);
+      clearInterval(secondTimer);
+    });
   });
 
   describe('re-entrancy coalescing', () => {

--- a/test/unit/connectionsManager/synchronizer.test.ts
+++ b/test/unit/connectionsManager/synchronizer.test.ts
@@ -1,4 +1,5 @@
 import {
+  __resetSynchronizerStateForTests,
   syncClientConfig,
   syncStateByConnection,
 } from '../../../lib/hybrid-sdk/client/connectionsManager/synchronizer';
@@ -25,7 +26,8 @@ jest.mock(
 );
 jest.mock('../../../lib/hybrid-sdk/common/utils/signals', () => ({
   isShuttingDown: jest.fn(() => false),
-  addTimerToTerminalHandlers: jest.fn(),
+  addIntervalToTerminalHandlers: jest.fn(),
+  addTimeoutToTerminalHandlers: jest.fn(),
 }));
 
 const mockedPluginManager = jest.mocked(pluginManager);
@@ -106,6 +108,7 @@ describe('syncClientConfig', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     syncStateByConnection.clear();
+    __resetSynchronizerStateForTests();
     process.env.SKIP_REMOTE_CONFIG = 'true';
     process.env.NODE_ENV = 'test';
 
@@ -433,20 +436,79 @@ describe('syncClientConfig', () => {
     });
   });
 
-  describe('recursive setTimeout registration', () => {
-    it('registers the recursive setTimeout via addTimerToTerminalHandlers when polling', async () => {
-      // Need NODE_ENV != 'test' for the setTimeout branch to fire.
+  describe('polling interval registration', () => {
+    it('registers a single setInterval via addIntervalToTerminalHandlers across multiple polling cycles', async () => {
+      // Need NODE_ENV != 'test' for the setInterval branch to fire.
+      process.env.NODE_ENV = 'production';
+      const clientOpts = makeClientOpts(undefined);
+
+      await syncClientConfig(clientOpts, [], IDENTIFYING_METADATA);
+      await syncClientConfig(clientOpts, [], IDENTIFYING_METADATA);
+      await syncClientConfig(clientOpts, [], IDENTIFYING_METADATA);
+
+      expect(mockedSignals.addIntervalToTerminalHandlers).toHaveBeenCalledTimes(
+        1,
+      );
+      const registeredTimer =
+        mockedSignals.addIntervalToTerminalHandlers.mock.calls[0][0];
+      expect(registeredTimer).toBeDefined();
+      // Mock doesn't clear; do it manually so the interval doesn't fire post-test.
+      clearInterval(registeredTimer as NodeJS.Timeout);
+    });
+
+    it('does not register via addTimeoutToTerminalHandlers (intervals only)', async () => {
       process.env.NODE_ENV = 'production';
       const clientOpts = makeClientOpts(undefined);
 
       await syncClientConfig(clientOpts, [], IDENTIFYING_METADATA);
 
-      expect(mockedSignals.addTimerToTerminalHandlers).toHaveBeenCalledTimes(1);
+      expect(mockedSignals.addTimeoutToTerminalHandlers).not.toHaveBeenCalled();
       const registeredTimer =
-        mockedSignals.addTimerToTerminalHandlers.mock.calls[0][0];
-      expect(registeredTimer).toBeDefined();
-      // Mock doesn't clear; do it manually to prevent the recursive callback firing post-test.
-      clearTimeout(registeredTimer as NodeJS.Timeout);
+        mockedSignals.addIntervalToTerminalHandlers.mock.calls[0]?.[0];
+      if (registeredTimer) clearInterval(registeredTimer as NodeJS.Timeout);
+    });
+  });
+
+  describe('re-entrancy guard', () => {
+    it('skips a second concurrent call while the first is in progress', async () => {
+      delete process.env.SKIP_REMOTE_CONFIG;
+      let resolveFirst: (() => void) | undefined;
+      mockedRemoteConnectionSync.retrieveAndLoadRemoteConfigSync.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveFirst = resolve;
+          }),
+      );
+      mockedRemoteConnectionSync.retrieveAndLoadRemoteConfigSync.mockResolvedValue(
+        undefined,
+      );
+
+      const clientOpts = makeClientOpts(undefined);
+      const firstCall = syncClientConfig(clientOpts, [], IDENTIFYING_METADATA);
+      const secondCall = syncClientConfig(clientOpts, [], IDENTIFYING_METADATA);
+
+      await secondCall;
+      expect(
+        mockedRemoteConnectionSync.retrieveAndLoadRemoteConfigSync,
+      ).toHaveBeenCalledTimes(1);
+
+      resolveFirst!();
+      await firstCall;
+    });
+
+    it('allows a subsequent call after the first completes', async () => {
+      delete process.env.SKIP_REMOTE_CONFIG;
+      mockedRemoteConnectionSync.retrieveAndLoadRemoteConfigSync.mockResolvedValue(
+        undefined,
+      );
+      const clientOpts = makeClientOpts(undefined);
+
+      await syncClientConfig(clientOpts, [], IDENTIFYING_METADATA);
+      await syncClientConfig(clientOpts, [], IDENTIFYING_METADATA);
+
+      expect(
+        mockedRemoteConnectionSync.retrieveAndLoadRemoteConfigSync,
+      ).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/test/unit/connectionsManager/synchronizer.test.ts
+++ b/test/unit/connectionsManager/synchronizer.test.ts
@@ -11,6 +11,8 @@ import {
 import * as pluginManager from '../../../lib/hybrid-sdk/client/brokerClientPlugins/pluginManager';
 import * as socket from '../../../lib/hybrid-sdk/client/socket';
 import * as connectionHelpers from '../../../lib/hybrid-sdk/client/connectionsManager/connectionHelpers';
+import * as signals from '../../../lib/hybrid-sdk/common/utils/signals';
+import * as remoteConnectionSync from '../../../lib/hybrid-sdk/client/connectionsManager/remoteConnectionSync';
 import { log as logger } from '../../../lib/logs/logger';
 
 jest.mock(
@@ -21,10 +23,16 @@ jest.mock('../../../lib/hybrid-sdk/client/socket');
 jest.mock(
   '../../../lib/hybrid-sdk/client/connectionsManager/connectionHelpers',
 );
+jest.mock('../../../lib/hybrid-sdk/common/utils/signals', () => ({
+  isShuttingDown: jest.fn(() => false),
+  addTimerToTerminalHandlers: jest.fn(),
+}));
 
 const mockedPluginManager = jest.mocked(pluginManager);
 const mockedSocket = jest.mocked(socket);
 const mockedConnectionHelpers = jest.mocked(connectionHelpers);
+const mockedSignals = jest.mocked(signals);
+const mockedRemoteConnectionSync = jest.mocked(remoteConnectionSync);
 
 /** Create a minimal mock WebSocketConnection */
 function makeWsConn(
@@ -393,6 +401,52 @@ describe('syncClientConfig', () => {
         expect.anything(),
         'Shutting down connection',
       );
+    });
+  });
+
+  describe('shutdown gate', () => {
+    afterEach(() => {
+      mockedSignals.isShuttingDown.mockReturnValue(false);
+    });
+
+    it('returns immediately when isShuttingDown() is true, without calling retrieveAndLoadRemoteConfigSync', async () => {
+      mockedSignals.isShuttingDown.mockReturnValue(true);
+      delete process.env.SKIP_REMOTE_CONFIG;
+      const clientOpts = makeClientOpts({
+        'my-conn': {
+          type: 'github',
+          identifier: 'token-1',
+          friendlyName: 'my-conn',
+        },
+      });
+      const wsConns: WebSocketConnection[] = [];
+
+      await syncClientConfig(clientOpts, wsConns, IDENTIFYING_METADATA);
+
+      expect(
+        mockedRemoteConnectionSync.retrieveAndLoadRemoteConfigSync,
+      ).not.toHaveBeenCalled();
+      expect(mockedPluginManager.runStartupPlugins).not.toHaveBeenCalled();
+      expect(
+        mockedSocket.createWebSocketConnectionPairs,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('recursive setTimeout registration', () => {
+    it('registers the recursive setTimeout via addTimerToTerminalHandlers when polling', async () => {
+      // Need NODE_ENV != 'test' for the setTimeout branch to fire.
+      process.env.NODE_ENV = 'production';
+      const clientOpts = makeClientOpts(undefined);
+
+      await syncClientConfig(clientOpts, [], IDENTIFYING_METADATA);
+
+      expect(mockedSignals.addTimerToTerminalHandlers).toHaveBeenCalledTimes(1);
+      const registeredTimer =
+        mockedSignals.addTimerToTerminalHandlers.mock.calls[0][0];
+      expect(registeredTimer).toBeDefined();
+      // Mock doesn't clear; do it manually to prevent the recursive callback firing post-test.
+      clearTimeout(registeredTimer as NodeJS.Timeout);
     });
   });
 

--- a/test/unit/connectionsManager/synchronizer.test.ts
+++ b/test/unit/connectionsManager/synchronizer.test.ts
@@ -107,6 +107,8 @@ describe('syncClientConfig', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // clearAllMocks resets call history but not mockReturnValue overrides.
+    mockedSignals.isShuttingDown.mockReturnValue(false);
     syncStateByConnection.clear();
     __resetSynchronizerStateForTests();
     process.env.SKIP_REMOTE_CONFIG = 'true';
@@ -469,8 +471,8 @@ describe('syncClientConfig', () => {
     });
   });
 
-  describe('re-entrancy guard', () => {
-    it('skips a second concurrent call while the first is in progress', async () => {
+  describe('re-entrancy coalescing', () => {
+    it('coalesces a concurrent call into exactly one follow-up cycle', async () => {
       delete process.env.SKIP_REMOTE_CONFIG;
       let resolveFirst: (() => void) | undefined;
       mockedRemoteConnectionSync.retrieveAndLoadRemoteConfigSync.mockImplementationOnce(
@@ -488,12 +490,77 @@ describe('syncClientConfig', () => {
       const secondCall = syncClientConfig(clientOpts, [], IDENTIFYING_METADATA);
 
       await secondCall;
+      // Second call returned immediately (coalesced) — only the first cycle has started.
       expect(
         mockedRemoteConnectionSync.retrieveAndLoadRemoteConfigSync,
       ).toHaveBeenCalledTimes(1);
 
       resolveFirst!();
       await firstCall;
+
+      // Follow-up cycle ran exactly once after the first completed.
+      expect(
+        mockedRemoteConnectionSync.retrieveAndLoadRemoteConfigSync,
+      ).toHaveBeenCalledTimes(2);
+    });
+
+    it('collapses multiple concurrent calls to a single follow-up cycle', async () => {
+      delete process.env.SKIP_REMOTE_CONFIG;
+      let resolveFirst: (() => void) | undefined;
+      mockedRemoteConnectionSync.retrieveAndLoadRemoteConfigSync.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveFirst = resolve;
+          }),
+      );
+      mockedRemoteConnectionSync.retrieveAndLoadRemoteConfigSync.mockResolvedValue(
+        undefined,
+      );
+
+      const clientOpts = makeClientOpts(undefined);
+      const firstCall = syncClientConfig(clientOpts, [], IDENTIFYING_METADATA);
+      // Three concurrent calls during the first in-flight sync.
+      await Promise.all([
+        syncClientConfig(clientOpts, [], IDENTIFYING_METADATA),
+        syncClientConfig(clientOpts, [], IDENTIFYING_METADATA),
+        syncClientConfig(clientOpts, [], IDENTIFYING_METADATA),
+      ]);
+
+      resolveFirst!();
+      await firstCall;
+
+      // First cycle + exactly one coalesced follow-up = 2 total, not 4.
+      expect(
+        mockedRemoteConnectionSync.retrieveAndLoadRemoteConfigSync,
+      ).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips the queued follow-up cycle if shutdown begins mid-sync', async () => {
+      delete process.env.SKIP_REMOTE_CONFIG;
+      let resolveFirst: (() => void) | undefined;
+      mockedRemoteConnectionSync.retrieveAndLoadRemoteConfigSync.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveFirst = resolve;
+          }),
+      );
+      mockedRemoteConnectionSync.retrieveAndLoadRemoteConfigSync.mockResolvedValue(
+        undefined,
+      );
+
+      const clientOpts = makeClientOpts(undefined);
+      const firstCall = syncClientConfig(clientOpts, [], IDENTIFYING_METADATA);
+      await syncClientConfig(clientOpts, [], IDENTIFYING_METADATA); // queues follow-up
+
+      // Shutdown begins before the first cycle finishes.
+      mockedSignals.isShuttingDown.mockReturnValue(true);
+      resolveFirst!();
+      await firstCall;
+
+      // Only the first cycle ran; the queued follow-up was skipped.
+      expect(
+        mockedRemoteConnectionSync.retrieveAndLoadRemoteConfigSync,
+      ).toHaveBeenCalledTimes(1);
     });
 
     it('allows a subsequent call after the first completes', async () => {

--- a/test/unit/connectionsManager/synchronizer.test.ts
+++ b/test/unit/connectionsManager/synchronizer.test.ts
@@ -550,6 +550,10 @@ describe('syncClientConfig', () => {
       const secondTimer = mockedSignals.addIntervalToTerminalHandlers.mock
         .calls[1][0] as NodeJS.Timeout;
       expect(secondTimer).not.toBe(firstTimer);
+      // clearAndRemoveInterval is mocked, so the underlying NodeJS interval
+      // from Cycle 1 is never actually cleared by production code — drain it
+      // here to avoid an open handle keeping Jest alive.
+      clearInterval(firstTimer);
       clearInterval(secondTimer);
     });
   });

--- a/test/unit/lib/hybrid-sdk/common/utils/signals.test.ts
+++ b/test/unit/lib/hybrid-sdk/common/utils/signals.test.ts
@@ -82,13 +82,13 @@ describe('signals', () => {
     });
   });
 
-  describe('addTimerToTerminalHandlers', () => {
-    it('clears a registered setInterval on SIGTERM', () => {
+  describe('terminal handler registries', () => {
+    it('clearAllTimers clears a registered setInterval on SIGTERM', () => {
       const signals = loadSignals();
       signals.handleTerminationSignal(() => {});
       const fn = jest.fn();
       const interval = setInterval(fn, 10);
-      signals.addTimerToTerminalHandlers(interval);
+      signals.addIntervalToTerminalHandlers(interval);
 
       process.emit('SIGTERM' as any);
 
@@ -96,12 +96,12 @@ describe('signals', () => {
       expect(fn).not.toHaveBeenCalled();
     });
 
-    it('clears a registered setTimeout on SIGTERM', () => {
+    it('clearAllTimers clears a registered setTimeout on SIGTERM', () => {
       const signals = loadSignals();
       signals.handleTerminationSignal(() => {});
       const fn = jest.fn();
       const timeout = setTimeout(fn, 50);
-      signals.addTimerToTerminalHandlers(timeout);
+      signals.addTimeoutToTerminalHandlers(timeout);
 
       process.emit('SIGTERM' as any);
 
@@ -109,19 +109,51 @@ describe('signals', () => {
       expect(fn).not.toHaveBeenCalled();
     });
 
-    it('clears both setTimeout and setInterval on SIGINT', () => {
+    it('clearAllTimers clears both kinds together on SIGINT', () => {
       const signals = loadSignals();
       signals.handleTerminationSignal(() => {});
       const intervalFn = jest.fn();
       const timeoutFn = jest.fn();
-      signals.addTimerToTerminalHandlers(setInterval(intervalFn, 10));
-      signals.addTimerToTerminalHandlers(setTimeout(timeoutFn, 50));
+      signals.addIntervalToTerminalHandlers(setInterval(intervalFn, 10));
+      signals.addTimeoutToTerminalHandlers(setTimeout(timeoutFn, 50));
 
       process.emit('SIGINT' as any);
 
       jest.advanceTimersByTime(100);
       expect(intervalFn).not.toHaveBeenCalled();
       expect(timeoutFn).not.toHaveBeenCalled();
+    });
+
+    it('dispatches clearInterval (not clearTimeout) for registered intervals', () => {
+      const signals = loadSignals();
+      signals.handleTerminationSignal(() => {});
+      const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+      const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+      const interval = setInterval(() => {}, 10);
+      signals.addIntervalToTerminalHandlers(interval);
+
+      process.emit('SIGTERM' as any);
+
+      expect(clearIntervalSpy).toHaveBeenCalledWith(interval);
+      expect(clearTimeoutSpy).not.toHaveBeenCalledWith(interval);
+      clearIntervalSpy.mockRestore();
+      clearTimeoutSpy.mockRestore();
+    });
+
+    it('dispatches clearTimeout (not clearInterval) for registered timeouts', () => {
+      const signals = loadSignals();
+      signals.handleTerminationSignal(() => {});
+      const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+      const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+      const timeout = setTimeout(() => {}, 50);
+      signals.addTimeoutToTerminalHandlers(timeout);
+
+      process.emit('SIGTERM' as any);
+
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(timeout);
+      expect(clearIntervalSpy).not.toHaveBeenCalledWith(timeout);
+      clearIntervalSpy.mockRestore();
+      clearTimeoutSpy.mockRestore();
     });
   });
 });

--- a/test/unit/lib/hybrid-sdk/common/utils/signals.test.ts
+++ b/test/unit/lib/hybrid-sdk/common/utils/signals.test.ts
@@ -156,4 +156,88 @@ describe('signals', () => {
       clearTimeoutSpy.mockRestore();
     });
   });
+
+  describe('clearAndRemoveInterval / clearAndRemoveTimeout', () => {
+    it('clearAndRemoveInterval clears the timer and removes it from the registry so shutdown does not re-clear it', () => {
+      const signals = loadSignals();
+      signals.handleTerminationSignal(() => {});
+      const fn = jest.fn();
+      const interval = setInterval(fn, 10);
+      signals.addIntervalToTerminalHandlers(interval);
+      const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+
+      signals.clearAndRemoveInterval(interval);
+      expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+      expect(clearIntervalSpy).toHaveBeenCalledWith(interval);
+
+      // Shutdown should not redundantly call clearInterval on the removed handle.
+      process.emit('SIGTERM' as any);
+      expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(100);
+      expect(fn).not.toHaveBeenCalled();
+      clearIntervalSpy.mockRestore();
+    });
+
+    it('clearAndRemoveTimeout clears the timer and removes it from the registry so shutdown does not re-clear it', () => {
+      const signals = loadSignals();
+      signals.handleTerminationSignal(() => {});
+      const fn = jest.fn();
+      const timeout = setTimeout(fn, 50);
+      signals.addTimeoutToTerminalHandlers(timeout);
+      const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+
+      signals.clearAndRemoveTimeout(timeout);
+      expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(timeout);
+
+      process.emit('SIGTERM' as any);
+      expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(100);
+      expect(fn).not.toHaveBeenCalled();
+      clearTimeoutSpy.mockRestore();
+    });
+
+    it('repeated toggle does not grow the registry: shutdown clears only the currently-registered handle', () => {
+      const signals = loadSignals();
+      signals.handleTerminationSignal(() => {});
+      const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+
+      // Simulate three add/clear cycles followed by a final live registration.
+      for (let i = 0; i < 3; i++) {
+        const id = setInterval(() => {}, 10);
+        signals.addIntervalToTerminalHandlers(id);
+        signals.clearAndRemoveInterval(id);
+      }
+      const liveId = setInterval(() => {}, 10);
+      signals.addIntervalToTerminalHandlers(liveId);
+
+      clearIntervalSpy.mockClear();
+      process.emit('SIGTERM' as any);
+
+      // Only the live handle is in the registry; the three cleared ones are gone.
+      expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+      expect(clearIntervalSpy).toHaveBeenCalledWith(liveId);
+      clearIntervalSpy.mockRestore();
+    });
+
+    it('clearAndRemoveInterval is a no-op (no throw) on an unregistered handle', () => {
+      const signals = loadSignals();
+      signals.handleTerminationSignal(() => {});
+      const stray = setInterval(() => {}, 10);
+      const registered = setInterval(() => {}, 10);
+      signals.addIntervalToTerminalHandlers(registered);
+      const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+
+      expect(() => signals.clearAndRemoveInterval(stray)).not.toThrow();
+      // Stray handle gets cleared (defensive), but the registered one survives.
+      expect(clearIntervalSpy).toHaveBeenCalledWith(stray);
+
+      clearIntervalSpy.mockClear();
+      process.emit('SIGTERM' as any);
+      expect(clearIntervalSpy).toHaveBeenCalledWith(registered);
+      clearIntervalSpy.mockRestore();
+    });
+  });
 });

--- a/test/unit/lib/hybrid-sdk/common/utils/signals.test.ts
+++ b/test/unit/lib/hybrid-sdk/common/utils/signals.test.ts
@@ -1,0 +1,127 @@
+jest.mock('../../../../../../lib/hybrid-sdk/client', () => ({
+  getWebsocketConnections: jest.fn(() => [{ send: jest.fn() }]),
+}));
+
+type SignalsModule =
+  typeof import('../../../../../../lib/hybrid-sdk/common/utils/signals');
+
+const loadSignals = (): SignalsModule => {
+  let mod!: SignalsModule;
+  jest.isolateModules(() => {
+    mod = require('../../../../../../lib/hybrid-sdk/common/utils/signals');
+  });
+  return mod;
+};
+
+describe('signals', () => {
+  const realListeners: { sigterm: any[]; sigint: any[] } = {
+    sigterm: [],
+    sigint: [],
+  };
+  let exitSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    realListeners.sigterm = process.listeners('SIGTERM');
+    realListeners.sigint = process.listeners('SIGINT');
+    process.removeAllListeners('SIGTERM');
+    process.removeAllListeners('SIGINT');
+    jest.useFakeTimers();
+    exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as any);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    exitSpy.mockRestore();
+    process.removeAllListeners('SIGTERM');
+    process.removeAllListeners('SIGINT');
+    for (const l of realListeners.sigterm) process.on('SIGTERM', l);
+    for (const l of realListeners.sigint) process.on('SIGINT', l);
+  });
+
+  describe('isShuttingDown', () => {
+    it('is false on module load', () => {
+      const signals = loadSignals();
+      expect(signals.isShuttingDown()).toBe(false);
+    });
+
+    it('flips to true synchronously on SIGTERM', () => {
+      const signals = loadSignals();
+      signals.handleTerminationSignal(() => {});
+      expect(signals.isShuttingDown()).toBe(false);
+      process.emit('SIGTERM' as any);
+      expect(signals.isShuttingDown()).toBe(true);
+    });
+
+    it('flips to true synchronously on SIGINT', () => {
+      const signals = loadSignals();
+      signals.handleTerminationSignal(() => {});
+      expect(signals.isShuttingDown()).toBe(false);
+      process.emit('SIGINT' as any);
+      expect(signals.isShuttingDown()).toBe(true);
+    });
+
+    it('stays true after subsequent ticks; never resets within a process', async () => {
+      const signals = loadSignals();
+      signals.handleTerminationSignal(() => {});
+      process.emit('SIGTERM' as any);
+      expect(signals.isShuttingDown()).toBe(true);
+      jest.advanceTimersByTime(60_000);
+      expect(signals.isShuttingDown()).toBe(true);
+    });
+
+    it('is set BEFORE the user callback runs (first line of handler)', () => {
+      const signals = loadSignals();
+      let observedDuringCallback: boolean | null = null;
+      signals.handleTerminationSignal(() => {
+        observedDuringCallback = signals.isShuttingDown();
+      });
+      process.emit('SIGTERM' as any);
+      expect(observedDuringCallback).toBe(true);
+    });
+  });
+
+  describe('addTimerToTerminalHandlers', () => {
+    it('clears a registered setInterval on SIGTERM', () => {
+      const signals = loadSignals();
+      signals.handleTerminationSignal(() => {});
+      const fn = jest.fn();
+      const interval = setInterval(fn, 10);
+      signals.addTimerToTerminalHandlers(interval);
+
+      process.emit('SIGTERM' as any);
+
+      jest.advanceTimersByTime(100);
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    it('clears a registered setTimeout on SIGTERM', () => {
+      const signals = loadSignals();
+      signals.handleTerminationSignal(() => {});
+      const fn = jest.fn();
+      const timeout = setTimeout(fn, 50);
+      signals.addTimerToTerminalHandlers(timeout);
+
+      process.emit('SIGTERM' as any);
+
+      jest.advanceTimersByTime(100);
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    it('clears both setTimeout and setInterval on SIGINT', () => {
+      const signals = loadSignals();
+      signals.handleTerminationSignal(() => {});
+      const intervalFn = jest.fn();
+      const timeoutFn = jest.fn();
+      signals.addTimerToTerminalHandlers(setInterval(intervalFn, 10));
+      signals.addTimerToTerminalHandlers(setTimeout(timeoutFn, 50));
+
+      process.emit('SIGINT' as any);
+
+      jest.advanceTimersByTime(100);
+      expect(intervalFn).not.toHaveBeenCalled();
+      expect(timeoutFn).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

## Summary

During pod shutdown, the broker emits an unhandled level 50 log.
The cleanup step deletes `config.universal.json` but a remote-config sync that started moments earlier is still in flight, and attempts to read this file after it's already been deleted.

This is a race condition that occurs on SIGTERM.

There is no major impact to traffic on open websockets due to this but this error can be misleading to customers and lead them to believing that their broker client is erroring.

While addressing the race, reviewer feedback surfaced three adjacent fixes also bundled here: a polling-lifecycle regression, re-entrant sync calls, and unbounded growth of the signals timer registry.

## Changes

Shutdown is now a first-class state — in-flight and scheduled sync work bails out cleanly.

- `lib/hybrid-sdk/common/utils/signals.ts` - add `isShuttingDown()` flag which is flipped in SIGTERM/SIGINT handlers before any timer is cleared and added a paired `clearAndRemoveInterval` / `clearAndRemoveTimeout` so toggled timers don't leak into the registry.
- `lib/hybrid-sdk/client/connectionsManager/synchronizer.ts` - early-return from `syncClientConfig` when shutting down. Track the polling interval handle so it can be cleared when no longer required and re-armed cleanly if needed. Coalesce concurrent calls (polling, backup watcher, RPC) into one in-flight cycle with at most one queued follow-up.
- `lib/hybrid-sdk/client/connectionsManager/remoteConnectionSync.ts` - early-return when shutting down; wrap the body in a try/catch so any future read failures degrade to a warn log instead of an unhandledRejection. The `existsSync` check after retrieve skips validation/reload when the file is already gone (to avoid a misleading "sync failed" warn every tick).
- `lib/hybrid-sdk/client/config/remoteConfig.ts` - `existsSync` guard at the top of `retrieveConnectionsForDeployment` skips both the network round-trip and the file read when the universal file is gone.

Unit tests added:
  - `signals.test.ts` (flag lifecycle, timer cancellation, paired clear/remove)
  - `remoteConnectionSync.test.ts` (shutdown gate, try/catch, file-missing skip)
  - `remoteConfig.test.ts` (file-missing guard skips network + file I/O)
  - existing `synchronizer.test.ts` extended (polling lifecycle, re-entrancy coalescing)