### PR TITLE
refactor: introduce typed requestId accessor across proxy request path

### DIFF
--- a/lib/broker-workload/prepareRequest.ts
+++ b/lib/broker-workload/prepareRequest.ts
@@ -29,6 +29,7 @@ export interface PostFilterPreparedRequest {
   body?: any;
   timeoutMs?: number;
   tlsOptions?: Record<string, boolean | string>;
+  requestId?: string;
 }
 
 export const prepareRequest = async (
@@ -114,6 +115,8 @@ export const prepareRequest = async (
     }
   }
 
+  // Propagate under the generic x-request-id header for downstream services
+  // that do not read the snyk-specific header.
   if (payload.headers['snyk-request-id'] && !payload.headers['x-request-id']) {
     payload.headers['x-request-id'] = payload.headers['snyk-request-id'];
   }
@@ -209,6 +212,7 @@ export const prepareRequest = async (
     url: result.url,
     headers: payload.headers,
     method: payload.method,
+    requestId: payload.requestId,
   };
   if (payload.body) {
     req.body = payload.body;

--- a/lib/broker-workload/websocketRequests.ts
+++ b/lib/broker-workload/websocketRequests.ts
@@ -97,6 +97,7 @@ export class BrokerWorkload extends Workload<WorkloadType.remoteServer> {
         ? 'websocket'
         : 'http',
       ...correlationHeaders,
+      requestId: payload.requestId,
     };
 
     const responseHandler = new HybridResponseHandler(

--- a/lib/hybrid-sdk/client/dispatcher/client/api.ts
+++ b/lib/hybrid-sdk/client/dispatcher/client/api.ts
@@ -55,6 +55,8 @@ export class HttpDispatcherServiceClient implements DispatcherServiceClient {
           `Unexpected connection allocation server response - ${response.statusCode}: ${response.body}`,
         );
       }
+      // Reading the ID echoed by the remote API in its response headers — there
+      // is no typed accessor on the HTTP response type for this field.
       const snykRequestId = response.headers['snyk-request-id'] || '';
       logger.trace(
         { snykRequestId, apiResponse },

--- a/lib/hybrid-sdk/client/socketHandlers/serviceHandler.ts
+++ b/lib/hybrid-sdk/client/socketHandlers/serviceHandler.ts
@@ -10,6 +10,8 @@ export const serviceHandler = async (msg, cb) => {
   const clientOptions = getClientOpts();
   // strip off any query strings
   const command = msg.url.indexOf('?') < 0 ? msg.url : msg.url.split('?')[0];
+  // msg is a raw WebSocket payload, not an Express Request — there is no typed
+  // requestId accessor available here.
   const requestId = msg.headers['snyk-request-id'];
   logger.debug({ command, requestId }, 'Service message received.');
   if (!clientOptions) {

--- a/lib/hybrid-sdk/clientRequestHelpers.ts
+++ b/lib/hybrid-sdk/clientRequestHelpers.ts
@@ -97,6 +97,7 @@ export class HybridClientRequestHandler {
       body: this.req.body,
       headers: this.req.headers,
       streamingID,
+      requestId: this.req.requestId,
     });
     incrementWebSocketRequestsTotal(false, 'outbound-request');
     return;
@@ -123,6 +124,7 @@ export class HybridClientRequestHandler {
         body: this.req.body,
         headers: this.req.headers,
         streamingID: '',
+        requestId: this.req.requestId,
       },
       (ioResponse) => {
         this.logContext.responseStatus = ioResponse.status;
@@ -209,6 +211,7 @@ export class HybridClientRequestHandler {
       method: this.req.method,
       body: this.req.body,
       headers: this.req.headers,
+      requestId: this.req.requestId,
     };
 
     // deepcode ignore Ssrf: request URL comes from the filter response, with the origin url being injected by the filtered version

--- a/lib/hybrid-sdk/common/connectionToWorkloadInterface/forwardWebsocketRequest.ts
+++ b/lib/hybrid-sdk/common/connectionToWorkloadInterface/forwardWebsocketRequest.ts
@@ -32,6 +32,7 @@ export const forwardWebSocketRequest = (
       if (!isUUID(payload.headers['snyk-request-id'])) {
         payload.headers['snyk-request-id'] = randomUUID();
       }
+      payload.requestId = payload.headers['snyk-request-id'];
 
       const workloadName = options.config.remoteWorkloadName;
       const workloadModulePath = options.config.remoteWorkloadModulePath;

--- a/lib/hybrid-sdk/common/filter/filtersAsync.ts
+++ b/lib/hybrid-sdk/common/filter/filtersAsync.ts
@@ -225,7 +225,10 @@ export const loadFilters: LOADEDFILTER = (
 
   return (payload: RequestPayload): false | Rule => {
     let res: false | Rule = false;
-    logger.debug({ rulesCount: tests.length }, 'looking for a rule match');
+    logger.debug(
+      { rulesCount: tests.length, requestId: payload.requestId },
+      'looking for a rule match',
+    );
 
     try {
       for (const test of tests) {
@@ -235,7 +238,7 @@ export const loadFilters: LOADEDFILTER = (
         }
       }
     } catch (e: unknown) {
-      const requestId = payload.headers?.['snyk-request-id'] || '';
+      const requestId = payload.requestId;
       logger.warn(
         { error: e, requestId },
         'Caught error checking request against rules.',

--- a/lib/hybrid-sdk/common/http/webserver.ts
+++ b/lib/hybrid-sdk/common/http/webserver.ts
@@ -56,7 +56,7 @@ export const webserver = (config, altPort: number) => {
           url: safeUrl(req.url),
           requestMethod: req.method,
           requestHeaders: req.headers,
-          requestId: req.requestId ?? '',
+          requestId: req.requestId,
           maskedToken: maskToken(brokerToken),
           hashedToken: hashedToken,
           error: err,

--- a/lib/hybrid-sdk/common/types/http.ts
+++ b/lib/hybrid-sdk/common/types/http.ts
@@ -5,4 +5,5 @@ export interface RequestPayload {
   body?: any;
   streamingID?: string;
   connectionIdentifier?: string;
+  requestId: string;
 }

--- a/lib/hybrid-sdk/http/request.ts
+++ b/lib/hybrid-sdk/http/request.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import http from 'node:http';
 import https from 'node:https';
 import { performance } from 'node:perf_hooks';
@@ -35,7 +36,8 @@ export const makeRequestToDownstream = async (
   const startTime = performance.now();
   const config = getConfig();
   const localRequest = req;
-  const requestId = localRequest.headers['snyk-request-id'] || '';
+  const requestId = localRequest.requestId ?? randomUUID();
+  localRequest.headers['snyk-request-id'] = requestId;
   if (config.INSECURE_DOWNSTREAM) {
     localRequest.url = switchToInsecure(localRequest.url);
   }
@@ -81,6 +83,7 @@ export const makeRequestToDownstream = async (
                   statusCode: response.statusCode,
                   url: safeUrl(localRequest.url),
                   requestDurationMs,
+                  requestId,
                 },
                 `Successful request`,
               );
@@ -90,6 +93,7 @@ export const makeRequestToDownstream = async (
                   statusCode: response.statusCode,
                   url: safeUrl(localRequest.url),
                   requestDurationMs,
+                  requestId,
                 },
                 `Non 2xx HTTP Code Received`,
               );
@@ -168,7 +172,8 @@ export const makeStreamingRequestToDownstream = (
   const startTime = performance.now();
   const config = getConfig();
   const localRequest = req;
-  const requestId = localRequest.headers['snyk-request-id'] || '';
+  const requestId = localRequest.requestId ?? randomUUID();
+  localRequest.headers['snyk-request-id'] = requestId;
   if (config.INSECURE_DOWNSTREAM) {
     localRequest.url = switchToInsecure(localRequest.url);
   }
@@ -206,6 +211,7 @@ export const makeStreamingRequestToDownstream = (
                 url: safeUrl(localRequest.url),
                 headers: config.LOG_INFO_VERBOSE ? response.headers : {},
                 requestDurationMs,
+                requestId,
               },
               `Successful downstream request.`,
             );
@@ -292,7 +298,8 @@ export const makeSingleRawRequestToDownstream = async (
   const startTime = performance.now();
   const config = getConfig();
   const localRequest = req;
-  const requestId = localRequest.headers['snyk-request-id'] || '';
+  const requestId = localRequest.requestId ?? randomUUID();
+  localRequest.headers['snyk-request-id'] = requestId;
   if (config.INSECURE_DOWNSTREAM) {
     localRequest.url = switchToInsecure(localRequest.url);
   }
@@ -335,6 +342,7 @@ export const makeSingleRawRequestToDownstream = async (
                 statusCode: response.statusCode,
                 url: localRequest.url,
                 requestDurationMs,
+                requestId,
               },
               'Successful raw request',
             );

--- a/lib/hybrid-sdk/server/broker-middleware.ts
+++ b/lib/hybrid-sdk/server/broker-middleware.ts
@@ -18,7 +18,7 @@ export const validateBrokerTypeMiddleware = (
       requestId: req.requestId,
     };
     logger.warn(
-      { logContext },
+      logContext,
       'Error: Request does not contain the x-snyk-broker-type header.',
     );
     // Will eventually return an error when all services will have this enabled

--- a/lib/hybrid-sdk/server/routesHandlers/connectionStatusHandler.ts
+++ b/lib/hybrid-sdk/server/routesHandlers/connectionStatusHandler.ts
@@ -41,6 +41,7 @@ export const connectionStatusHandler = async (req: Request, res: Response) => {
         url: url.toString(),
         headers: req.headers,
         method: req.method,
+        requestId: req.requestId,
       };
       if (
         req.method == 'POST' ||
@@ -50,7 +51,7 @@ export const connectionStatusHandler = async (req: Request, res: Response) => {
         postFilterPreparedRequest.body = req.body;
       }
       logger.debug(
-        { url: req.url, method: req.method },
+        { url: req.url, method: req.method, requestId: req.requestId },
         'Making request to primary',
       );
       try {
@@ -61,12 +62,18 @@ export const connectionStatusHandler = async (req: Request, res: Response) => {
         res.writeHead(httpResponse.statusCode ?? 500, httpResponse.headers);
         return httpResponse.pipe(res);
       } catch (err) {
-        logger.error({ err }, `Error in HTTP middleware: ${err}`);
+        logger.error(
+          { err, requestId: req.requestId },
+          `Error in HTTP middleware: ${err}`,
+        );
         res.setHeader('x-broker-failure', 'error-forwarding-to-primary');
         res.status(500).send('Error forwarding request to primary.');
       }
     } else {
-      logger.warn({ desensitizedToken }, 'No matching connection found.');
+      logger.warn(
+        { desensitizedToken, requestId: req.requestId },
+        'No matching connection found.',
+      );
       res.setHeader('x-broker-failure', 'no-connection');
       return res.status(404).json({ ok: false });
     }

--- a/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.ts
+++ b/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.ts
@@ -38,6 +38,7 @@ export const overloadHttpRequestWithConnectionDetailsMiddleware = async (
         url: url.toString(),
         headers: req.headers,
         method: req.method,
+        requestId: req.requestId,
       };
       if (
         req.method == 'POST' ||
@@ -47,7 +48,7 @@ export const overloadHttpRequestWithConnectionDetailsMiddleware = async (
         postFilterPreparedRequest.body = req.body;
       }
       logger.debug(
-        { url: req.url, method: req.method },
+        { url: req.url, method: req.method, requestId },
         'Making request to primary',
       );
       try {
@@ -120,7 +121,7 @@ export const overloadHttpRequestWithConnectionDetailsMiddleware = async (
     }
   }
 
-  logger.debug({ url: req.url }, 'request');
+  logger.debug({ url: req.url, requestId }, 'request');
   next();
 };
 

--- a/lib/hybrid-sdk/server/socket.ts
+++ b/lib/hybrid-sdk/server/socket.ts
@@ -56,6 +56,8 @@ const socket = ({ server, loadedServerOpts }): SocketHandler => {
       const connectionIdentifier = req.uri.pathname
         .replaceAll(/^\/primus\/([^/]+)\//g, '$1')
         .toLowerCase();
+      // Primus authorize callbacks receive the raw HTTP upgrade request before
+      // the Express middleware chain runs, so req.requestId is not available here.
       const requestId = req.headers['snyk-request-id'];
       try {
         const { brokerClientId, credentials, role } =

--- a/test/unit/filters-and-interpolates.test.ts
+++ b/test/unit/filters-and-interpolates.test.ts
@@ -33,6 +33,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'GET',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         expect(filterResponse).toStrictEqual({
@@ -60,6 +61,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url: '/repos/angular/angular/contents/test-main.js#/package.json',
           method: 'GET',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).toBeFalsy();
       });
@@ -68,6 +70,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url: '/repos/angular/angular/contents/path/to/docs/../../sensitive/file.js',
           method: 'GET',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).toBeFalsy();
       });
@@ -78,6 +81,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'POST',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -100,6 +104,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'PATCH',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -122,6 +127,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'POST',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -144,6 +150,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'PATCH',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
 
         expect(filterResponse).not.toEqual(false);
@@ -167,6 +174,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'DELETE',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -195,6 +203,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'DELETE',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).toBeTruthy();
       });
@@ -211,6 +220,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'POST',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -234,6 +244,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'PUT',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -257,6 +268,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'GET',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -280,6 +292,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'POST',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -303,6 +316,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'POST',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -326,6 +340,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'GET',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -349,6 +364,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'GET',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -372,6 +388,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'POST',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -402,6 +419,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'POST',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -425,6 +443,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'PUT',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -448,6 +467,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'GET',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -471,6 +491,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'POST',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -494,6 +515,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'POST',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -517,6 +539,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'GET',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -540,6 +563,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'GET',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -563,6 +587,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'GET',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -586,6 +611,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'PUT',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
 
         expect(filterResponse).not.toEqual(false);
@@ -614,6 +640,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'POST',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -637,6 +664,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'GET',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
 
         expect(filterResponse).not.toEqual(false);
@@ -661,6 +689,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'GET',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
 
         expect(filterResponse).not.toEqual(false);
@@ -685,6 +714,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'GET',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
 
         expect(filterResponse).not.toEqual(false);
@@ -709,6 +739,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'GET',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
 
         expect(filterResponse).not.toEqual(false);
@@ -733,6 +764,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'PUT',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
 
         expect(filterResponse).not.toEqual(false);
@@ -757,6 +789,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'POST',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -780,6 +813,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'PATCH',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -803,6 +837,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'POST',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -830,6 +865,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'GET',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -852,6 +888,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'GET',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -874,6 +911,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'GET',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -896,6 +934,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'PUT',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -917,6 +956,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'POST',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -939,6 +979,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'PUT',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -961,6 +1002,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'GET',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -983,6 +1025,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'POST',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -1006,6 +1049,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'PUT',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -1028,6 +1072,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'GET',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -1050,6 +1095,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'POST',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -1072,6 +1118,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'POST',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -1094,6 +1141,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'POST',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -1117,6 +1165,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'POST',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).not.toEqual(false);
         const filterResponseAsRule = filterResponse as Rule;
@@ -1150,6 +1199,7 @@ describe('filters and interpolates', () => {
             },
           ],
         }),
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       });
       const filterResponseAsRule = filterResponse as Rule;
       const result = getInterpolatedRequest(
@@ -1179,6 +1229,7 @@ describe('filters and interpolates', () => {
             },
           ],
         }),
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       });
       const filterResponseAsRule = filterResponse as Rule;
       const result = getInterpolatedRequest(
@@ -1208,6 +1259,7 @@ describe('filters and interpolates', () => {
             },
           ],
         }),
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       });
       expect(filterResponse).toBeFalsy();
     });
