### PR TITLE
chore: exclude npm from verify conditions

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,8 +1,13 @@
 {
+  "verifyConditions": [
+    "@semantic-release/github"
+  ],
   "prepare": [
     [
       "@semantic-release/npm",
-      { "npmPublish": false }
+      {
+        "npmPublish": false
+      }
     ],
     {
       "//": "build the linux, macos, and windows binaries",
@@ -66,5 +71,7 @@
       ]
     }
   ],
-  "branches": ["master"]
+  "branches": [
+    "master"
+  ]
 }


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

NPM config has changed. This excludes npm from the pre-release step to verify conditions. There is no reduction in security since the token is still checked at release step.


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
