### PR TITLE
feat: add typed broker error codes for telemetry

### DIFF
--- a/lib/broker-workload/clientLocalRequests.ts
+++ b/lib/broker-workload/clientLocalRequests.ts
@@ -10,6 +10,10 @@ import {
   WorkloadType,
 } from '../hybrid-sdk/workloadFactory';
 import { ExtendedLogContext } from '../hybrid-sdk/common/types/log';
+import {
+  BROKER_ERROR_CODES,
+  statusForErrorCode,
+} from '../hybrid-sdk/common/types/errorCodes';
 import { incrementHttpRequestsTotal } from '../hybrid-sdk/common/utils/metrics';
 import type { Client as MetricsClient } from '../hybrid-sdk/client/metrics/client';
 import { NoopClient } from '../hybrid-sdk/client/metrics/noopClient';
@@ -74,8 +78,13 @@ export class BrokerClientRequestWorkload extends Workload<WorkloadType.localClie
       logger.warn(hybridClientRequestHandler.logContext, reason);
       // TODO: respect request headers, block according to content-type
       return this.res
-        .status(401)
-        .send({ message: 'blocked', reason, url: this.req.url });
+        .status(statusForErrorCode(BROKER_ERROR_CODES.FILTER_BLOCKED))
+        .send({
+          code: BROKER_ERROR_CODES.FILTER_BLOCKED,
+          message: 'blocked',
+          reason,
+          url: this.req.url,
+        });
     } else {
       hybridClientRequestHandler.makeRequest(
         getInterpolatedRequest(

--- a/lib/broker-workload/websocketRequests.ts
+++ b/lib/broker-workload/websocketRequests.ts
@@ -20,6 +20,11 @@ import {
 import { prepareRequest } from './prepareRequest';
 import { ExtendedLogContext } from '../hybrid-sdk/common/types/log';
 import {
+  BROKER_ERROR_CODES,
+  classifyDownstreamError,
+  statusForErrorCode,
+} from '../hybrid-sdk/common/types/errorCodes';
+import {
   incrementWebSocketRequestsTotal,
   incrementHttpRequestsTotal,
 } from '../hybrid-sdk/common/utils/metrics';
@@ -135,10 +140,11 @@ export class BrokerWorkload extends Workload<WorkloadType.remoteServer> {
         '[Websocket Flow][Blocked Request] Does not match any accept rule';
       logContext.error = 'Blocked by filter rules';
       logger.warn(logContext, reason);
-      // TODO: need to type the response object
       return responseHandler.sendResponse({
-        status: 401,
+        status: statusForErrorCode(BROKER_ERROR_CODES.FILTER_BLOCKED),
+        errorType: BROKER_ERROR_CODES.FILTER_BLOCKED,
         body: {
+          code: BROKER_ERROR_CODES.FILTER_BLOCKED,
           message: 'blocked',
           reason,
           url: payload.url,
@@ -216,6 +222,12 @@ export class BrokerWorkload extends Workload<WorkloadType.remoteServer> {
               },
               '[Downstream] Caught error making streaming request to downstream ',
             );
+            const code = classifyDownstreamError(e);
+            return responseHandler.sendResponse({
+              status: statusForErrorCode(code),
+              errorType: code,
+              body: { code, message: (e as Error)?.message },
+            });
           }
         } else {
           // here if request against server had header x-broker-ws-response:true
@@ -252,9 +264,11 @@ export class BrokerWorkload extends Workload<WorkloadType.remoteServer> {
             );
             metricsClient?.recordDownstreamStatus('5xx');
             logError(logContext, error);
+            const code = classifyDownstreamError(error);
             return responseHandler.sendResponse({
-              status: 500,
-              body: error,
+              status: statusForErrorCode(code),
+              errorType: code,
+              body: { code, message: (error as Error)?.message },
             });
           }
         }

--- a/lib/hybrid-sdk/common/types/errorCodes.ts
+++ b/lib/hybrid-sdk/common/types/errorCodes.ts
@@ -1,0 +1,45 @@
+// BROKER_ERROR_CODES is a list of standard broker errors.
+export const BROKER_ERROR_CODES = {
+  DOWNSTREAM_TIMEOUT: 'DOWNSTREAM_TIMEOUT',
+  DOWNSTREAM_UNREACHABLE: 'DOWNSTREAM_UNREACHABLE',
+  DOWNSTREAM_ERROR: 'DOWNSTREAM_ERROR',
+  FILTER_BLOCKED: 'FILTER_BLOCKED',
+  BODY_TOO_LARGE: 'BODY_TOO_LARGE',
+} as const;
+
+export type BrokerErrorCode =
+  (typeof BROKER_ERROR_CODES)[keyof typeof BROKER_ERROR_CODES];
+
+// SYNTHESIZED_STATUS applies only when no downstream response exists.
+// It should never be used to overwrite a downstream status code.
+const SYNTHESIZED_STATUS: Partial<Record<BrokerErrorCode, number>> = {
+  DOWNSTREAM_TIMEOUT: 504,
+  DOWNSTREAM_UNREACHABLE: 502,
+  DOWNSTREAM_ERROR: 502,
+  FILTER_BLOCKED: 401,
+  BODY_TOO_LARGE: 502,
+};
+
+export const statusForErrorCode = (code: BrokerErrorCode): number => {
+  const status = SYNTHESIZED_STATUS[code];
+  if (status === undefined) {
+    throw new Error(`No synthesized status for broker error code: ${code}`);
+  }
+  return status;
+};
+
+const ERRNO_TO_CODE: Record<string, BrokerErrorCode> = {
+  ETIMEDOUT: 'DOWNSTREAM_TIMEOUT',
+  ECONNREFUSED: 'DOWNSTREAM_UNREACHABLE',
+  ENOTFOUND: 'DOWNSTREAM_UNREACHABLE',
+};
+
+export const classifyDownstreamError = (error: unknown): BrokerErrorCode => {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return (code && ERRNO_TO_CODE[code]) || 'DOWNSTREAM_ERROR';
+};
+
+export interface BrokerErrorBody {
+  code: BrokerErrorCode;
+  message: string;
+}

--- a/lib/hybrid-sdk/http/downstream-post-stream-to-server.ts
+++ b/lib/hybrid-sdk/http/downstream-post-stream-to-server.ts
@@ -478,8 +478,6 @@ class BrokerServerPostResponseHandler {
   }
 
   #handleRequestError() {
-    // For reasons unknown, doing foo.on(this.#func)
-    // doesn't work - you need return a function from here
     return (error: Error) => {
       this.#logger.error(
         {
@@ -489,24 +487,8 @@ class BrokerServerPostResponseHandler {
         },
         'received error from downstream request while streaming data to Broker Server',
       );
-      // If we already have a buffer object, then we've already started sending data back to the original requestor,
-      // so we have to destroy the stream and let that flow through the system
-      // If we *don't* have a buffer object, then there was a major failure with the request (e.g., host not found), so
-      // we will forward that directly to the Broker Server
-      if (this.#buffer) {
-        this.#buffer.end(error.message);
-      } else {
-        const body = JSON.stringify({ error: error });
-        this.#sendIoData(
-          JSON.stringify({
-            status: 500,
-            headers: {
-              'Content-Length': `${body.length}`,
-              'Content-Type': 'application/json',
-            },
-          }),
-        );
-      }
+      // Downstream status already streamed - cannot send an updated status code.
+      this.#buffer.end(error.message);
     };
   }
 

--- a/lib/hybrid-sdk/responseSenders.ts
+++ b/lib/hybrid-sdk/responseSenders.ts
@@ -9,12 +9,17 @@ import { RequestMetadata } from './types';
 import { WebSocketConnection } from './client/types/client';
 import { WebSocketServer } from './server/types/socket';
 import { ExtendedLogContext } from './common/types/log';
+import {
+  BrokerErrorCode,
+  BROKER_ERROR_CODES,
+  statusForErrorCode,
+} from './common/types/errorCodes';
 
 export interface HybridResponse {
   status: number;
   body?: any;
   headers?: any;
-  errorType?: any;
+  errorType?: BrokerErrorCode;
   originalBodySize?: any;
 }
 export class HybridResponseHandler {
@@ -77,10 +82,11 @@ export class HybridResponseHandler {
         errorMessage,
       });
       return this.sendResponse({
-        status: 502,
-        errorType: 'BODY_TOO_LARGE',
+        status: statusForErrorCode(BROKER_ERROR_CODES.BODY_TOO_LARGE),
+        errorType: BROKER_ERROR_CODES.BODY_TOO_LARGE,
         originalBodySize: contentLength,
         body: {
+          code: BROKER_ERROR_CODES.BODY_TOO_LARGE,
           message: errorMessage,
         },
       });

--- a/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.ts
+++ b/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.ts
@@ -112,6 +112,7 @@ export const handlePostResponse = (req: Request, res: Response) => {
             const logData = {
               ...logContext,
               responseStatus: statusAndHeadersJson.status,
+              errorType: statusAndHeadersJson.errorType,
             };
             const logMessage = 'Handling response-data request - io bits';
             if (

--- a/test/functional/client-server.test.ts
+++ b/test/functional/client-server.test.ts
@@ -122,6 +122,7 @@ describe('proxy requests originating from behind the broker client', () => {
 
     expect(response.status).toEqual(401);
     expect(response.data).toStrictEqual({
+      code: 'FILTER_BLOCKED',
       message: 'blocked',
       reason: 'Request does not match any accept rule, blocking HTTP request',
       url: '/not-allowed',
@@ -148,6 +149,7 @@ describe('proxy requests originating from behind the broker client', () => {
 
     expect(response.status).toEqual(401);
     expect(response.data).toStrictEqual({
+      code: 'FILTER_BLOCKED',
       message: 'blocked',
       reason: 'Request does not match any accept rule, blocking HTTP request',
       url: '/echo-body/filtered',
@@ -178,6 +180,7 @@ describe('proxy requests originating from behind the broker client', () => {
 
     expect(response.status).toEqual(401);
     expect(response.data).toStrictEqual({
+      code: 'FILTER_BLOCKED',
       message: 'blocked',
       reason: 'Request does not match any accept rule, blocking HTTP request',
       url: '/echo-query/filtered?proxyMe=now!',
@@ -191,6 +194,7 @@ describe('proxy requests originating from behind the broker client', () => {
 
     expect(response.status).toEqual(401);
     expect(response.data).toStrictEqual({
+      code: 'FILTER_BLOCKED',
       message: 'blocked',
       reason: 'Request does not match any accept rule, blocking HTTP request',
       url: '/echo-query/filtered',
@@ -204,6 +208,7 @@ describe('proxy requests originating from behind the broker client', () => {
 
     expect(response.status).toEqual(401);
     expect(response.data).toStrictEqual({
+      code: 'FILTER_BLOCKED',
       message: 'blocked',
       reason:
         '[Websocket Flow][Blocked Request] Does not match any accept rule',
@@ -218,6 +223,7 @@ describe('proxy requests originating from behind the broker client', () => {
 
     expect(response.status).toEqual(401);
     expect(response.data).toStrictEqual({
+      code: 'FILTER_BLOCKED',
       message: 'blocked',
       reason:
         '[Websocket Flow][Blocked Request] Does not match any accept rule',
@@ -253,6 +259,7 @@ describe('proxy requests originating from behind the broker client', () => {
 
     expect(response.status).toEqual(401);
     expect(response.data).toStrictEqual({
+      code: 'FILTER_BLOCKED',
       message: 'blocked',
       reason: 'Request does not match any accept rule, blocking HTTP request',
       url: '/echo-param-protected/xyz',

--- a/test/functional/client-universal-server.test.ts
+++ b/test/functional/client-universal-server.test.ts
@@ -125,6 +125,7 @@ describe('proxy requests originating from behind the broker client', () => {
 
     expect(response.status).toEqual(401);
     expect(response.data).toStrictEqual({
+      code: 'FILTER_BLOCKED',
       message: 'blocked',
       reason: 'Request does not match any accept rule, blocking HTTP request',
       url: '/not-allowed',
@@ -151,6 +152,7 @@ describe('proxy requests originating from behind the broker client', () => {
 
     expect(response.status).toEqual(401);
     expect(response.data).toStrictEqual({
+      code: 'FILTER_BLOCKED',
       message: 'blocked',
       reason: 'Request does not match any accept rule, blocking HTTP request',
       url: '/echo-body/filtered',
@@ -181,6 +183,7 @@ describe('proxy requests originating from behind the broker client', () => {
 
     expect(response.status).toEqual(401);
     expect(response.data).toStrictEqual({
+      code: 'FILTER_BLOCKED',
       message: 'blocked',
       reason: 'Request does not match any accept rule, blocking HTTP request',
       url: '/echo-query/filtered?proxyMe=now!',
@@ -194,6 +197,7 @@ describe('proxy requests originating from behind the broker client', () => {
 
     expect(response.status).toEqual(401);
     expect(response.data).toStrictEqual({
+      code: 'FILTER_BLOCKED',
       message: 'blocked',
       reason: 'Request does not match any accept rule, blocking HTTP request',
       url: '/echo-query/filtered',
@@ -207,6 +211,7 @@ describe('proxy requests originating from behind the broker client', () => {
 
     expect(response.status).toEqual(401);
     expect(response.data).toStrictEqual({
+      code: 'FILTER_BLOCKED',
       message: 'blocked',
       reason:
         '[Websocket Flow][Blocked Request] Does not match any accept rule',
@@ -221,6 +226,7 @@ describe('proxy requests originating from behind the broker client', () => {
 
     expect(response.status).toEqual(401);
     expect(response.data).toStrictEqual({
+      code: 'FILTER_BLOCKED',
       message: 'blocked',
       reason:
         '[Websocket Flow][Blocked Request] Does not match any accept rule',
@@ -256,6 +262,7 @@ describe('proxy requests originating from behind the broker client', () => {
 
     expect(response.status).toEqual(401);
     expect(response.data).toStrictEqual({
+      code: 'FILTER_BLOCKED',
       message: 'blocked',
       reason: 'Request does not match any accept rule, blocking HTTP request',
       url: '/echo-param-protected/xyz',

--- a/test/functional/no-filter.test.ts
+++ b/test/functional/no-filter.test.ts
@@ -51,6 +51,7 @@ describe('no filters broker', () => {
 
     expect(response.status).toEqual(401);
     expect(response.data).toStrictEqual({
+      code: 'FILTER_BLOCKED',
       message: 'blocked',
       reason: 'Request does not match any accept rule, blocking HTTP request',
       url: '/echo-body',

--- a/test/functional/server-client.test.ts
+++ b/test/functional/server-client.test.ts
@@ -233,6 +233,7 @@ describe('proxy requests originating from behind the broker server', () => {
     );
     expect(response.status).toEqual(401);
     expect(response.data).toStrictEqual({
+      code: 'FILTER_BLOCKED',
       message: 'blocked',
       reason:
         '[Websocket Flow][Blocked Request] Does not match any accept rule',
@@ -270,6 +271,7 @@ describe('proxy requests originating from behind the broker server', () => {
 
     expect(response.status).toEqual(401);
     expect(response.data).toStrictEqual({
+      code: 'FILTER_BLOCKED',
       message: 'blocked',
       reason:
         '[Websocket Flow][Blocked Request] Does not match any accept rule',
@@ -299,6 +301,7 @@ describe('proxy requests originating from behind the broker server', () => {
 
     expect(response.status).toEqual(401);
     expect(response.data).toStrictEqual({
+      code: 'FILTER_BLOCKED',
       message: 'blocked',
       reason:
         '[Websocket Flow][Blocked Request] Does not match any accept rule',
@@ -313,6 +316,7 @@ describe('proxy requests originating from behind the broker server', () => {
 
     expect(response.status).toEqual(401);
     expect(response.data).toStrictEqual({
+      code: 'FILTER_BLOCKED',
       message: 'blocked',
       reason:
         '[Websocket Flow][Blocked Request] Does not match any accept rule',
@@ -394,6 +398,7 @@ describe('proxy requests originating from behind the broker server', () => {
 
     expect(response.status).toEqual(401);
     expect(response.data).toStrictEqual({
+      code: 'FILTER_BLOCKED',
       message: 'blocked',
       reason:
         '[Websocket Flow][Blocked Request] Does not match any accept rule',

--- a/test/unit/lib/broker-workload/websocketRequests.test.ts
+++ b/test/unit/lib/broker-workload/websocketRequests.test.ts
@@ -4,15 +4,50 @@ import {
   BrokerWorkloadOptions,
 } from '../../../../lib/broker-workload/websocketRequests';
 import { filterRequest } from '../../../../lib/broker-workload/requestFiltering';
+import {
+  makeRequestToDownstream,
+  makeStreamingRequestToDownstream,
+} from '../../../../lib/hybrid-sdk/http/request';
+
+const mockSendResponse = jest.fn();
+const mockStreamDataResponse = jest.fn();
+const mockSendDataResponse = jest.fn();
 
 jest.mock('../../../../lib/logs/logger');
 jest.mock('../../../../lib/broker-workload/requestFiltering', () => ({
   filterRequest: jest.fn(),
 }));
+jest.mock('../../../../lib/hybrid-sdk/responseSenders', () => ({
+  HybridResponseHandler: jest.fn().mockImplementation(() => ({
+    sendResponse: mockSendResponse,
+    streamDataResponse: mockStreamDataResponse,
+    sendDataResponse: mockSendDataResponse,
+  })),
+}));
+jest.mock('../../../../lib/hybrid-sdk/http/request', () => ({
+  makeRequestToDownstream: jest.fn(),
+  makeStreamingRequestToDownstream: jest.fn(),
+}));
+jest.mock('../../../../lib/broker-workload/prepareRequest', () => ({
+  prepareRequest: jest.fn(async () => ({
+    req: { url: 'http://downstream.example', headers: {}, method: 'GET' },
+  })),
+}));
+jest.mock(
+  '../../../../lib/hybrid-sdk/interpolateRequestWithConfigData',
+  () => ({ getInterpolatedRequest: jest.fn(() => ({})) }),
+);
 
 const mockFilterRequest = filterRequest as jest.MockedFunction<
   typeof filterRequest
 >;
+const mockMakeRequest = makeRequestToDownstream as jest.MockedFunction<
+  typeof makeRequestToDownstream
+>;
+const mockMakeStreamingRequest =
+  makeStreamingRequestToDownstream as jest.MockedFunction<
+    typeof makeStreamingRequestToDownstream
+  >;
 
 // snyk-request-id is pre-populated in fixtures to reflect production reality:
 // forwardWebSocketRequest guarantees the header is a valid UUID before
@@ -113,5 +148,122 @@ describe('BrokerWorkload', () => {
       }),
       expect.stringContaining('[Websocket Flow] Received request'),
     );
+  });
+
+  describe('broker error responses', () => {
+    const matchedRule: any = { use: {}, valid: [] };
+
+    it('blocked request returns FILTER_BLOCKED with 401', async () => {
+      mockFilterRequest.mockReturnValue(null);
+      const workload = new BrokerWorkload(
+        connectionIdentifier,
+        options,
+        websocketConnectionHandler,
+      );
+      const payload = {
+        url: '/blocked',
+        method: 'GET',
+        headers: { 'snyk-request-id': '33333333-3333-4333-8333-333333333333' },
+        streamingID: '',
+      };
+
+      await workload.handler({ payload, websocketHandler: jest.fn() });
+
+      expect(mockSendResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 401,
+          errorType: 'FILTER_BLOCKED',
+          body: expect.objectContaining({
+            code: 'FILTER_BLOCKED',
+            message: 'blocked',
+            url: '/blocked',
+          }),
+        }),
+      );
+    });
+
+    it('non-streaming ECONNREFUSED returns DOWNSTREAM_UNREACHABLE with 502', async () => {
+      mockFilterRequest.mockReturnValue(matchedRule);
+      mockMakeRequest.mockRejectedValueOnce(
+        Object.assign(new Error('connect ECONNREFUSED'), {
+          code: 'ECONNREFUSED',
+        }),
+      );
+      const workload = new BrokerWorkload(
+        connectionIdentifier,
+        options,
+        websocketConnectionHandler,
+      );
+      const payload = {
+        url: '/repo',
+        method: 'GET',
+        headers: { 'snyk-request-id': '44444444-4444-4444-8444-444444444444' },
+        streamingID: '',
+      };
+
+      await workload.handler({ payload, websocketHandler: jest.fn() });
+
+      expect(mockSendResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 502,
+          errorType: 'DOWNSTREAM_UNREACHABLE',
+          body: expect.objectContaining({ code: 'DOWNSTREAM_UNREACHABLE' }),
+        }),
+      );
+    });
+
+    it('streaming failure before response returns DOWNSTREAM_ERROR with 502', async () => {
+      mockFilterRequest.mockReturnValue(matchedRule);
+      mockMakeStreamingRequest.mockRejectedValueOnce(new Error('boom'));
+      const workload = new BrokerWorkload(
+        connectionIdentifier,
+        options,
+        websocketConnectionHandler,
+      );
+      const payload = {
+        url: '/stream',
+        method: 'GET',
+        headers: { 'snyk-request-id': '55555555-5555-4555-8555-555555555555' },
+        streamingID: 'stream-err',
+      };
+
+      await workload.handler({ payload, websocketHandler: jest.fn() });
+
+      expect(mockSendResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 502,
+          errorType: 'DOWNSTREAM_ERROR',
+          body: expect.objectContaining({ code: 'DOWNSTREAM_ERROR' }),
+        }),
+      );
+    });
+
+    it('streaming ETIMEDOUT returns DOWNSTREAM_TIMEOUT with 504', async () => {
+      mockFilterRequest.mockReturnValue(matchedRule);
+      mockMakeStreamingRequest.mockRejectedValueOnce(
+        Object.assign(new Error('timed out'), { code: 'ETIMEDOUT' }),
+      );
+      const workload = new BrokerWorkload(
+        connectionIdentifier,
+        options,
+        websocketConnectionHandler,
+      );
+      const payload = {
+        url: '/stream',
+        method: 'GET',
+        headers: { 'snyk-request-id': '66666666-6666-4666-8666-666666666666' },
+        streamingID: 'stream-timeout',
+      };
+
+      await workload.handler({ payload, websocketHandler: jest.fn() });
+
+      expect(mockSendResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 504,
+          errorType: 'DOWNSTREAM_TIMEOUT',
+          body: expect.objectContaining({ code: 'DOWNSTREAM_TIMEOUT' }),
+        }),
+      );
+    });
   });
 });

--- a/test/unit/lib/hybrid-sdk/common/types/errorCodes.test.ts
+++ b/test/unit/lib/hybrid-sdk/common/types/errorCodes.test.ts
@@ -1,0 +1,59 @@
+import {
+  BROKER_ERROR_CODES,
+  classifyDownstreamError,
+  statusForErrorCode,
+} from '../../../../../../lib/hybrid-sdk/common/types/errorCodes';
+
+describe('errorCodes catalog', () => {
+  describe('classifyDownstreamError', () => {
+    it.each([
+      ['ETIMEDOUT', BROKER_ERROR_CODES.DOWNSTREAM_TIMEOUT],
+      ['ECONNREFUSED', BROKER_ERROR_CODES.DOWNSTREAM_UNREACHABLE],
+      ['ENOTFOUND', BROKER_ERROR_CODES.DOWNSTREAM_UNREACHABLE],
+    ])('maps errno %s to %s', (errno, expected) => {
+      expect(
+        classifyDownstreamError(Object.assign(new Error('x'), { code: errno })),
+      ).toBe(expected);
+    });
+
+    it('maps ECONNRESET to DOWNSTREAM_ERROR (not unreachable/timeout)', () => {
+      expect(
+        classifyDownstreamError(
+          Object.assign(new Error('reset'), { code: 'ECONNRESET' }),
+        ),
+      ).toBe(BROKER_ERROR_CODES.DOWNSTREAM_ERROR);
+    });
+
+    it('falls back to DOWNSTREAM_ERROR for an unknown errno', () => {
+      expect(
+        classifyDownstreamError(
+          Object.assign(new Error('?'), { code: 'EWAT' }),
+        ),
+      ).toBe(BROKER_ERROR_CODES.DOWNSTREAM_ERROR);
+    });
+
+    it('falls back to DOWNSTREAM_ERROR for a code-less error', () => {
+      expect(classifyDownstreamError(new Error('plain'))).toBe(
+        BROKER_ERROR_CODES.DOWNSTREAM_ERROR,
+      );
+    });
+
+    it('falls back to DOWNSTREAM_ERROR for undefined', () => {
+      expect(classifyDownstreamError(undefined)).toBe(
+        BROKER_ERROR_CODES.DOWNSTREAM_ERROR,
+      );
+    });
+  });
+
+  describe('statusForErrorCode', () => {
+    it.each([
+      [BROKER_ERROR_CODES.DOWNSTREAM_TIMEOUT, 504],
+      [BROKER_ERROR_CODES.DOWNSTREAM_UNREACHABLE, 502],
+      [BROKER_ERROR_CODES.DOWNSTREAM_ERROR, 502],
+      [BROKER_ERROR_CODES.FILTER_BLOCKED, 401],
+      [BROKER_ERROR_CODES.BODY_TOO_LARGE, 502],
+    ])('returns %s -> %d', (code, status) => {
+      expect(statusForErrorCode(code)).toBe(status);
+    });
+  });
+});

--- a/test/unit/lib/hybrid-sdk/http/downstream-post-stream-to-server.test.ts
+++ b/test/unit/lib/hybrid-sdk/http/downstream-post-stream-to-server.test.ts
@@ -282,6 +282,54 @@ describe('BrokerServerPostResponseHandler', () => {
     });
   });
 
+  describe('mid-stream downstream error', () => {
+    beforeEach(() => {
+      setConfig({
+        brokerServerUrl,
+        universalBrokerEnabled: false,
+        universalBrokerGa: false,
+      });
+    });
+
+    it('ends the stream without synthesizing a status or error code', async () => {
+      nock(brokerServerUrl)
+        .post(`/response-data/${brokerToken}/${streamingId}`)
+        .query(true)
+        .reply(200, 'OK');
+
+      const handler = createHandler();
+
+      const mockSocket = new Socket();
+      const mockResponse = new http.IncomingMessage(mockSocket);
+      mockResponse.statusCode = 200;
+      mockResponse.headers = { 'content-type': 'application/json' };
+
+      const forwardPromise = handler.forwardRequest(mockResponse, streamingId);
+      setTimeout(() => {
+        mockResponse.emit('error', new Error('mid-stream boom'));
+        mockResponse.push(null);
+      }, 50);
+      await forwardPromise;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const handlerError = testLogger.errorCalls.find(
+        (call) =>
+          call.message ===
+          'received error from downstream request while streaming data to Broker Server',
+      );
+      expect(handlerError).toBeDefined();
+
+      const anyErrorType = [
+        ...testLogger.errorCalls,
+        ...testLogger.warnCalls,
+        ...testLogger.debugCalls,
+      ].some((call) => 'errorType' in call.context);
+      expect(anyErrorType).toBe(false);
+
+      mockSocket.destroy();
+    });
+  });
+
   describe('duration tracking on successful requests', () => {
     beforeEach(() => {
       setConfig({

--- a/test/unit/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.test.ts
+++ b/test/unit/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.test.ts
@@ -1,0 +1,136 @@
+import { EventEmitter } from 'events';
+import { log } from '../../../../../../lib/logs/logger';
+import { handlePostResponse } from '../../../../../../lib/hybrid-sdk/server/routesHandlers/postResponseHandler';
+
+jest.mock('../../../../../../lib/logs/logger', () => ({
+  log: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    trace: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+const mockWriteStatusAndHeaders = jest.fn();
+jest.mock(
+  '../../../../../../lib/hybrid-sdk/http/server-post-stream-handler',
+  () => ({
+    StreamResponseHandler: {
+      create: jest.fn(() => ({
+        writeStatusAndHeaders: mockWriteStatusAndHeaders,
+        writeChunk: jest.fn(),
+        finished: jest.fn(),
+        destroy: jest.fn(),
+        streamResponse: {},
+      })),
+    },
+  }),
+);
+
+jest.mock('../../../../../../lib/hybrid-sdk/common/config/config', () => ({
+  getConfig: jest.fn(() => ({ BROKER_SERVER_MANDATORY_AUTH_ENABLED: false })),
+}));
+
+jest.mock('../../../../../../lib/hybrid-sdk/common/utils/metrics', () => ({
+  incrementHttpRequestsTotal: jest.fn(),
+}));
+
+jest.mock('../../../../../../lib/hybrid-sdk/server/utils/token', () => ({
+  getDesensitizedToken: jest.fn(() => ({
+    hashedToken: 'hashed',
+    maskedToken: 'masked',
+  })),
+}));
+
+const frameIoData = (obj: Record<string, unknown>): Buffer => {
+  const json = JSON.stringify(obj);
+  const length = Buffer.byteLength(json, 'utf8');
+  const prefix = Buffer.alloc(4);
+  prefix.writeUInt32LE(length);
+  return Buffer.concat([prefix, Buffer.from(json, 'utf8')]);
+};
+
+const createReqRes = () => {
+  const req = new EventEmitter() as any;
+  req.params = { brokerToken: 'token', streamingId: 'stream-1' };
+  req.headers = {};
+  req.requestId = 'req-1';
+  req.pause = jest.fn();
+  req.resume = jest.fn();
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  } as any;
+  return { req, res };
+};
+
+describe('handlePostResponse — errorType logging', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('logs errorType at info level when an error code accompanies a >299 status', () => {
+    const { req, res } = createReqRes();
+    handlePostResponse(req, res);
+
+    req.emit(
+      'data',
+      frameIoData({
+        status: 401,
+        errorType: 'FILTER_BLOCKED',
+        headers: {},
+      }),
+    );
+    req.emit('end');
+
+    expect(log.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responseStatus: 401,
+        errorType: 'FILTER_BLOCKED',
+      }),
+      'Handling response-data request - io bits',
+    );
+    expect(mockWriteStatusAndHeaders).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 401, errorType: 'FILTER_BLOCKED' }),
+    );
+  });
+
+  it('carries a synthesized DOWNSTREAM_UNREACHABLE code on a 502', () => {
+    const { req, res } = createReqRes();
+    handlePostResponse(req, res);
+
+    req.emit(
+      'data',
+      frameIoData({
+        status: 502,
+        errorType: 'DOWNSTREAM_UNREACHABLE',
+        headers: {},
+      }),
+    );
+    req.emit('end');
+
+    expect(log.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responseStatus: 502,
+        errorType: 'DOWNSTREAM_UNREACHABLE',
+      }),
+      'Handling response-data request - io bits',
+    );
+  });
+
+  it('leaves errorType undefined for a normal 2xx response (debug branch)', () => {
+    const { req, res } = createReqRes();
+    handlePostResponse(req, res);
+
+    req.emit('data', frameIoData({ status: 200, headers: {} }));
+    req.emit('end');
+
+    expect(log.info).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'Handling response-data request - io bits',
+    );
+    expect(log.debug).toHaveBeenCalledWith(
+      expect.objectContaining({ responseStatus: 200, errorType: undefined }),
+      'Handling response-data request - io bits',
+    );
+  });
+});


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Add a shared error code catalog so broker failures return consistent code/errorType values and synthesized HTTP statuses only when no downstream response exists. Wire filter blocks, downstream failures, and server logging through the catalog, and stop attempting to update the status code on mid-stream errors after headers are already streamed (it won).

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
