### PR TITLE
fix(circleci): revert circleci trusted publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -483,6 +483,7 @@ workflows:
           context:
             - github-release
             - snyk-bot-slack
+            - team-access-npm-release
             - team-hybrid-snyk
           requires:
             - Snyk Security Scans

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -38,8 +38,7 @@ module.exports = {
           'mkdir -p sboms && npx snyk sbom --format spdx2.3+json > sboms/broker.sbom.spdx.json',
       },
     ],
-    ['@semantic-release/npm', { npmPublish: false }],
-    ['@semantic-release/exec', { publishCmd: 'npm publish' }],
+    '@semantic-release/npm',
     [
       '@semantic-release/github',
       {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR reverts CircleCI trusted publishing back to granular access tokens.