### PR TITLE
chore(docker): install libatomic1 package

### DIFF
--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -24,6 +24,7 @@ RUN <<EOF
     apt install --assume-yes \
       curl \
       gpg \
+      libatomic1 \
       xz-utils
     # install node
     ARCH= && dpkgArch="$(dpkg --print-architecture)"


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR adds `libatomic.so.1` package for Ubuntu-based images.

Node.js 25+ introduced a runtime dependency on libatomic.so.1 (via V8 atomic intrinsics) that is absent by default on Debian/Ubuntu systems.

https://github.com/nodejs/node/blob/v25.2.0/BUILDING.md#official-binary-platforms-and-toolchains
