### PR TITLE
feat: downstream x-request-id mirror + webhook HTTP fallback fix

### DIFF
--- a/lib/broker-workload/prepareRequest.ts
+++ b/lib/broker-workload/prepareRequest.ts
@@ -114,6 +114,10 @@ export const prepareRequest = async (
     }
   }
 
+  if (payload.headers['snyk-request-id'] && !payload.headers['x-request-id']) {
+    payload.headers['x-request-id'] = payload.headers['snyk-request-id'];
+  }
+
   if (brokerToken && socketType === 'server') {
     Object.assign(payload.headers, { 'X-Broker-Token': brokerToken });
   }

--- a/lib/hybrid-sdk/clientRequestHelpers.ts
+++ b/lib/hybrid-sdk/clientRequestHelpers.ts
@@ -83,6 +83,7 @@ export class HybridClientRequestHandler {
       streamSize: 0,
       brokerAppClientId: this.res.locals.brokerAppClientId ?? null,
     });
+    this.res.setHeader('snyk-request-id', this.req.requestId);
     streamBuffer.pipe(this.res);
     const simplifiedContextWithStreamingID = this.simplifiedContext;
     simplifiedContextWithStreamingID['streamingID'] = streamingID;
@@ -161,7 +162,8 @@ export class HybridClientRequestHandler {
 
         const httpResponse = this.res
           .status(ioResponse.status)
-          .set(ioResponse.headers);
+          .set(ioResponse.headers)
+          .set('snyk-request-id', this.req.requestId);
 
         const encodingType = undefsafe(ioResponse, 'headers.transfer-encoding');
         try {
@@ -213,7 +215,11 @@ export class HybridClientRequestHandler {
     makeRequestToDownstream(filteredReq)
       .then((resp) => {
         if (resp.statusCode) {
-          this.res.status(resp.statusCode).set(resp.headers).send(resp.body);
+          this.res
+            .status(resp.statusCode)
+            .set(resp.headers)
+            .set('snyk-request-id', this.req.requestId)
+            .send(resp.body);
         } else {
           this.res.status(500).send(resp.statusText);
         }

--- a/lib/hybrid-sdk/common/http/middleware/requestId.ts
+++ b/lib/hybrid-sdk/common/http/middleware/requestId.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 import type { Request, Response, NextFunction, RequestHandler } from 'express';
 import { log as logger } from '../../../../logs/logger';
 import { isUUID } from '../../utils/uuid';
+import { extractBrokerTokenFromUrl, maskToken } from '../../utils/token';
 
 /** Inbound headers inspected for an existing request ID, in priority order. */
 const DEFAULT_INHERITED_HEADERS: ReadonlyArray<string> = [
@@ -50,8 +51,12 @@ export const setRequestIdHeader = (
         req.requestId = inherited;
       } else {
         req.requestId = randomUUID();
+        const brokerToken = extractBrokerTokenFromUrl(req.url);
+        const safeUrl = brokerToken
+          ? req.url.replaceAll(brokerToken, maskToken(brokerToken))
+          : req.url;
         logger.debug(
-          { method: req.method, url: req.url },
+          { method: req.method, url: safeUrl },
           'No valid request ID in inbound headers — new request ID generated',
         );
       }

--- a/test/functional/webhook.test.ts
+++ b/test/functional/webhook.test.ts
@@ -104,6 +104,33 @@ describe('proxy requests originating from behind the broker client', () => {
     expect(response.status).toEqual(200);
     expect(response.data).toStrictEqual('Received webhook via API');
   });
+
+  it('echoes broker snyk-request-id on HTTP fallback response even when caller omits it', async () => {
+    await closeBrokerServer(bs);
+
+    const response = await axiosClient.post(
+      `http://localhost:${bc.port}/webhook/github/12345678-1234-1234-1234-000000000000`,
+      { some: { example: 'json' } },
+    );
+
+    expect(response.status).toEqual(200);
+    expect(isUUID(response.headers['snyk-request-id'])).toBe(true);
+  });
+
+  it('preserves caller-supplied snyk-request-id on HTTP fallback response', async () => {
+    await closeBrokerServer(bs);
+    const supplied = '33333333-3333-4333-8333-333333333333';
+
+    const response = await axiosClient.post(
+      `http://localhost:${bc.port}/webhook/github/12345678-1234-1234-1234-000000000000`,
+      { some: { example: 'json' } },
+      { headers: { 'snyk-request-id': supplied } },
+    );
+
+    expect(response.status).toEqual(200);
+    expect(response.headers['snyk-request-id']).toEqual(supplied);
+  });
+
   it('successfully broker injects x-snyk-broker header to Webhook calls', async () => {
     await closeBrokerServer(bs);
 

--- a/test/unit/lib/broker-workload/prepareRequest.test.ts
+++ b/test/unit/lib/broker-workload/prepareRequest.test.ts
@@ -1,0 +1,72 @@
+import { prepareRequest } from '../../../../lib/broker-workload/prepareRequest';
+
+jest.mock('../../../../lib/logs/logger');
+jest.mock('../../../../lib/hybrid-sdk/client/scm', () => ({
+  gitHubCommitSigningEnabled: () => false,
+  gitHubTreeCheckNeeded: () => false,
+  signGitHubCommit: jest.fn(),
+  validateGitHubTreePayload: jest.fn(),
+}));
+
+describe('prepareRequest — downstream x-request-id mirror', () => {
+  const baseResult = { url: 'https://example.com/path' } as any;
+  const baseOptions = {
+    config: { removeXForwardedHeaders: 'false', universalBrokerEnabled: false },
+  } as any;
+  const logContext: any = {};
+
+  it('mirrors snyk-request-id onto x-request-id when x-request-id is absent', async () => {
+    const id = '11111111-1111-4111-8111-111111111111';
+    const payload = {
+      method: 'GET',
+      url: '/path',
+      headers: { 'snyk-request-id': id },
+    };
+    const { req } = await prepareRequest(
+      { ...baseResult },
+      payload,
+      logContext,
+      baseOptions,
+      'tok',
+      'client',
+    );
+    expect(req.headers['snyk-request-id']).toBe(id);
+    expect(req.headers['x-request-id']).toBe(id);
+  });
+
+  it('preserves an existing x-request-id', async () => {
+    const id = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const payload = {
+      method: 'GET',
+      url: '/path',
+      headers: { 'snyk-request-id': id, 'x-request-id': 'preexisting-id' },
+    };
+    const { req } = await prepareRequest(
+      { ...baseResult },
+      payload,
+      logContext,
+      baseOptions,
+      'tok',
+      'client',
+    );
+    expect(req.headers['x-request-id']).toBe('preexisting-id');
+    expect(req.headers['snyk-request-id']).toBe(id);
+  });
+
+  it('does not synthesise x-request-id when snyk-request-id is absent', async () => {
+    const payload = {
+      method: 'GET',
+      url: '/path',
+      headers: {},
+    };
+    const { req } = await prepareRequest(
+      { ...baseResult },
+      payload,
+      logContext,
+      baseOptions,
+      'tok',
+      'client',
+    );
+    expect(req.headers['x-request-id']).toBeUndefined();
+  });
+});

--- a/test/unit/lib/hybrid-sdk/clientRequestHelpers.test.ts
+++ b/test/unit/lib/hybrid-sdk/clientRequestHelpers.test.ts
@@ -1,4 +1,6 @@
+import { EventEmitter } from 'events';
 import { log as logger } from '../../../../lib/logs/logger';
+import { makeRequestToDownstream } from '../../../../lib/hybrid-sdk/http/request';
 import { HybridClientRequestHandler } from '../../../../lib/hybrid-sdk/clientRequestHelpers';
 
 jest.mock('../../../../lib/logs/logger');
@@ -78,5 +80,270 @@ describe('HybridClientRequestHandler — req.requestId propagation into req.head
     new HybridClientRequestHandler(req, res);
 
     expect(req.headers['snyk-request-id']).toBe(RESOLVED_UUID);
+  });
+});
+
+describe('HybridClientRequestHandler — makeHttpRequest() snyk-request-id response echo', () => {
+  const BROKER_UUID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+  const SNYK_API_UUID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+  const makeMockRes = () => {
+    const res: any = {
+      locals: { websocket: { identifier: 'test-identifier' } },
+      set: jest.fn(),
+      status: jest.fn(),
+      send: jest.fn(),
+    };
+    res.status.mockReturnValue(res);
+    res.set.mockReturnValue(res);
+    res.send.mockReturnValue(res);
+    return res;
+  };
+
+  const makeMockReq = (extra: Record<string, unknown> = {}) => ({
+    url: '/webhook/github/aaaa',
+    method: 'POST',
+    body: '{}',
+    headers: { 'snyk-request-id': BROKER_UUID },
+    requestId: BROKER_UUID,
+    maskedToken: '',
+    hashedToken: '',
+    ...extra,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (
+      require('../../../../lib/hybrid-sdk/common/config/config')
+        .getConfig as jest.Mock
+    ).mockReturnValue({
+      API_BASE_URL: 'http://snyk-api.example.com',
+    });
+  });
+
+  it('sends snyk-request-id in outbound request headers to Snyk API', async () => {
+    (makeRequestToDownstream as jest.Mock).mockResolvedValue({
+      statusCode: 200,
+      headers: {},
+      body: '{}',
+    });
+
+    const req: any = makeMockReq();
+    const res: any = makeMockRes();
+    const handler = new HybridClientRequestHandler(req, res);
+    handler.makeRequest({ url: '/webhook/github/aaaa' } as any, true);
+
+    await new Promise((r) => setImmediate(r));
+
+    expect(makeRequestToDownstream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'snyk-request-id': BROKER_UUID }),
+      }),
+    );
+  });
+
+  it('echoes broker UUID even when Snyk API response carries a different snyk-request-id', async () => {
+    (makeRequestToDownstream as jest.Mock).mockResolvedValue({
+      statusCode: 200,
+      headers: {
+        'snyk-request-id': SNYK_API_UUID,
+        'content-type': 'application/json',
+      },
+      body: '{}',
+    });
+
+    const req: any = makeMockReq();
+    const res: any = makeMockRes();
+    const handler = new HybridClientRequestHandler(req, res);
+    handler.makeRequest({ url: '/webhook/github/aaaa' } as any, true);
+
+    // Allow the promise chain to settle
+    await new Promise((r) => setImmediate(r));
+
+    // The final .set('snyk-request-id', ...) must use the broker's UUID
+    const setCalls: string[][] = res.set.mock.calls;
+    const idCall = setCalls.find((args) => args[0] === 'snyk-request-id');
+    expect(idCall).toBeDefined();
+    expect(idCall![1]).toBe(BROKER_UUID);
+    expect(idCall![1]).not.toBe(SNYK_API_UUID);
+  });
+
+  it('echoes broker UUID when Snyk API response omits snyk-request-id', async () => {
+    (makeRequestToDownstream as jest.Mock).mockResolvedValue({
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+
+    const req: any = makeMockReq();
+    const res: any = makeMockRes();
+    const handler = new HybridClientRequestHandler(req, res);
+    handler.makeRequest({ url: '/webhook/github/aaaa' } as any, true);
+
+    await new Promise((r) => setImmediate(r));
+
+    const setCalls: string[][] = res.set.mock.calls;
+    const idCall = setCalls.find((args) => args[0] === 'snyk-request-id');
+    expect(idCall).toBeDefined();
+    expect(idCall![1]).toBe(BROKER_UUID);
+  });
+});
+
+describe('HybridClientRequestHandler — response carries snyk-request-id on WS paths', () => {
+  const BROKER_UUID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+  const DOWNSTREAM_UUID = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
+
+  const makeMockReq = () => ({
+    url: '/some/path',
+    method: 'GET',
+    body: '{}',
+    headers: { 'snyk-request-id': BROKER_UUID },
+    requestId: BROKER_UUID,
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('sets broker snyk-request-id on WS response even when downstream echoes a different value', () => {
+    const wsSend = jest.fn();
+    const res: any = {
+      locals: {
+        websocket: { send: wsSend, identifier: 'id' },
+        capabilities: [],
+      },
+      set: jest.fn().mockReturnThis(),
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn().mockReturnThis(),
+    };
+
+    const handler = new HybridClientRequestHandler(makeMockReq() as any, res);
+    handler.makeRequest({ url: '/some/path' } as any);
+
+    const callback = wsSend.mock.calls[0][2];
+    callback({
+      status: 200,
+      headers: {
+        'snyk-request-id': DOWNSTREAM_UUID,
+        'content-type': 'application/json',
+      },
+      body: '{}',
+    });
+
+    const idCall = (res.set.mock.calls as string[][]).find(
+      (args) => args[0] === 'snyk-request-id',
+    );
+    expect(idCall).toBeDefined();
+    expect(idCall![1]).toBe(BROKER_UUID);
+    expect(idCall![1]).not.toBe(DOWNSTREAM_UUID);
+  });
+
+  it('sets broker snyk-request-id on WS response when downstream omits it', () => {
+    const wsSend = jest.fn();
+    const res: any = {
+      locals: {
+        websocket: { send: wsSend, identifier: 'id' },
+        capabilities: [],
+      },
+      set: jest.fn().mockReturnThis(),
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn().mockReturnThis(),
+    };
+
+    const handler = new HybridClientRequestHandler(makeMockReq() as any, res);
+    handler.makeRequest({ url: '/some/path' } as any);
+
+    const callback = wsSend.mock.calls[0][2];
+    callback({
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+
+    const idCall = (res.set.mock.calls as string[][]).find(
+      (args) => args[0] === 'snyk-request-id',
+    );
+    expect(idCall).toBeDefined();
+    expect(idCall![1]).toBe(BROKER_UUID);
+  });
+
+  it('sets broker snyk-request-id header on streaming response before piping', () => {
+    const wsSend = jest.fn();
+    const res: any = Object.assign(new EventEmitter(), {
+      locals: {
+        websocket: { send: wsSend, identifier: 'id' },
+        capabilities: ['post-streams'],
+      },
+      write: jest.fn(),
+      end: jest.fn(),
+      destroy: jest.fn(),
+      setHeader: jest.fn(),
+    });
+
+    const handler = new HybridClientRequestHandler(makeMockReq() as any, res);
+    handler.makeRequest({ url: '/some/path' } as any);
+
+    expect(res.setHeader).toHaveBeenCalledWith('snyk-request-id', BROKER_UUID);
+  });
+});
+
+describe('HybridClientRequestHandler — WS paths include snyk-request-id in payload', () => {
+  const BROKER_UUID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+
+  const makeMockReq = () => ({
+    url: '/webhook/github/aaaa',
+    method: 'POST',
+    body: '{}',
+    headers: { 'snyk-request-id': BROKER_UUID },
+    requestId: BROKER_UUID,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('includes snyk-request-id in WS payload (websocket response path)', () => {
+    const wsSend = jest.fn();
+    const res: any = {
+      locals: {
+        websocket: { send: wsSend, identifier: 'test-identifier' },
+        capabilities: [],
+      },
+    };
+
+    const handler = new HybridClientRequestHandler(makeMockReq() as any, res);
+    handler.makeRequest({ url: '/webhook/github/aaaa' } as any);
+
+    expect(wsSend).toHaveBeenCalledWith(
+      'request',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'snyk-request-id': BROKER_UUID }),
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it('includes snyk-request-id in WS payload (streaming response path)', () => {
+    const wsSend = jest.fn();
+    // The streaming path calls streamBuffer.pipe(this.res), so res must be
+    // an EventEmitter-compatible writable to avoid a synchronous throw.
+    const res: any = Object.assign(new EventEmitter(), {
+      locals: {
+        websocket: { send: wsSend, identifier: 'test-identifier' },
+        capabilities: ['post-streams'],
+      },
+      write: jest.fn(),
+      end: jest.fn(),
+      destroy: jest.fn(),
+      setHeader: jest.fn(),
+    });
+
+    const handler = new HybridClientRequestHandler(makeMockReq() as any, res);
+    handler.makeRequest({ url: '/webhook/github/aaaa' } as any);
+
+    expect(wsSend).toHaveBeenCalledWith(
+      'request',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'snyk-request-id': BROKER_UUID }),
+      }),
+    );
   });
 });

--- a/test/unit/lib/hybrid-sdk/common/http/requestId.test.ts
+++ b/test/unit/lib/hybrid-sdk/common/http/requestId.test.ts
@@ -157,6 +157,25 @@ describe('setRequestIdHeader middleware', () => {
 
       expect(debugSpy).not.toHaveBeenCalled();
     });
+
+    it('masks broker token in URL when logging synthesis', async () => {
+      const debugSpy = jest.spyOn(logger, 'debug');
+      const brokerToken = 'broker-token-12345';
+
+      await request(setupApp())
+        .get(`/broker/${brokerToken}/github/repos`)
+        .set('snyk-request-id', 'not-a-uuid');
+
+      const synthCall = (debugSpy.mock.calls as any[]).find(
+        (args) =>
+          args[1] ===
+          'No valid request ID in inbound headers — new request ID generated',
+      );
+      expect(synthCall).toBeDefined();
+      const loggedUrl: string = synthCall[0].url;
+      expect(loggedUrl).not.toContain(brokerToken);
+      expect(loggedUrl).toContain('brok-...-2345');
+    });
   });
 
   it('forwards the error to Express and logs at error level when randomUUID throws', async () => {


### PR DESCRIPTION
## Context

This PR is part of a multi-PR effort to guarantee every request handled by broker carries a stable, traceable request ID end-to-end.

- PR #1127: HTTP inbound — every request hitting broker's Express server gets `snyk-request-id` assigned by middleware and echoed in the response.
- PR #1142: WebSocket inbound — every WS `request` event payload has `snyk-request-id` backfilled before it reaches `BrokerWorkload.handler`.

This PR extends that guarantee outward to the customer system and close a gap in the webhook fallback path.

## What problem does this solve?

**Gap 1 — Downstream tracing.** When broker fires an outbound HTTP request to a customer system (GitHub, GitLab, Jira, etc.), it sends `snyk-request-id` but never the more standard `x-request-id`. Tracing systems and proxies on the customer side that key off `x-request-id` cannot correlate the request back to anything in Snyk's traces.

**Gap 2 — Webhook HTTP fallback.** The normal webhook flow (SCM → broker-client → WebSocket → broker-server → Snyk API) is fully covered by the other two PRs But when the WebSocket is unavailable, the broker-client falls back to a direct HTTP call to the Snyk API. In that fallback path, whatever `snyk-request-id` the Snyk API chose to echo could overwrite the UUID the broker had already assigned — breaking the invariant that the broker's ID is the correlation handle for the full round trip.