### PR TITLE
fix: gracefully handle broker client reconnect handshake window

### DIFF
--- a/lib/hybrid-sdk/client/checks/config/brokerClientUrlCheck.ts
+++ b/lib/hybrid-sdk/client/checks/config/brokerClientUrlCheck.ts
@@ -9,7 +9,7 @@ import {
   HttpResponse,
   makeSingleRawRequestToDownstream,
 } from '../../../http/request';
-import { retry } from '../../retry/exponential-backoff';
+import { retry } from '../../../http/exponential-backoff';
 
 export async function validateBrokerClientUrl(
   checkOptions: CheckOptions,

--- a/lib/hybrid-sdk/client/checks/http/http-executor.ts
+++ b/lib/hybrid-sdk/client/checks/http/http-executor.ts
@@ -1,5 +1,5 @@
 import { log as logger } from '../../../../logs/logger';
-import { retry } from '../../retry/exponential-backoff';
+import { retry } from '../../../http/exponential-backoff';
 import type { CheckId, CheckResult, CheckStatus } from '../types';
 import {
   HttpResponse,

--- a/lib/hybrid-sdk/http/exponential-backoff.ts
+++ b/lib/hybrid-sdk/http/exponential-backoff.ts
@@ -1,4 +1,4 @@
-import { log as logger } from '../../../logs/logger';
+import { log as logger } from '../../logs/logger';
 
 export const retry = async <T>(
   fn: () => Promise<T> | T,

--- a/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.ts
+++ b/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.ts
@@ -122,7 +122,7 @@ export const overloadHttpRequestWithConnectionDetailsMiddleware = async (
   } catch {
     // Retries exhausted while a handshake was still in progress — a genuinely
     // slow or stuck (re)connect. Transient, so signal it is safe to retry.
-    logger.warn(
+    logger.error(
       { desensitizedToken, requestId },
       'No ready connection after retries (client handshake still in progress).',
     );
@@ -135,7 +135,7 @@ export const overloadHttpRequestWithConnectionDetailsMiddleware = async (
     // Connections are present but missing required metadata (e.g. a legacy
     // client that never sends capabilities) — permanent for this client, so keep
     // the fast-fail 400 to avoid turning these into retry storms.
-    logger.warn(
+    logger.error(
       { desensitizedToken, requestId },
       'Connection metadata is missing required properties (version or capabilities).',
     );

--- a/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.ts
+++ b/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.ts
@@ -9,13 +9,7 @@ import { PostFilterPreparedRequest } from '../../../broker-workload/prepareReque
 import { makeStreamingRequestToDownstream } from '../../http/request';
 import { retry } from '../../http/exponential-backoff';
 
-// When no connection is ready yet, a client may still be completing its
-// handshake during a (re)connect. Retry a few times with exponential backoff to
-// let it become ready and serve the request transparently, rather than failing
-// back to the caller (bare git does not retry). Tunable via env for ops.
-const CONNECTION_READY_MAX_RETRIES = Number(
-  process.env.BROKER_CONNECTION_READY_MAX_RETRIES ?? 4,
-);
+const CONNECTION_READY_MAX_RETRIES = 4;
 
 export const overloadHttpRequestWithConnectionDetailsMiddleware = async (
   req: Request,

--- a/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.ts
+++ b/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.ts
@@ -1,12 +1,21 @@
 import { NextFunction, Request, Response } from 'express';
 import { log as logger } from '../../../logs/logger';
 import { getDesensitizedToken } from '../utils/token';
-import { getSocketConnections } from '../socket';
+import { ClientSocket, getSocketConnections } from '../socket';
 import { incrementHttpRequestsTotal } from '../../common/utils/metrics';
 import { hostname } from 'node:os';
 import { URL, URLSearchParams } from 'node:url';
 import { PostFilterPreparedRequest } from '../../../broker-workload/prepareRequest';
 import { makeStreamingRequestToDownstream } from '../../http/request';
+import { retry } from '../../http/exponential-backoff';
+
+// When no connection is ready yet, a client may still be completing its
+// handshake during a (re)connect. Retry a few times with exponential backoff to
+// let it become ready and serve the request transparently, rather than failing
+// back to the caller (bare git does not retry). Tunable via env for ops.
+const CONNECTION_READY_MAX_RETRIES = Number(
+  process.env.BROKER_CONNECTION_READY_MAX_RETRIES ?? 4,
+);
 
 export const overloadHttpRequestWithConnectionDetailsMiddleware = async (
   req: Request,
@@ -72,7 +81,7 @@ export const overloadHttpRequestWithConnectionDetailsMiddleware = async (
       return res.status(404).json({ ok: false });
     }
   }
-  // Grab a first (newest) client from the pool
+  // Grab the pool of connections for this token
   const connection = connections.get(token)!;
   // Make sure a connection actually exists before proceeding
   if (connection.length === 0) {
@@ -83,9 +92,49 @@ export const overloadHttpRequestWithConnectionDetailsMiddleware = async (
     res.setHeader('x-broker-failure', 'no-connection');
     return res.status(404).json({ ok: false });
   }
-  // Todo: We may not always want to select the first client from the pool
-  const client = connection[0];
-  if (!client.metadata?.version || !client.metadata?.capabilities) {
+  const isReady = (c: ClientSocket): boolean =>
+    Boolean(c.socket && c.metadata?.version && c.metadata?.capabilities);
+
+  // The pool is newest-first, so find() returns the newest fully-ready
+  // connection. This keeps HA clients immune to reconnect churn, which will
+  // briefly create a not-yet-ready connection. If none is ready yet but a connection is still
+  // completing its handshake, retry with exponential backoff. A permanently-incomplete pool
+  // won't become ready, so return without retrying.
+  let client: ClientSocket | undefined;
+  try {
+    client = await retry<ClientSocket | undefined>(
+      () => {
+        const pool = connections.get(token) ?? [];
+        const ready = pool.find(isReady);
+        if (ready) {
+          return ready;
+        }
+        if (pool.some((c) => !c.socket || !c.metadata)) {
+          throw new Error('client handshake in progress');
+        }
+        return undefined;
+      },
+      {
+        retries: CONNECTION_READY_MAX_RETRIES,
+        operation: 'await-ready-broker-connection',
+      },
+    );
+  } catch {
+    // Retries exhausted while a handshake was still in progress — a genuinely
+    // slow or stuck (re)connect. Transient, so signal it is safe to retry.
+    logger.warn(
+      { desensitizedToken, requestId },
+      'No ready connection after retries (client handshake still in progress).',
+    );
+    res.setHeader('x-broker-failure', 'connection-not-ready');
+    res.setHeader('Retry-After', '1');
+    return res.status(503).json({ ok: false });
+  }
+
+  if (!client) {
+    // Connections are present but missing required metadata (e.g. a legacy
+    // client that never sends capabilities) — permanent for this client, so keep
+    // the fast-fail 400 to avoid turning these into retry storms.
     logger.warn(
       { desensitizedToken, requestId },
       'Connection metadata is missing required properties (version or capabilities).',

--- a/test/unit/client/checks/http/http-executor.error-handling.test.ts
+++ b/test/unit/client/checks/http/http-executor.error-handling.test.ts
@@ -1,9 +1,6 @@
-jest.mock(
-  '../../../../../lib/hybrid-sdk/client/retry/exponential-backoff',
-  () => ({
-    retry: async <T>(fn: () => Promise<T> | T) => fn(),
-  }),
-);
+jest.mock('../../../../../lib/hybrid-sdk/http/exponential-backoff', () => ({
+  retry: async <T>(fn: () => Promise<T> | T) => fn(),
+}));
 
 // Replace the downstream HTTP call with a jest.fn we can drive per test.
 jest.mock('../../../../../lib/hybrid-sdk/http/request', () => ({

--- a/test/unit/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.test.ts
+++ b/test/unit/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.test.ts
@@ -15,6 +15,10 @@ describe('overloadHttpRequestWithConnectionDetailsMiddleware', () => {
     next = jest.fn();
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('should return 404 if no connections are found for the token', async () => {
     mockedGetSocketConnections.mockReturnValue(new Map());
     const req = httpMocks.createRequest({
@@ -31,14 +35,80 @@ describe('overloadHttpRequestWithConnectionDetailsMiddleware', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it('should return 400 if connection metadata is missing', async () => {
+  it('should return 503 after exhausting retries if the connection never finishes its handshake', async () => {
+    jest.useFakeTimers();
     const mockConnections = new Map();
     mockConnections.set('test-token', [
       {
-        socket: {},
+        // mid-handshake: seated but not yet identified
         socketVersion: '1.0',
-        // metadata is intentionally missing
+        // socket and metadata are intentionally missing, and never arrive
       },
+    ]);
+    mockedGetSocketConnections.mockReturnValue(mockConnections);
+    const req = httpMocks.createRequest({
+      params: { token: 'test-token' },
+      url: '/broker/test-token/some/path',
+    });
+    const res = httpMocks.createResponse();
+
+    const pending = overloadHttpRequestWithConnectionDetailsMiddleware(
+      req,
+      res,
+      next,
+    );
+    // Drive all the backoff sleeps to completion.
+    await jest.advanceTimersByTimeAsync(5000);
+    await pending;
+
+    expect(res.statusCode).toBe(503);
+    expect(res._getJSONData()).toEqual({ ok: false });
+    expect(res.getHeader('x-broker-failure')).toBe('connection-not-ready');
+    expect(res.getHeader('Retry-After')).toBe('1');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should retry and serve the request once the connection becomes ready', async () => {
+    jest.useFakeTimers();
+    const mockConnections = new Map();
+    // Starts mid-handshake; identify() completes after the first backoff.
+    const entry: Record<string, unknown> = { socketVersion: '1.0' };
+    mockConnections.set('test-token', [entry]);
+    mockedGetSocketConnections.mockReturnValue(mockConnections);
+    const req = httpMocks.createRequest({
+      params: { token: 'test-token' },
+      url: '/broker/test-token/some/path',
+    });
+    const res = httpMocks.createResponse();
+
+    const pending = overloadHttpRequestWithConnectionDetailsMiddleware(
+      req,
+      res,
+      next,
+    );
+    // Simulate identify() merging in the socket + metadata mid-retry.
+    entry.socket = {};
+    entry.metadata = { version: '1.2.3', capabilities: ['test'] };
+    await jest.advanceTimersByTimeAsync(100);
+    await pending;
+
+    expect(res.statusCode).toBe(200);
+    expect(next).toHaveBeenCalled();
+    expect(res.locals.websocket).toEqual(entry.socket);
+    expect(res.locals.clientVersion).toEqual('1.2.3');
+  });
+
+  it('should select the ready connection over an authorize-only entry seated ahead of it', async () => {
+    const mockConnections = new Map();
+    const readyConnection = {
+      socket: {},
+      socketVersion: '1.0',
+      metadata: { version: '1.2.3', capabilities: ['test'] },
+    };
+    mockConnections.set('test-token', [
+      // newest-first: an authorize-only entry sits at index 0 during reconnect
+      { socketVersion: '1.0' },
+      readyConnection,
     ]);
     mockedGetSocketConnections.mockReturnValue(mockConnections);
     const req = httpMocks.createRequest({
@@ -49,10 +119,10 @@ describe('overloadHttpRequestWithConnectionDetailsMiddleware', () => {
 
     await overloadHttpRequestWithConnectionDetailsMiddleware(req, res, next);
 
-    expect(res.statusCode).toBe(400);
-    expect(res._getJSONData()).toEqual({ ok: false });
-    expect(res.getHeader('x-broker-failure')).toBe('bad-request');
-    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+    expect(next).toHaveBeenCalled();
+    expect(res.locals.websocket).toEqual(readyConnection.socket);
+    expect(res.locals.clientVersion).toEqual(readyConnection.metadata.version);
   });
 
   it('should return 400 if capabilities are missing from metadata', async () => {


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

httpRequestHandler now selects the newest ready connection instead of connection[0], retrying mid-handshake windows with exponential backoff so reconnect churn no longer returns a hard 400 (stuck handshakes get a retriable 503; legacy incomplete clients keep the fast-fail 400). The shared retry helper moves from `client` to `http` alongside its consumers.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
