### PR TITLE
feat: classify downstream non-2xx responses with errorType

### DIFF
--- a/lib/hybrid-sdk/common/types/errorCodes.ts
+++ b/lib/hybrid-sdk/common/types/errorCodes.ts
@@ -1,10 +1,16 @@
-// BROKER_ERROR_CODES is a list of standard broker errors.
 export const BROKER_ERROR_CODES = {
+  // Carry a synthesized status; used when no downstream response exists.
   DOWNSTREAM_TIMEOUT: 'DOWNSTREAM_TIMEOUT',
   DOWNSTREAM_UNREACHABLE: 'DOWNSTREAM_UNREACHABLE',
   DOWNSTREAM_ERROR: 'DOWNSTREAM_ERROR',
   FILTER_BLOCKED: 'FILTER_BLOCKED',
   BODY_TOO_LARGE: 'BODY_TOO_LARGE',
+  // Label a status the downstream already returned; status from downstream response.
+  DOWNSTREAM_UNAUTHORIZED: 'DOWNSTREAM_UNAUTHORIZED',
+  DOWNSTREAM_FORBIDDEN: 'DOWNSTREAM_FORBIDDEN',
+  DOWNSTREAM_RATE_LIMITED: 'DOWNSTREAM_RATE_LIMITED',
+  DOWNSTREAM_SERVER_ERROR: 'DOWNSTREAM_SERVER_ERROR',
+  DOWNSTREAM_UNEXPECTED: 'DOWNSTREAM_UNEXPECTED',
 } as const;
 
 export type BrokerErrorCode =
@@ -37,6 +43,18 @@ const ERRNO_TO_CODE: Record<string, BrokerErrorCode> = {
 export const classifyDownstreamError = (error: unknown): BrokerErrorCode => {
   const code = (error as NodeJS.ErrnoException | undefined)?.code;
   return (code && ERRNO_TO_CODE[code]) || 'DOWNSTREAM_ERROR';
+};
+
+// undefined means the status needs no error code.
+export const classifyDownstreamStatus = (
+  status: number,
+): BrokerErrorCode | undefined => {
+  if (status === 401) return 'DOWNSTREAM_UNAUTHORIZED';
+  if (status === 403) return 'DOWNSTREAM_FORBIDDEN';
+  if (status === 429) return 'DOWNSTREAM_RATE_LIMITED';
+  if (status >= 500 && status <= 599) return 'DOWNSTREAM_SERVER_ERROR';
+  if (status >= 400 && status !== 404) return 'DOWNSTREAM_UNEXPECTED';
+  return undefined;
 };
 
 export interface BrokerErrorBody {

--- a/lib/hybrid-sdk/http/downstream-post-stream-to-server.ts
+++ b/lib/hybrid-sdk/http/downstream-post-stream-to-server.ts
@@ -14,6 +14,7 @@ import { addServerIdAndRoleQS } from './utils';
 import { getConfig } from '../common/config/config';
 import type { ExtendedLogContext } from '../common/types/log';
 import { replaceUrlPartialChunk } from '../common/utils/replace-vars';
+import { classifyDownstreamStatus } from '../common/types/errorCodes';
 import { performance } from 'node:perf_hooks';
 
 const BROKER_CONTENT_TYPE = 'application/vnd.broker.stream+octet-stream';
@@ -550,9 +551,11 @@ class BrokerServerPostResponseHandler {
         );
       }
       const isResponseJson = isJson(response.headers);
+      const errorType = classifyDownstreamStatus(status);
       const ioData = JSON.stringify({
         status,
         headers: response.headers,
+        errorType,
       });
 
       await this.#initHttpClientRequest();

--- a/lib/hybrid-sdk/responseSenders.ts
+++ b/lib/hybrid-sdk/responseSenders.ts
@@ -12,6 +12,7 @@ import { ExtendedLogContext } from './common/types/log';
 import {
   BrokerErrorCode,
   BROKER_ERROR_CODES,
+  classifyDownstreamStatus,
   statusForErrorCode,
 } from './common/types/errorCodes';
 
@@ -98,10 +99,12 @@ export class HybridResponseHandler {
     }
     const status = (response && response.statusCode) || 500;
     logResponse(logContext, status, response, this.config);
+    const errorType = classifyDownstreamStatus(status);
     this.sendResponse({
       status,
       body: response.body,
       headers: response.headers,
+      ...(errorType && { errorType }),
     });
   };
 

--- a/test/functional/server-client.test.ts
+++ b/test/functional/server-client.test.ts
@@ -539,6 +539,17 @@ describe('proxy requests originating from behind the broker server', () => {
     expect(response.data).toEqual(String(buf));
   });
 
