### PR TITLE
fix: add missing user filter rules for ghsa and ghca [ACC-3324]

### DIFF
--- a/defaultFilters/github-cloud-app.json
+++ b/defaultFilters/github-cloud-app.json
@@ -330,6 +330,36 @@
         }
       },
       {
+        "//": "list the user's info, and validate their credentials",
+        "method": "GET",
+        "path": "/user",
+        "origin": "https://${GITHUB_API}",
+        "auth": {
+          "scheme": "bearer",
+          "token": "${GHA_ACCESS_TOKEN}"
+        }
+      },
+      {
+        "//": "list the user's orgs",
+        "method": "GET",
+        "path": "/user/orgs",
+        "origin": "https://${GITHUB_API}",
+        "auth": {
+          "scheme": "bearer",
+          "token": "${GHA_ACCESS_TOKEN}"
+        }
+      },
+      {
+        "//": "list the logged in user's repos",
+        "method": "GET",
+        "path": "/user/repos",
+        "origin": "https://${GITHUB_API}",
+        "auth": {
+          "scheme": "bearer",
+          "token": "${GHA_ACCESS_TOKEN}"
+        }
+      },
+      {
         "//": "list a user's repos",
         "method": "GET",
         "path": "/users/:username/repos",

--- a/defaultFilters/github-server-app.json
+++ b/defaultFilters/github-server-app.json
@@ -330,9 +330,29 @@
         }
       },
       {
+        "//": "list the user's info, and validate their credentials",
+        "method": "GET",
+        "path": "/user",
+        "origin": "https://${GITHUB_API}",
+        "auth": {
+          "scheme": "bearer",
+          "token": "${GHA_ACCESS_TOKEN}"
+        }
+      },
+      {
         "//": "list the user's orgs",
         "method": "GET",
         "path": "/user/orgs",
+        "origin": "https://${GITHUB_API}",
+        "auth": {
+          "scheme": "bearer",
+          "token": "${GHA_ACCESS_TOKEN}"
+        }
+      },
+      {
+        "//": "list the logged in user's repos",
+        "method": "GET",
+        "path": "/user/repos",
         "origin": "https://${GITHUB_API}",
         "auth": {
           "scheme": "bearer",

--- a/defaultFilters/github-server-app.json
+++ b/defaultFilters/github-server-app.json
@@ -330,6 +330,16 @@
         }
       },
       {
+        "//": "list the user's orgs",
+        "method": "GET",
+        "path": "/user/orgs",
+        "origin": "https://${GITHUB_API}",
+        "auth": {
+          "scheme": "bearer",
+          "token": "${GHA_ACCESS_TOKEN}"
+        }
+      },
+      {
         "//": "list a user's repos",
         "method": "GET",
         "path": "/users/:username/repos",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adds missing rules for GHSA and GHCA:
- `/user`
- `/user/repos`
- `/user/orgs`
