### PR TITLE
fix(circleci): resolve ENONPMTOKEN semantic-version error

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,6 +1,9 @@
 {
   "prepare": [
-    "@semantic-release/npm",
+    [
+      "@semantic-release/npm",
+      { "npmPublish": false }
+    ],
     {
       "//": "build the linux, macos, and windows binaries",
       "path": "@semantic-release/exec",
@@ -23,7 +26,10 @@
     }
   ],
   "publish": [
-    "@semantic-release/npm",
+    {
+      "path": "@semantic-release/exec",
+      "cmd": "npm publish"
+    },
     {
       "path": "@semantic-release/github",
       "assets": [


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
semantic-release/npm package doesn't support circleci yet: https://github.com/semantic-release/npm/blob/master/lib/trusted-publishing/token-exchange.js#L61-L71

This PR skips npm validateAuth steps that relies on checking NPM_TOKEN envvar and uses plain `npm publish`.