+  it('relays a downstream 500 with its status unchanged', async () => {
+    const response = await axiosClient.get(
+      `http://localhost:${bs.port}/broker/${brokerToken}/test-blob/2`,
+      {
+        headers: {},
+      },
+    );
+    expect(response.status).toEqual(500);
+    expect(response.data).toEqual('Test Error');
+  });
+
   it('successfully redirect POST request to git client', async () => {
     const response = await axiosClient.post(
       `http://localhost:${bs.port}/broker/${brokerToken}/snykgit/echo-body`,

--- a/test/unit/lib/hybrid-sdk/common/types/errorCodes.test.ts
+++ b/test/unit/lib/hybrid-sdk/common/types/errorCodes.test.ts
@@ -1,6 +1,7 @@
 import {
   BROKER_ERROR_CODES,
   classifyDownstreamError,
+  classifyDownstreamStatus,
   statusForErrorCode,
 } from '../../../../../../lib/hybrid-sdk/common/types/errorCodes';
 
@@ -55,5 +56,39 @@ describe('errorCodes catalog', () => {
     ])('returns %s -> %d', (code, status) => {
       expect(statusForErrorCode(code)).toBe(status);
     });
+
+    it.each([
+      [BROKER_ERROR_CODES.DOWNSTREAM_UNAUTHORIZED],
+      [BROKER_ERROR_CODES.DOWNSTREAM_FORBIDDEN],
+      [BROKER_ERROR_CODES.DOWNSTREAM_RATE_LIMITED],
+      [BROKER_ERROR_CODES.DOWNSTREAM_SERVER_ERROR],
+      [BROKER_ERROR_CODES.DOWNSTREAM_UNEXPECTED],
+    ])('throws for pass-through code %s (no synthesized status)', (code) => {
+      expect(() => statusForErrorCode(code)).toThrow(/No synthesized status/);
+    });
+  });
+
+  describe('classifyDownstreamStatus', () => {
+    it.each([
+      [401, BROKER_ERROR_CODES.DOWNSTREAM_UNAUTHORIZED],
+      [403, BROKER_ERROR_CODES.DOWNSTREAM_FORBIDDEN],
+      [429, BROKER_ERROR_CODES.DOWNSTREAM_RATE_LIMITED],
+      [500, BROKER_ERROR_CODES.DOWNSTREAM_SERVER_ERROR],
+      [502, BROKER_ERROR_CODES.DOWNSTREAM_SERVER_ERROR],
+      [599, BROKER_ERROR_CODES.DOWNSTREAM_SERVER_ERROR],
+      [400, BROKER_ERROR_CODES.DOWNSTREAM_UNEXPECTED],
+      [405, BROKER_ERROR_CODES.DOWNSTREAM_UNEXPECTED],
+      [409, BROKER_ERROR_CODES.DOWNSTREAM_UNEXPECTED],
+      [422, BROKER_ERROR_CODES.DOWNSTREAM_UNEXPECTED],
+    ])('maps actionable status %d to %s', (status, expected) => {
+      expect(classifyDownstreamStatus(status)).toBe(expected);
+    });
+
+    it.each([[200], [204], [301], [404]])(
+      'returns undefined for non-actionable status %d',
+      (status) => {
+        expect(classifyDownstreamStatus(status)).toBeUndefined();
+      },
+    );
   });
 });

--- a/test/unit/lib/hybrid-sdk/http/downstream-post-stream-to-server.test.ts
+++ b/test/unit/lib/hybrid-sdk/http/downstream-post-stream-to-server.test.ts
@@ -1265,4 +1265,83 @@ describe('BrokerServerPostResponseHandler', () => {
       },
     );
   });
+
+  describe('SCM response errorType labeling', () => {
+    let realServer: http.Server;
+    let bodyPromise: Promise<Buffer>;
+
+    beforeEach((done) => {
+      let resolveBody: (b: Buffer) => void;
+      bodyPromise = new Promise<Buffer>((resolve) => {
+        resolveBody = resolve;
+      });
+      realServer = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on('data', (chunk) => chunks.push(chunk));
+        req.on('end', () => {
+          resolveBody(Buffer.concat(chunks));
+          res.writeHead(200);
+          res.end('OK');
+        });
+      });
+      realServer.listen(0, '127.0.0.1', () => {
+        const addr = realServer.address() as AddressInfo;
+        setConfig({
+          brokerServerUrl: `http://127.0.0.1:${addr.port}`,
+          universalBrokerEnabled: false,
+          universalBrokerGa: false,
+        });
+        done();
+      });
+    });
+
+    afterEach((done) => {
+      realServer.close(done);
+    });
+
+    async function driveAndParseIoData(scmStatus: number) {
+      const handler = createHandler();
+      const mockSocket = new Socket();
+      const mockResponse = new http.IncomingMessage(mockSocket);
+      mockResponse.statusCode = scmStatus;
+      mockResponse.headers = { 'content-type': 'application/json' };
+
+      const forwardPromise = handler.forwardRequest(mockResponse, streamingId);
+      process.nextTick(() => mockResponse.push(null));
+      await forwardPromise;
+      const body = await bodyPromise;
+      mockSocket.destroy();
+
+      // Frame is a 4-byte little-endian length prefix followed by the JSON.
+      const ioDataLength = body.readUInt32LE(0);
+      const ioDataJson = body.subarray(4, 4 + ioDataLength).toString('utf8');
+      return JSON.parse(ioDataJson);
+    }
+
+    it.each([
+      [401, 'DOWNSTREAM_UNAUTHORIZED'],
+      [403, 'DOWNSTREAM_FORBIDDEN'],
+      [429, 'DOWNSTREAM_RATE_LIMITED'],
+      [500, 'DOWNSTREAM_SERVER_ERROR'],
+      [503, 'DOWNSTREAM_SERVER_ERROR'],
+      [400, 'DOWNSTREAM_UNEXPECTED'],
+      [422, 'DOWNSTREAM_UNEXPECTED'],
+    ])(
+      'labels SCM %d ioData with errorType %s, status unchanged',
+      async (scmStatus, expectedCode) => {
+        const ioData = await driveAndParseIoData(scmStatus as number);
+        expect(ioData.status).toBe(scmStatus);
+        expect(ioData.errorType).toBe(expectedCode);
+      },
+    );
+
+    it.each([200, 204, 301, 404])(
+      'leaves SCM %d ioData without an errorType',
+      async (scmStatus) => {
+        const ioData = await driveAndParseIoData(scmStatus);
+        expect(ioData.status).toBe(scmStatus);
+        expect(ioData.errorType).toBeUndefined();
+      },
+    );
+  });
 });