@@ -1219,6 +1271,7 @@ describe('filters and interpolates', () => {
         body: jsonBuffer({
           commits: [],
         }),
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       });
       expect(filterResponse).toBeFalsy();
     });
@@ -1260,6 +1313,7 @@ describe('filters and interpolates', () => {
         }
       }`,
           }),
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         const filterResponseAsRule = filterResponse as Rule;
         const result = getInterpolatedRequest(
@@ -1313,6 +1367,7 @@ describe('filters and interpolates', () => {
             }`,
             /* eslint-enable no-useless-escape */
           }),
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).toBeFalsy();
       });
@@ -1327,6 +1382,7 @@ describe('filters and interpolates', () => {
                 '/../fixtures/client/github/graphql/find-pull-requests-invalid-query.txt',
             ).toString('utf-8'),
           }),
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).toBeFalsy();
       });
@@ -1341,6 +1397,7 @@ describe('filters and interpolates', () => {
                 '/../fixtures/client/github/graphql/find-pull-requests-open.txt',
             ).toString('utf-8'),
           }),
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         const filterResponseAsRule = filterResponse as Rule;
         const result = getInterpolatedRequest(
@@ -1366,6 +1423,7 @@ describe('filters and interpolates', () => {
                 '/../fixtures/client/github/graphql/find-pull-requests-closed.txt',
             ).toString('utf-8'),
           }),
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         const filterResponseAsRule = filterResponse as Rule;
         const result = getInterpolatedRequest(
@@ -1391,6 +1449,7 @@ describe('filters and interpolates', () => {
                 '/../fixtures/client/github/graphql/find-pull-request-threads.txt',
             ).toString('utf-8'),
           }),
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         const filterResponseAsRule = filterResponse as Rule;
         const result = getInterpolatedRequest(
@@ -1416,6 +1475,7 @@ describe('filters and interpolates', () => {
                 '/../fixtures/client/github/graphql/resolve-pull-request-thread.txt',
             ).toString('utf-8'),
           }),
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         const filterResponseAsRule = filterResponse as Rule;
         const result = getInterpolatedRequest(
@@ -1442,6 +1502,7 @@ describe('filters and interpolates', () => {
       const filterResponse = filter({
         url,
         method: 'GET',
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       });
       const filterResponseAsRule = filterResponse as Rule;
       const result = getInterpolatedRequest(
@@ -1462,6 +1523,7 @@ describe('filters and interpolates', () => {
       const filterResponse = filter({
         url,
         method: 'GET',
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       });
       const filterResponseAsRule = filterResponse as Rule;
       const result = getInterpolatedRequest(
@@ -1482,6 +1544,7 @@ describe('filters and interpolates', () => {
       const filterResponse = filter({
         url,
         method: 'GET',
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       });
       const filterResponseAsRule = filterResponse as Rule;
       const result = getInterpolatedRequest(
@@ -1502,6 +1565,7 @@ describe('filters and interpolates', () => {
       const filterResponse = filter({
         url,
         method: 'GET',
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       });
       const filterResponseAsRule = filterResponse as Rule;
       const result = getInterpolatedRequest(
@@ -1523,6 +1587,7 @@ describe('filters and interpolates', () => {
       const filterResponse = filter({
         url,
         method: 'GET',
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       });
       const filterResponseAsRule = filterResponse as Rule;
       const result = getInterpolatedRequest(
@@ -1542,6 +1607,7 @@ describe('filters and interpolates', () => {
       const filterResponse = filter({
         url: '/filtered-on-query?filePath=secret.file',
         method: 'GET',
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       });
       expect(filterResponse).toBeFalsy();
     });
@@ -1550,6 +1616,7 @@ describe('filters and interpolates', () => {
       const filterResponse = filter({
         url: '/filtered-on-query',
         method: 'GET',
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       });
       expect(filterResponse).toBeFalsy();
     });
@@ -1560,6 +1627,7 @@ describe('filters and interpolates', () => {
       const filterResponse = filter({
         url,
         method: 'GET',
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       });
       const filterResponseAsRule = filterResponse as Rule;
       const result = getInterpolatedRequest(
@@ -1579,6 +1647,7 @@ describe('filters and interpolates', () => {
       const filterResponse = filter({
         url: '/filtered-on-multiple-queries?filePath=package.json&download=false',
         method: 'GET',
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       });
       expect(filterResponse).toBeFalsy();
     });
@@ -1587,6 +1656,7 @@ describe('filters and interpolates', () => {
       const filterResponse = filter({
         url: '/filtered-on-multiple-queries?filePath=package.json',
         method: 'GET',
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       });
       expect(filterResponse).toBeFalsy();
     });
@@ -1596,6 +1666,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url: '/filtered-on-query?filePath=/path/to/sensitive/file#package.json',
           method: 'GET',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).toBeFalsy();
       });
@@ -1606,6 +1677,7 @@ describe('filters and interpolates', () => {
         const filterResponse = filter({
           url,
           method: 'GET',
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         const filterResponseAsRule = filterResponse as Rule;
         const result = getInterpolatedRequest(
@@ -1639,6 +1711,7 @@ describe('filters and interpolates', () => {
             },
           ],
         }),
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       });
       const filterResponseAsRule = filterResponse as Rule;
       const result = getInterpolatedRequest(
@@ -1659,6 +1732,7 @@ describe('filters and interpolates', () => {
       const filterResponse = filter({
         url,
         method: 'POST',
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       });
       const filterResponseAsRule = filterResponse as Rule;
       const result = getInterpolatedRequest(
@@ -1688,6 +1762,7 @@ describe('filters and interpolates', () => {
             },
           ],
         }),
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       });
       expect(filterResponse).toBeFalsy();
     });
@@ -1699,6 +1774,7 @@ describe('filters and interpolates', () => {
         body: jsonBuffer({
           commits: [],
         }),
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       });
       expect(filterResponse).toBeFalsy();
     });
@@ -1711,6 +1787,7 @@ describe('filters and interpolates', () => {
           body: jsonBuffer({
             commits: [],
           }),
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         expect(filterResponse).toBeFalsy();
       });
@@ -1724,6 +1801,7 @@ describe('filters and interpolates', () => {
           body: jsonBuffer({
             commits: [],
           }),
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
         });
         const filterResponseAsRule = filterResponse as Rule;
         const result = getInterpolatedRequest(
@@ -1751,6 +1829,7 @@ describe('filters and interpolates', () => {
         headers: {
           accept: 'unlisted.header',
         },
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       });
       expect(filterResponse).toBeFalsy();
     });
@@ -1759,6 +1838,7 @@ describe('filters and interpolates', () => {
       const filterResponse = filter({
         url: '/accept-header',
         method: 'GET',
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       });
       expect(filterResponse).toBeFalsy();
     });
@@ -1838,6 +1918,7 @@ describe('with auth', () => {
     const filterResponse = filter({
       url,
       method: 'GET',
+      requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
     });
     const filterResponseAsRule = filterResponse as Rule;
     const result = getInterpolatedRequest(
@@ -1860,6 +1941,7 @@ describe('with auth', () => {
     const filterResponse = filter({
       url,
       method: 'GET',
+      requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
     });
     const filterResponseAsRule = filterResponse as Rule;
     const result = getInterpolatedRequest(
@@ -1891,6 +1973,7 @@ describe('Github big files (optional rules)', () => {
         query:
           '{\n        repository(owner: "some-owner", name: "some-name") {\n          object(expression: "refs/heads/some-thing:a/path/to/package-lock.json") {\n            ... on Blob {\n              oid,\n            }\n          }\n        }\n      }',
       }),
+      requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
     });
     const filterResponseAsRule = filterResponse as Rule;
     const result = getInterpolatedRequest(

--- a/test/unit/lib/broker-workload/prepareRequest.test.ts
+++ b/test/unit/lib/broker-workload/prepareRequest.test.ts
@@ -8,6 +8,53 @@ jest.mock('../../../../lib/hybrid-sdk/client/scm', () => ({
   validateGitHubTreePayload: jest.fn(),
 }));
 
+describe('prepareRequest — requestId propagation', () => {
+  const baseResult = { url: 'https://example.com/path' } as any;
+  const baseOptions = {
+    config: { removeXForwardedHeaders: 'false', universalBrokerEnabled: false },
+  } as any;
+  const logContext: any = {};
+
+  it('propagates requestId from payload onto the prepared request', async () => {
+    const id = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+    const payload = {
+      method: 'GET',
+      url: '/path',
+      headers: { 'snyk-request-id': id },
+      requestId: id,
+    };
+    const { req } = await prepareRequest(
+      { ...baseResult },
+      payload,
+      logContext,
+      baseOptions,
+      'tok',
+      'client',
+    );
+    expect(req.requestId).toBe(id);
+  });
+
+  it('req.requestId matches snyk-request-id header after prepare', async () => {
+    const id = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+    const payload = {
+      method: 'POST',
+      url: '/path',
+      headers: { 'snyk-request-id': id },
+      requestId: id,
+    };
+    const { req } = await prepareRequest(
+      { ...baseResult },
+      payload,
+      logContext,
+      baseOptions,
+      'tok',
+      'client',
+    );
+    expect(req.requestId).toBe(id);
+    expect(req.headers['snyk-request-id']).toBe(id);
+  });
+});
+
 describe('prepareRequest — downstream x-request-id mirror', () => {
   const baseResult = { url: 'https://example.com/path' } as any;
   const baseOptions = {

--- a/test/unit/lib/broker-workload/websocketRequests.test.ts
+++ b/test/unit/lib/broker-workload/websocketRequests.test.ts
@@ -63,6 +63,34 @@ describe('BrokerWorkload', () => {
     );
   });
 
+  it('uses payload.requestId in logContext even when headers["snyk-request-id"] differs', async () => {
+    const workload = new BrokerWorkload(
+      connectionIdentifier,
+      options,
+      websocketConnectionHandler,
+    );
+    const payloadRequestId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const headerRequestId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+    const payload = {
+      url: '/',
+      method: 'GET',
+      headers: { 'snyk-request-id': headerRequestId },
+      streamingID: '',
+      requestId: payloadRequestId,
+    };
+
+    await workload.handler({ payload, websocketHandler: jest.fn() });
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: payloadRequestId }),
+      expect.stringContaining('[Websocket Flow] Received request'),
+    );
+    expect(logger.debug).not.toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: headerRequestId }),
+      expect.stringContaining('[Websocket Flow] Received request'),
+    );
+  });
+
   it('sets contextId to undefined in logContext when x-snyk-broker-context-id header is absent', async () => {
     const workload = new BrokerWorkload(
       connectionIdentifier,

--- a/test/unit/lib/hybrid-sdk/clientRequestHelpers.test.ts
+++ b/test/unit/lib/hybrid-sdk/clientRequestHelpers.test.ts
@@ -316,6 +316,7 @@ describe('HybridClientRequestHandler — WS paths include snyk-request-id in pay
       'request',
       expect.objectContaining({
         headers: expect.objectContaining({ 'snyk-request-id': BROKER_UUID }),
+        requestId: BROKER_UUID,
       }),
       expect.any(Function),
     );
@@ -343,6 +344,7 @@ describe('HybridClientRequestHandler — WS paths include snyk-request-id in pay
       'request',
       expect.objectContaining({
         headers: expect.objectContaining({ 'snyk-request-id': BROKER_UUID }),
+        requestId: BROKER_UUID,
       }),
     );
   });

--- a/test/unit/lib/hybrid-sdk/common/connectionToWorkloadInterface/forwardWebsocketRequest.test.ts
+++ b/test/unit/lib/hybrid-sdk/common/connectionToWorkloadInterface/forwardWebsocketRequest.test.ts
@@ -125,3 +125,50 @@ describe('forwardWebSocketRequest — snyk-request-id backfill', () => {
     });
   });
 });
+
+describe('forwardWebSocketRequest — payload.requestId typed accessor', () => {
+  it('sets payload.requestId to the synthesised UUID when header was absent', async () => {
+    const payload = { url: '/foo', method: 'GET', headers: {} };
+    const { capturedPayload } = await runHandler(payload);
+
+    expect(capturedPayload.requestId).toBe(
+      capturedPayload.headers['snyk-request-id'],
+    );
+    expect(isUUID(capturedPayload.requestId)).toBe(true);
+  });
+
+  it('sets payload.requestId to the existing valid UUID', async () => {
+    const payload = {
+      url: '/bar',
+      method: 'GET',
+      headers: { 'snyk-request-id': VALID_UUID },
+    };
+    const { capturedPayload } = await runHandler(payload);
+
+    expect(capturedPayload.requestId).toBe(VALID_UUID);
+    expect(capturedPayload.requestId).toBe(
+      capturedPayload.headers['snyk-request-id'],
+    );
+  });
+
+  it('payload.requestId matches headers entry in every case', async () => {
+    for (const headerValue of [
+      undefined,
+      'not-a-uuid',
+      '00000000-0000-0000-0000-000000000000',
+      VALID_UUID,
+    ]) {
+      const headers = headerValue ? { 'snyk-request-id': headerValue } : {};
+      const { capturedPayload } = await runHandler({
+        url: '/',
+        method: 'GET',
+        headers,
+      });
+
+      expect(capturedPayload.requestId).toBe(
+        capturedPayload.headers['snyk-request-id'],
+      );
+      expect(isUUID(capturedPayload.requestId)).toBe(true);
+    }
+  });
+});

--- a/test/unit/lib/hybrid-sdk/http/request.test.ts
+++ b/test/unit/lib/hybrid-sdk/http/request.test.ts
@@ -251,4 +251,82 @@ describe('http/request', () => {
       expect(logContext.requestDurationMs).toBeGreaterThan(0);
     });
   });
+
+  describe('requestId typed accessor', () => {
+    const FIXED_UUID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+    it('makeRequestToDownstream uses requestId from the typed field, not the header bag', async () => {
+      nock(downstreamUrl).post(downstreamPath).reply(200, {});
+
+      await makeRequestToDownstream({
+        url: fullDownstreamUrl,
+        method: 'POST',
+        headers: {},
+        requestId: FIXED_UUID,
+      });
+
+      const [logContext] = (logger.trace as jest.Mock).mock.calls[0];
+      expect(logContext.requestId).toBe(FIXED_UUID);
+    });
+
+    it('makeRequestToDownstream synthesises a UUID when requestId is absent', async () => {
+      nock(downstreamUrl).post(downstreamPath).reply(200, {});
+
+      await makeRequestToDownstream({
+        url: fullDownstreamUrl,
+        method: 'POST',
+        headers: {},
+      });
+
+      const [logContext] = (logger.trace as jest.Mock).mock.calls[0];
+      expect(typeof logContext.requestId).toBe('string');
+      expect(logContext.requestId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      );
+    });
+
+    it('makeSingleRawRequestToDownstream uses requestId from the typed field', async () => {
+      nock(downstreamUrl).post(downstreamPath).reply(200, {});
+
+      await makeSingleRawRequestToDownstream({
+        url: fullDownstreamUrl,
+        method: 'POST',
+        headers: {},
+        requestId: FIXED_UUID,
+      });
+
+      const [logContext] = (logger.trace as jest.Mock).mock.calls[0];
+      expect(logContext.requestId).toBe(FIXED_UUID);
+    });
+
+    it('makeStreamingRequestToDownstream uses requestId from the typed field', async () => {
+      nock(downstreamUrl).post(downstreamPath).reply(200, {});
+
+      await makeStreamingRequestToDownstream({
+        url: fullDownstreamUrl,
+        method: 'POST',
+        headers: {},
+        requestId: FIXED_UUID,
+      });
+
+      const [logContext] = (logger.debug as jest.Mock).mock.calls[0];
+      expect(logContext.requestId).toBe(FIXED_UUID);
+    });
+
+    it('makeStreamingRequestToDownstream synthesises a UUID when requestId is absent', async () => {
+      nock(downstreamUrl).post(downstreamPath).reply(200, {});
+
+      await makeStreamingRequestToDownstream({
+        url: fullDownstreamUrl,
+        method: 'POST',
+        headers: {},
+      });
+
+      const [logContext] = (logger.debug as jest.Mock).mock.calls[0];
+      expect(typeof logContext.requestId).toBe('string');
+      expect(logContext.requestId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      );
+    });
+  });
 });

--- a/test/unit/plugins/pluginManager.test.ts
+++ b/test/unit/plugins/pluginManager.test.ts
@@ -208,6 +208,7 @@ describe('Plugin Manager', () => {
         headers: { myHeader: 'my_value' },
         method: 'POST',
         body: { myField: 'my field value' },
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       };
       const requestBodyDetailsOriginal = Object.assign({}, requestDetails.body);
       const expectedRequestBody = Object.assign({}, requestDetails.body);
@@ -278,6 +279,7 @@ describe('Plugin Manager', () => {
         headers: { myHeader: 'my_value' },
         method: 'POST',
         body: { myField: 'my field value' },
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       };
       const requestBodyDetailsOriginal = Object.assign({}, requestDetails.body);
       const expectedRequestBody = Object.assign({}, requestDetails.body);
@@ -332,6 +334,7 @@ describe('Plugin Manager', () => {
         headers: { myHeader: 'my_value' },
         method: 'POST',
         body: { myField: 'my field value' },
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       };
       const requestBodyDetailsOriginal = Object.assign({}, requestDetails.body);
       const request = await runPreRequestPlugins(
@@ -390,6 +393,7 @@ describe('Plugin Manager', () => {
         headers: { myHeader: 'my_value' },
         method: 'POST',
         body: { myField: 'my field value' },
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       };
       const requestBodyDetailsOriginal = Object.assign({}, requestDetails.body);
       const expectedRequestBody = Object.assign({}, requestDetails.body);
@@ -408,6 +412,7 @@ describe('Plugin Manager', () => {
         headers: { myHeader: 'my_value' },
         method: 'POST',
         body: { myField: 'my field value' },
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       };
       const requestBodyDetailsOriginal2 = Object.assign(
         {},
@@ -489,6 +494,7 @@ describe('Plugin Manager', () => {
         headers: { myHeader: 'my_value' },
         method: 'POST',
         body: { myField: 'my field value' },
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       };
       const requestBodyDetailsOriginal = Object.assign({}, requestDetails.body);
       const expectedRequestBody = Object.assign({}, requestDetails.body);
@@ -507,6 +513,7 @@ describe('Plugin Manager', () => {
         headers: { myHeader: 'my_value' },
         method: 'POST',
         body: { myField: 'my field value' },
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       };
       const requestBodyDetailsOriginal2 = Object.assign(
         {},
@@ -525,6 +532,7 @@ describe('Plugin Manager', () => {
         headers: { myHeader: 'my_value' },
         method: 'POST',
         body: { myField: 'my field value' },
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       };
       const requestBodyDetailsOriginal3 = Object.assign(
         {},

--- a/test/unit/relay-response-body-client.test.ts
+++ b/test/unit/relay-response-body-client.test.ts
@@ -137,6 +137,7 @@ describe('body relay', () => {
         // @ts-ignore
         body: Buffer.from(JSON.stringify(body)),
         headers: {},
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
@@ -203,6 +204,7 @@ describe('body relay', () => {
         // @ts-ignore
         body: Buffer.from(JSON.stringify(body)),
         headers: {},
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
@@ -268,6 +270,7 @@ describe('body relay', () => {
         // @ts-ignore
         body: Buffer.from(JSON.stringify(body)),
         headers: {},
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);

--- a/test/unit/relay-response-body-form-url-encoded.test.ts
+++ b/test/unit/relay-response-body-form-url-encoded.test.ts
@@ -125,6 +125,7 @@ describe('body relay', () => {
         // @ts-ignore
         body: Buffer.from(JSON.stringify(body)),
         headers,
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
@@ -184,6 +185,7 @@ describe('body relay', () => {
         // @ts-ignore
         body: Buffer.from(JSON.stringify(body)),
         headers: {},
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
@@ -245,6 +247,7 @@ describe('body relay', () => {
         // @ts-ignore
         body: Buffer.from(JSON.stringify(body)),
         headers: {},
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
@@ -306,6 +309,7 @@ describe('body relay', () => {
         // @ts-ignore
         body: Buffer.from(JSON.stringify(body)),
         headers,
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);

--- a/test/unit/relay-response-body-universal-form-url-encoded.test.ts
+++ b/test/unit/relay-response-body-universal-form-url-encoded.test.ts
@@ -132,6 +132,7 @@ describe('body relay', () => {
         // @ts-ignore
         body: Buffer.from(JSON.stringify(body)),
         headers: headers,
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
@@ -204,6 +205,7 @@ describe('body relay', () => {
         // @ts-ignore
         body: Buffer.from(JSON.stringify(body)),
         headers: {},
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
@@ -271,6 +273,7 @@ describe('body relay', () => {
         // @ts-ignore
         body: Buffer.from(JSON.stringify(body)),
         headers: headers,
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);

--- a/test/unit/relay-response-body-universal.test.ts
+++ b/test/unit/relay-response-body-universal.test.ts
@@ -149,6 +149,7 @@ describe('body relay', () => {
 
         body: Buffer.from(JSON.stringify(body)),
         headers: {},
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       (responseCallback) => {
         response = responseCallback;
@@ -224,6 +225,7 @@ describe('body relay', () => {
 
         body: Buffer.from(JSON.stringify(body)),
         headers: {},
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       (responseCallback) => {
         response = responseCallback;

--- a/test/unit/relay-response-body.test.ts
+++ b/test/unit/relay-response-body.test.ts
@@ -131,6 +131,7 @@ describe('body relay', () => {
         // @ts-ignore
         body: Buffer.from(JSON.stringify(body)),
         headers: {},
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
@@ -194,6 +195,7 @@ describe('body relay', () => {
         // @ts-ignore
         body: Buffer.from(JSON.stringify(body)),
         headers: {},
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
@@ -256,6 +258,7 @@ describe('body relay', () => {
         // @ts-ignore
         body: Buffer.from(JSON.stringify(body)),
         headers: {},
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);

--- a/test/unit/relay-response-headers-form-url-headers.test.ts
+++ b/test/unit/relay-response-headers-form-url-headers.test.ts
@@ -118,6 +118,7 @@ describe('header relay', () => {
         url: '/',
         method: 'GET',
         headers: headers,
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
@@ -179,6 +180,7 @@ describe('header relay', () => {
         url: '/',
         method: 'GET',
         headers: headers,
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
@@ -240,6 +242,7 @@ describe('header relay', () => {
         url: '/',
         method: 'GET',
         headers: headers,
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
@@ -298,6 +301,7 @@ describe('header relay', () => {
         url: '/',
         method: 'GET',
         headers: headers,
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);

--- a/test/unit/relay-response-headers-universal-form-url-headers.test.ts
+++ b/test/unit/relay-response-headers-universal-form-url-headers.test.ts
@@ -126,6 +126,7 @@ describe('header relay', () => {
         url: '/',
         method: 'GET',
         headers: headers,
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
@@ -201,6 +202,7 @@ describe('header relay', () => {
         url: '/',
         method: 'GET',
         headers: headers,
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);

--- a/test/unit/relay-response-headers-universal.test.ts
+++ b/test/unit/relay-response-headers-universal.test.ts
@@ -124,6 +124,7 @@ describe('header relay', () => {
         url: '/',
         method: 'GET',
         headers: headers,
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
@@ -194,6 +195,7 @@ describe('header relay', () => {
         url: '/',
         method: 'GET',
         headers: headers,
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);

--- a/test/unit/relay-response-headers.test.ts
+++ b/test/unit/relay-response-headers.test.ts
@@ -118,6 +118,7 @@ describe('header relay', () => {
         url: '/',
         method: 'GET',
         headers: headers,
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);
@@ -179,6 +180,7 @@ describe('header relay', () => {
         url: '/',
         method: 'GET',
         headers: headers,
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       () => {
         expect(makeRequestToDownstream).toHaveBeenCalledTimes(1);

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -7,6 +7,7 @@ describe('utils', () => {
       url: 'dummy',
       headers: {},
       method: 'GET',
+      requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
     };
     expect(computeContentLength(dummyReq)).toEqual(0);
   });
@@ -17,6 +18,7 @@ describe('utils', () => {
       headers: {},
       method: 'POST',
       body: '1234567890',
+      requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
     };
     expect(computeContentLength(dummyReq)).toEqual(10);
   });
@@ -27,6 +29,7 @@ describe('utils', () => {
       headers: {},
       method: 'POST',
       body: '1234567890-1234567890',
+      requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
     };
     expect(computeContentLength(dummyReq)).toEqual(21);
   });
@@ -36,6 +39,7 @@ describe('utils', () => {
       headers: {},
       method: 'POST',
       body: '1234567890–1234567890',
+      requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
     };
     expect(computeContentLength(dummyReq)).toEqual(23);
   });


### PR DESCRIPTION
## Summary

Direct reads of \`snyk-request-id\` from header bags were scattered across 14 files, creating several problems: easy to miss sites when tracing a request, silent empty-string fallbacks on paths where the header wasn't propagated, and no single place to reason about where the ID comes from.

This PR centralises the concern:

- \`RequestPayload\` gains a required \`requestId: string\` field, populated by the WS backfill in \`forwardWebsocketRequest\` alongside the \`snyk-request-id\` header
- \`PostFilterPreparedRequest\` gains an optional \`requestId?: string\` field, populated explicitly from \`payload.requestId\` on the proxy path
- All direct \`headers['snyk-request-id']\` reads in request handlers and filter logic are replaced with the typed accessor
- Both \`websocket.send\` call-sites in \`clientRequestHelpers\` now include \`requestId\` in the payload so \`forwardWebsocketRequest\` receives it directly rather than synthesising a fresh UUID
- The three \`make*RequestToDownstream\` functions resolve \`requestId\` (inherited or synthesised) and write it into the outgoing \`snyk-request-id\` header — so every outbound HTTP call carries the header, including self-initiated broker requests (auth, health checks, config fetches) that previously had no request ID at all
- \`BrokerWorkload\` log context now uses \`payload.requestId\` as the authoritative source rather than re-reading from the header spread, eliminating a potential divergence if headers are mutated downstream
- Logging gaps fixed: \`filtersAsync\` rule-match debug, \`broker-middleware\` broker-type warn (was nested under an extra key), two \`httpRequestHandler\` debug calls, and three \`connectionStatusHandler\` log calls (debug, error, warn) were all missing \`requestId\` despite having it in scope
- Comments added at the three legitimate direct header read sites explaining why the typed accessor cannot be used (Primus authorize callback runs pre-middleware, service-channel WS messages have no Express request, outbound API response read has no typed accessor on the response type)

Three sites that cannot use the accessor are left as direct header reads with explanatory comments.

## Test plan

- [ ] All unit test suites pass (\`npm run test:unit\`)
- [ ] Typecheck passes (\`npx tsc --noEmit\`)
- [ ] New tests cover: \`payload.requestId\` backfill in \`forwardWebsocketRequest\`, \`requestId\` propagation through \`prepareRequest\`, typed accessor usage (including UUID synthesis fallback) in all three \`make*RequestToDownstream\` functions, \`requestId\` field in WS payloads sent from \`clientRequestHelpers\`, and \`payload.requestId\` as authoritative source in \`BrokerWorkload\` log context
- [ ] Post-refactor grep confirms only the expected cannot-refactor read sites remain: \`grep -rn "headers\['snyk-request-id'\]" lib/ --include="*.ts"\`