### PR TITLE
fix(deps): drop uuid@8.3.2 dependency in favor of node:crypto

### DIFF
--- a/lib/hybrid-sdk/client/checks/config/brokerTokenCheck.ts
+++ b/lib/hybrid-sdk/client/checks/config/brokerTokenCheck.ts
@@ -1,7 +1,7 @@
 import { log as logger } from '../../../../logs/logger';
 import type { CheckOptions, CheckResult } from '../types';
 import type { Config } from '../../types/config';
-import { validate } from 'uuid';
+import { validate } from '../../../common/utils/uuid';
 
 export async function validateBrokerToken(
   checkOptions: CheckOptions,

--- a/lib/hybrid-sdk/client/index.ts
+++ b/lib/hybrid-sdk/client/index.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
+import { uuidv4 } from '../common/utils/uuid';
 import { createWebSocket } from './socket';
 import { log as logger } from '../../logs/logger';
 import { forwardHttpRequest } from '../common/connectionToWorkloadInterface/forwardHttpRequest';

--- a/lib/hybrid-sdk/client/socket.ts
+++ b/lib/hybrid-sdk/client/socket.ts
@@ -1,7 +1,7 @@
 // import '../common/http/patch-https-request-for-proxying';
 
 import Primus from 'primus';
-import { v4 as uuid } from 'uuid';
+import { uuidv4 } from '../common/utils/uuid';
 import { log as logger } from '../../logs/logger';
 import primusEmitter from 'primus-emitter';
 import {
@@ -170,7 +170,7 @@ export const createWebSocket = (
     timeout: parseInt(localClientOps.config.socketConnectTimeout) || 10000,
   };
 
-  let currentRequestId = uuid();
+  let currentRequestId = uuidv4();
   const buildExtraHeaders = (requestId: string): Record<string, string> => {
     const headers: Record<string, string> = {
       'x-snyk-broker-client-id': identifyingMetadata.clientId,
@@ -321,7 +321,7 @@ export const createWebSocket = (
     metricsClient.setConnectionState('reconnecting', identifyingMetadata.role);
     metricsClient.recordReconnect();
 
-    currentRequestId = uuid();
+    currentRequestId = uuidv4();
     websocket.transport.extraHeaders = buildExtraHeaders(currentRequestId);
     reconnectScheduledHandler(opts, currentRequestId);
   });

--- a/lib/hybrid-sdk/clientRequestHelpers.ts
+++ b/lib/hybrid-sdk/clientRequestHelpers.ts
@@ -9,7 +9,7 @@ import {
 } from './common/utils/metrics';
 import undefsafe from 'undefsafe';
 import { ExtendedLogContext } from './common/types/log';
-import { v4 as uuid } from 'uuid';
+import { uuidv4 } from './common/utils/uuid';
 import stream from 'stream';
 import { streamsStore } from './http/server-post-stream-handler';
 import { maskToken } from './common/utils/token';
@@ -57,7 +57,7 @@ export class HybridClientRequestHandler {
   }
 
   private makeWebsocketRequestWithStreamingResponse() {
-    const streamingID = uuid();
+    const streamingID = uuidv4();
     const streamBuffer = new stream.PassThrough({ highWaterMark: 1048576 });
     streamBuffer.on('error', (error) => {
       // This may be a duplicate error, as the most likely cause of this is the POST handler calling destroy.

--- a/lib/hybrid-sdk/common/utils/uuid.ts
+++ b/lib/hybrid-sdk/common/utils/uuid.ts
@@ -1,4 +1,17 @@
-import { validate, NIL } from 'uuid';
+import { randomUUID } from 'node:crypto';
+
+/** The nil UUID (all-zeros) as a sentinel meaning "no value". */
+export const NIL = '00000000-0000-0000-0000-000000000000';
+
+const UUID_REGEX =
+  /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
+
+/** Generates a random version 4 UUID. */
+export const uuidv4 = (): string => randomUUID();
+
+/** Returns true when `value` is a valid UUID string (versions 1-5 or nil). */
+export const validate = (value: unknown): boolean =>
+  typeof value === 'string' && UUID_REGEX.test(value);
 
 /**
  * Returns true when `value` is a non-nil RFC 4122 UUID string.
@@ -7,4 +20,4 @@ import { validate, NIL } from 'uuid';
  * sentinel meaning "no value", not as an actual identifier.
  */
 export const isUUID = (value: unknown): value is string =>
-  typeof value === 'string' && validate(value) && value !== NIL;
+  validate(value) && value !== NIL;

--- a/lib/hybrid-sdk/server/infra/dispatcher.ts
+++ b/lib/hybrid-sdk/server/infra/dispatcher.ts
@@ -2,7 +2,7 @@ import { hashToken } from '../../common/utils/token';
 import { log as logger } from '../../../logs/logger';
 import { getConfig } from '../../common/config/config';
 
-import { v4 as uuid } from 'uuid';
+import { uuidv4 } from '../../common/utils/uuid';
 import { axiosInstance } from '../../http/axios';
 
 class DispatcherClient {
@@ -92,7 +92,7 @@ class DispatcherClient {
   }
 
   async #makeRequest(logContext, url, method, requestBody?, cb?) {
-    const requestId = uuid();
+    const requestId = uuidv4();
     // version *must* be provided
     const urlWithVersion = new URL(url);
     urlWithVersion.searchParams.append('version', this.#version);

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,8 +45,7 @@
         "snyk-config": "5.3.0",
         "then-fs": "^2.0.0",
         "tunnel": "0.0.6",
-        "undefsafe": "^2.0.2",
-        "uuid": "8.3.2"
+        "undefsafe": "^2.0.2"
       },
       "bin": {
         "broker": "dist/cli/index.js",
@@ -8782,14 +8781,6 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {

--- a/package.json
+++ b/package.json
@@ -117,8 +117,7 @@
     "snyk-config": "5.3.0",
     "then-fs": "^2.0.0",
     "tunnel": "0.0.6",
-    "undefsafe": "^2.0.2",
-    "uuid": "8.3.2"
+    "undefsafe": "^2.0.2"
   },
   "repository": {
     "type": "git",

--- a/test/unit/lib/hybrid-sdk/http/downstream-post-stream-to-server.test.ts
+++ b/test/unit/lib/hybrid-sdk/http/downstream-post-stream-to-server.test.ts
@@ -1,7 +1,7 @@
 import http from 'http';
 import { AddressInfo, Socket } from 'net';
 import nock from 'nock';
-import { v4 as uuidv4 } from 'uuid';
+import { uuidv4 } from '../../../../../lib/hybrid-sdk/common/utils/uuid';
 
 import { BrokerServerPostResponseHandler } from '../../../../../lib/hybrid-sdk/http/downstream-post-stream-to-server';
 import {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR drops usage of uuid@8.3.2 package in favor of builtin `node:crypto`, because we use only `v4`, `validate`, and `NIL`.

The constant name is normalized to use in the same way across the project: `uuidv4`.

`uuid@8.3.2` is flagged by GHSA-w5hq-g745-h8pq (moderate). We don't hit the vulnerable path (v3/v5/v6 + buf), but it's noise in SCA scans. Node >=24 covers `randomUUID` natively, so the package is unnecessary.