--- a/test/unit/lib/hybrid-sdk/responseSenders.test.ts
+++ b/test/unit/lib/hybrid-sdk/responseSenders.test.ts
@@ -1,0 +1,60 @@
+import { HybridResponseHandler } from '../../../../lib/hybrid-sdk/responseSenders';
+
+describe('HybridResponseHandler.sendDataResponse — downstream relay classification', () => {
+  const createHandler = () => {
+    const handler = new HybridResponseHandler(
+      { connectionIdentifier: 'conn-1' } as any,
+      {} as any,
+      undefined as any,
+      { socketMaxResponseLength: '20971520' } as any,
+      {} as any,
+    );
+    handler.sendResponse = jest.fn();
+    return handler;
+  };
+
+  it.each([
+    [401, 'DOWNSTREAM_UNAUTHORIZED'],
+    [403, 'DOWNSTREAM_FORBIDDEN'],
+    [429, 'DOWNSTREAM_RATE_LIMITED'],
+    [500, 'DOWNSTREAM_SERVER_ERROR'],
+    [503, 'DOWNSTREAM_SERVER_ERROR'],
+    [400, 'DOWNSTREAM_UNEXPECTED'],
+    [422, 'DOWNSTREAM_UNEXPECTED'],
+  ])(
+    'labels a downstream %d relay with errorType %s, status + body untouched',
+    (status, expectedCode) => {
+      const handler = createHandler();
+      const body = `downstream-${status}-body`;
+      const headers = { 'content-type': 'application/json' };
+
+      handler.sendDataResponse({ statusCode: status, body, headers }, {});
+
+      expect(handler.sendResponse).toHaveBeenCalledWith({
+        status,
+        body,
+        headers,
+        errorType: expectedCode,
+      });
+    },
+  );
+
+  it.each([200, 204, 301, 404])(
+    'does not set errorType for a downstream %d relay',
+    (status) => {
+      const handler = createHandler();
+      const body = `downstream-${status}-body`;
+      const headers = { 'content-type': 'application/json' };
+
+      handler.sendDataResponse({ statusCode: status, body, headers }, {});
+
+      expect(handler.sendResponse).toHaveBeenCalledWith({
+        status,
+        body,
+        headers,
+      });
+      const payload = (handler.sendResponse as jest.Mock).mock.calls[0][0];
+      expect(payload).not.toHaveProperty('errorType');
+    },
+  );
+});

--- a/test/unit/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.test.ts
+++ b/test/unit/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.test.ts
@@ -117,6 +117,29 @@ describe('handlePostResponse — errorType logging', () => {
     );
   });
 
+  it.each([
+    [401, 'DOWNSTREAM_UNAUTHORIZED'],
+    [429, 'DOWNSTREAM_RATE_LIMITED'],
+    [503, 'DOWNSTREAM_SERVER_ERROR'],
+  ])(
+    'logs a pass-through code on a downstream %d, status unchanged',
+    (status, errorType) => {
+      const { req, res } = createReqRes();
+      handlePostResponse(req, res);
+
+      req.emit('data', frameIoData({ status, errorType, headers: {} }));
+      req.emit('end');
+
+      expect(log.info).toHaveBeenCalledWith(
+        expect.objectContaining({ responseStatus: status, errorType }),
+        'Handling response-data request - io bits',
+      );
+      expect(mockWriteStatusAndHeaders).toHaveBeenCalledWith(
+        expect.objectContaining({ status, errorType }),
+      );
+    },
+  );
+
   it('leaves errorType undefined for a normal 2xx response (debug branch)', () => {
     const { req, res } = createReqRes();
     handlePostResponse(req, res);


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Downstream failures relayed through the broker were invisible server-side beyond the raw status, leaving support unable to triage them. Tag relayed non-2xx responses with a typed errorType so the failure class is queryable on the log facet, while the caller's status and body pass through untouched.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
