### PR TITLE
refactor: extract safeUrl utility to eliminate duplicated token masking

### DIFF
--- a/lib/hybrid-sdk/common/http/middleware/requestId.ts
+++ b/lib/hybrid-sdk/common/http/middleware/requestId.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto';
 import type { Request, Response, NextFunction, RequestHandler } from 'express';
 import { log as logger } from '../../../../logs/logger';
 import { isUUID } from '../../utils/uuid';
-import { extractBrokerTokenFromUrl, maskToken } from '../../utils/token';
+import { safeUrl } from '../../utils/token';
 
 /** Inbound headers inspected for an existing request ID, in priority order. */
 const DEFAULT_INHERITED_HEADERS: ReadonlyArray<string> = [
@@ -51,12 +51,8 @@ export const setRequestIdHeader = (
         req.requestId = inherited;
       } else {
         req.requestId = randomUUID();
-        const brokerToken = extractBrokerTokenFromUrl(req.url);
-        const safeUrl = brokerToken
-          ? req.url.replaceAll(brokerToken, maskToken(brokerToken))
-          : req.url;
         logger.debug(
-          { method: req.method, url: safeUrl },
+          { method: req.method, url: safeUrl(req.url) },
           'No valid request ID in inbound headers — new request ID generated',
         );
       }

--- a/lib/hybrid-sdk/common/http/webserver.ts
+++ b/lib/hybrid-sdk/common/http/webserver.ts
@@ -7,6 +7,7 @@ import {
   maskToken,
   hashToken,
   extractBrokerTokenFromUrl,
+  safeUrl,
 } from '../utils/token';
 import { createServer as createHttpServer } from 'http';
 import { createServer as createHttpsServer } from 'https';
@@ -49,15 +50,14 @@ export const webserver = (config, altPort: number) => {
   app.use((err, req, res, next) => {
     if (err) {
       const brokerToken = extractBrokerTokenFromUrl(req.url);
-      const maskedToken = maskToken(brokerToken);
       const hashedToken = hashToken(brokerToken);
       logger.error(
         {
-          url: req.url.replaceAll(brokerToken, maskedToken),
+          url: safeUrl(req.url),
           requestMethod: req.method,
           requestHeaders: req.headers,
           requestId: req.requestId ?? '',
-          maskedToken: maskedToken,
+          maskedToken: maskToken(brokerToken),
           hashedToken: hashedToken,
           error: err,
         },

--- a/lib/hybrid-sdk/common/utils/token.ts
+++ b/lib/hybrid-sdk/common/utils/token.ts
@@ -26,3 +26,8 @@ export const extractBrokerTokenFromUrl = (urlString) => {
   const regex = /\/broker\/([a-z0-9-]+)\//;
   return urlString.match(regex) ? urlString.match(regex)[1] : null;
 };
+
+export const safeUrl = (url: string): string => {
+  const token = extractBrokerTokenFromUrl(url);
+  return token ? url.replaceAll(token, maskToken(token)) : url;
+};

--- a/lib/hybrid-sdk/http/request.ts
+++ b/lib/hybrid-sdk/http/request.ts
@@ -6,7 +6,7 @@ import { bootstrap } from 'global-agent';
 import { log as logger } from '../../logs/logger';
 import { PostFilterPreparedRequest } from '../../broker-workload/prepareRequest';
 import { getConfig } from '../common/config/config';
-import { extractBrokerTokenFromUrl, maskToken } from '../common/utils/token';
+import { safeUrl } from '../common/utils/token';
 import { switchToInsecure } from './utils';
 import version from '../common/utils/version';
 
@@ -76,23 +76,19 @@ export const makeRequestToDownstream = async (
               response.statusCode >= 200 &&
               response.statusCode < 300
             ) {
-              const brokerToken = extractBrokerTokenFromUrl(localRequest.url);
-              const maskedToken = maskToken(brokerToken);
               logger.trace(
                 {
                   statusCode: response.statusCode,
-                  url: localRequest.url.replaceAll(brokerToken, maskedToken),
+                  url: safeUrl(localRequest.url),
                   requestDurationMs,
                 },
                 `Successful request`,
               );
             } else {
-              const brokerToken = extractBrokerTokenFromUrl(localRequest.url);
-              const maskedToken = maskToken(brokerToken);
               logger.debug(
                 {
                   statusCode: response.statusCode,
-                  url: localRequest.url.replaceAll(brokerToken, maskedToken),
+                  url: safeUrl(localRequest.url),
                   requestDurationMs,
                 },
                 `Non 2xx HTTP Code Received`,
@@ -128,11 +124,9 @@ export const makeRequestToDownstream = async (
       request.on('error', (error) => {
         const requestDurationMs = performance.now() - startTime;
         if (retries > 0) {
-          const brokerToken = extractBrokerTokenFromUrl(localRequest.url);
-          const maskedToken = maskToken(brokerToken);
           logger.warn(
             {
-              url: localRequest.url.replaceAll(brokerToken, maskedToken),
+              url: safeUrl(localRequest.url),
               err: error,
               requestDurationMs,
               requestId,
@@ -143,11 +137,9 @@ export const makeRequestToDownstream = async (
             resolve(makeRequestToDownstream(localRequest, retries - 1));
           }, 500); // Wait for 0.5 second before retrying
         } else {
-          const brokerToken = extractBrokerTokenFromUrl(localRequest.url);
-          const maskedToken = maskToken(brokerToken);
           logger.error(
             {
-              url: localRequest.url.replaceAll(brokerToken, maskedToken),
+              url: safeUrl(localRequest.url),
               err: error,
               requestDurationMs,
               requestId,
@@ -208,24 +200,20 @@ export const makeStreamingRequestToDownstream = (
             response.statusCode >= 200 &&
             response.statusCode < 300
           ) {
-            const brokerToken = extractBrokerTokenFromUrl(localRequest.url);
-            const maskedToken = maskToken(brokerToken);
             logger.debug(
               {
                 statusCode: response.statusCode,
-                url: localRequest.url.replaceAll(brokerToken, maskedToken),
+                url: safeUrl(localRequest.url),
                 headers: config.LOG_INFO_VERBOSE ? response.headers : {},
                 requestDurationMs,
               },
               `Successful downstream request.`,
             );
           } else {
-            const brokerToken = extractBrokerTokenFromUrl(localRequest.url);
-            const maskedToken = maskToken(brokerToken);
             logger.warn(
               {
                 statusCode: response.statusCode,
-                url: localRequest.url.replaceAll(brokerToken, maskedToken),
+                url: safeUrl(localRequest.url),
                 headers: response.headers,
                 requestDurationMs,
                 requestId,
@@ -261,11 +249,9 @@ export const makeStreamingRequestToDownstream = (
       request.on('error', (error) => {
         const requestDurationMs = performance.now() - startTime;
         if (retries > 0) {
-          const brokerToken = extractBrokerTokenFromUrl(req.url);
-          const maskedToken = maskToken(brokerToken);
           logger.warn(
             {
-              url: req.url.replaceAll(brokerToken, maskedToken),
+              url: safeUrl(req.url),
               err: error,
               requestDurationMs,
               requestId,
@@ -278,11 +264,9 @@ export const makeStreamingRequestToDownstream = (
             );
           }, 500); // Wait for 0.5 second before retrying
         } else {
-          const brokerToken = extractBrokerTokenFromUrl(localRequest.url);
-          const maskedToken = maskToken(brokerToken);
           logger.error(
             {
-              url: localRequest.url.replaceAll(brokerToken, maskedToken),
+              url: safeUrl(localRequest.url),
               err: error,
               requestDurationMs,
               requestId,

--- a/test/unit/token.test.ts
+++ b/test/unit/token.test.ts
@@ -3,6 +3,7 @@ import {
   extractBrokerTokenFromUrl,
   hashToken,
   maskToken,
+  safeUrl,
 } from '../../lib/hybrid-sdk/common/utils/token';
 
 describe('token', () => {
@@ -36,6 +37,29 @@ describe('token', () => {
 
       expect(maskedToken).toEqual('1234-...-2345');
       expect(maskedUUIDToken).toEqual('aaaa-...-dddd');
+    });
+  });
+
+  describe('safeUrl', () => {
+    it('masks the broker token in a URL path', () => {
+      const token = 'broker-token-12345';
+      const url = `/broker/${token}/github/repos`;
+      expect(safeUrl(url)).toBe(`/broker/${maskToken(token)}/github/repos`);
+      expect(safeUrl(url)).not.toContain(token);
+    });
+
+    it('masks the broker token in a full URL', () => {
+      const token = 'broker-token-12345';
+      const url = `http://my.hostname/broker/${token}/rest/of/path`;
+      expect(safeUrl(url)).toBe(
+        `http://my.hostname/broker/${maskToken(token)}/rest/of/path`,
+      );
+      expect(safeUrl(url)).not.toContain(token);
+    });
+
+    it('returns the URL unchanged when no broker token is present', () => {
+      const url = '/some/other/path';
+      expect(safeUrl(url)).toBe(url);
     });
   });
 


### PR DESCRIPTION
## Summary

- Extracts the repeated `extractBrokerTokenFromUrl` + `maskToken` + `replaceAll` pattern into a single `safeUrl(url: string): string` helper in `lib/hybrid-sdk/common/utils/token.ts`
- Removes 9 inline duplications across `request.ts` (8), `webserver.ts` (1), and `requestId.ts` (1)

## Test plan

- [ ] New `safeUrl` unit tests added to `test/unit/token.test.ts` (written first, TDD)
- [ ] Existing `requestId.ts` synthesis-logging test passes unchanged
- [ ] Full unit suite: `npx jest --no-coverage --testPathPattern='unit/lib/hybrid-sdk|unit/lib/broker-workload'` — 123 tests pass