### PR TITLE
fix(semantic-release): use npm publish via exec plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -397,8 +397,14 @@ jobs:
           name: Release to GitHub
           no_output_timeout: 20m
           command: |
-            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
             npm install --save-exact --save-dev semantic-release@25.0.3 @semantic-release/exec@7.1.0 pkg@5.8.1
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            # following lines can be removed after solving https://github.com/semantic-release/npm/issues/1121
+            export NPM_TOKEN=$(curl -fsS -X POST \
+              -H "Authorization: Bearer $NPM_ID_TOKEN" \
+              "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/snyk-broker" \
+              | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>console.log(JSON.parse(d).token))')
+            echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
             npx semantic-release
 
 workflows:
@@ -482,7 +488,6 @@ workflows:
           name: Release to GitHub and NPM
           context:
             - github-release
-            - nodejs-install
             - snyk-bot-slack
             - team-hybrid-snyk
           requires:

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -38,7 +38,8 @@ module.exports = {
           'mkdir -p sboms && npx snyk sbom --format spdx2.3+json > sboms/broker.sbom.spdx.json',
       },
     ],
-    '@semantic-release/npm',
+    ['@semantic-release/npm', { npmPublish: false }],
+    ['@semantic-release/exec', { publishCmd: 'npm publish' }],
     [
       '@semantic-release/github',
       {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR fixes the issue with failed release process.

`semantic-release/npm` plugin doesn't support token exchange at the moment for CirclCI, so we have to do it on own own in circleci config and save NPM_TOKEN into ~/.npmrc.

- https://github.com/semantic-release/npm/issues/1121
- https://github.com/semantic-release/npm/blob/38b0466f89ec7983f01824a55203e77237c77697/lib/trusted-publishing/token-exchange.js#L60-L70
