### PR TITLE
fix: make oauth client resilient to transient auth failures

### DIFF
--- a/lib/hybrid-sdk/client/metrics/client.ts
+++ b/lib/hybrid-sdk/client/metrics/client.ts
@@ -27,7 +27,11 @@ export interface Client {
    * Best-effort — call forceFlush() if in an async context.
    */
   recordProcessExit(
-    reason: 'reconnect_exhaustion' | 'auth_4xx' | 'uncaught_exception',
+    reason:
+      | 'reconnect_exhaustion'
+      | 'auth_4xx'
+      | 'oauth_token_unavailable'
+      | 'uncaught_exception',
   ): void;
 
   /** Increment broker.client.auth_renewal_failure.total for non-2xx auth renewal responses. */

--- a/lib/hybrid-sdk/client/metrics/otelClient.ts
+++ b/lib/hybrid-sdk/client/metrics/otelClient.ts
@@ -133,7 +133,7 @@ export class OtelClient implements Client {
       'broker.client.process_exit.total',
       {
         description:
-          'Count of process exits by reason (reconnect_exhaustion, auth_4xx, uncaught_exception).',
+          'Count of process exits by reason (reconnect_exhaustion, auth_4xx, oauth_token_unavailable, uncaught_exception).',
         valueType: ValueType.INT,
       },
     );
@@ -303,7 +303,11 @@ export class OtelClient implements Client {
   }
 
   recordProcessExit(
-    reason: 'reconnect_exhaustion' | 'auth_4xx' | 'uncaught_exception',
+    reason:
+      | 'reconnect_exhaustion'
+      | 'auth_4xx'
+      | 'oauth_token_unavailable'
+      | 'uncaught_exception',
   ): void {
     this.processExitCounter.add(1, { reason });
   }

--- a/lib/hybrid-sdk/client/socket.ts
+++ b/lib/hybrid-sdk/client/socket.ts
@@ -35,6 +35,8 @@ import version from '../common/utils/version';
 import { addServerIdAndRoleQS } from '../http/utils';
 import { serviceHandler } from './socketHandlers/serviceHandler';
 
+const MAX_CONSECUTIVE_AUTH_FAILURES = 3;
+
 /**
  * Creates a pair of WebSocket connections (primary and secondary) for the given connection key.
  * Each logical connection is represented by two sockets so they can be managed as a pair
@@ -213,6 +215,7 @@ export const createWebSocket = (
     // access token will be marked as stale and closed by the server.
     const renewalIntervalMs =
       clientOpts.config.AUTH_EXPIRATION_OVERRIDE ?? 10 * 60 * 1000;
+    let consecutiveAuthFailures = 0;
 
     const timeoutHandler = async () => {
       const commonLogFields = {
@@ -251,42 +254,45 @@ export const createWebSocket = (
           throw new AuthRenewalError(statusCode);
         }
 
+        consecutiveAuthFailures = 0;
         logger.debug(commonLogFields, 'Auth renewed.');
         // Re-read extraHeaders after renewal: the 401-retry path may have
         // invalidated and refreshed the cached token, and the next reconnect
         // needs to pick that up via the synchronous cache read.
         websocket.transport.extraHeaders = buildExtraHeaders(currentRequestId);
       } catch (err) {
-        if (err instanceof AuthRenewalError) {
-          if (err.statusCode >= 400 && err.statusCode < 500) {
-            logger.fatal(
-              { ...commonLogFields, responseCode: err.statusCode },
-              'Failed to renew connection due to a client error. Exiting...',
-            );
-            metricsClient.recordAuthRenewalFailure(err.statusCode);
-            metricsClient.recordProcessExit('auth_4xx');
-            await metricsClient.forceFlush().catch((flushErr) => {
-              logger.warn(
-                { ...commonLogFields, err: flushErr },
-                'Failed to flush metrics before exit',
-              );
-            });
-            process.exit(1);
-            return;
-          }
-          logger.warn(
-            {
-              ...commonLogFields,
-              responseCode: err.statusCode,
-            },
-            'Failed to renew connection.',
+        const statusCode = err instanceof AuthRenewalError ? err.statusCode : 0;
+        const errField = err instanceof AuthRenewalError ? undefined : err;
+        // Drop the token so the next attempt refreshes rather than reusing the rejected one.
+        invalidateToken();
+        consecutiveAuthFailures++;
+        metricsClient.recordAuthRenewalFailure(statusCode);
+
+        if (consecutiveAuthFailures >= MAX_CONSECUTIVE_AUTH_FAILURES) {
+          logger.fatal(
+            { ...commonLogFields, responseCode: statusCode, err: errField },
+            `Failed to renew connection ${consecutiveAuthFailures} consecutive times. Exiting...`,
           );
-          metricsClient.recordAuthRenewalFailure(err.statusCode);
+          metricsClient.recordProcessExit('oauth_token_unavailable');
+          await metricsClient.forceFlush().catch((flushErr) => {
+            logger.warn(
+              { ...commonLogFields, err: flushErr },
+              'Failed to flush metrics before exit',
+            );
+          });
+          process.exit(1);
           return;
         }
 
-        logger.warn({ ...commonLogFields, err }, 'Failed to renew connection.');
-        metricsClient.recordAuthRenewalFailure(0);
+        logger.warn(
+          {
+            ...commonLogFields,
+            responseCode: statusCode,
+            consecutiveAuthFailures,
+            err: errField,
+          },
+          'Failed to renew connection.',
+        );
       } finally {
         websocket.timeoutHandlerId = setTimeout(
           timeoutHandler,
@@ -354,6 +360,10 @@ export const createWebSocket = (
   );
   websocket.on('notification', notificationHandler);
   websocket.on('error', errorHandler);
+  if (isOAuthClientInitialized() && clientOpts.config.UNIVERSAL_BROKER_GA) {
+    // Drop the cached token on connection errors so the next reconnect fetches a fresh one.
+    websocket.on('error', () => invalidateToken());
+  }
 
   websocket.on('open', () =>
     openHandler(websocket, localClientOps, identifyingMetadata, metricsClient),

--- a/lib/hybrid-sdk/http/downstream-post-stream-to-server.ts
+++ b/lib/hybrid-sdk/http/downstream-post-stream-to-server.ts
@@ -9,7 +9,11 @@ import { bootstrap } from 'global-agent';
 import https from 'https';
 import http from 'http';
 
-import { getAccessToken, isOAuthClientInitialized } from '../client/auth/oauth';
+import {
+  getAccessToken,
+  invalidateToken,
+  isOAuthClientInitialized,
+} from '../client/auth/oauth';
 import { addServerIdAndRoleQS } from './utils';
 import { getConfig } from '../common/config/config';
 import type { ExtendedLogContext } from '../common/types/log';
@@ -371,6 +375,19 @@ class BrokerServerPostResponseHandler {
               'Stream Response error in POST to Broker Server',
             );
           });
+          if (
+            r.statusCode === 401 &&
+            this.#config.universalBrokerGa &&
+            isOAuthClientInitialized()
+          ) {
+            // Stream already sent; can't replay. Drop the rejected token so the
+            // next request/renewal fetches a fresh one.
+            logger.warn(
+              { streamingId: this.#streamingId },
+              'Broker Server rejected POST with 401; invalidating cached OAuth token.',
+            );
+            invalidateToken();
+          }
           if (r.statusCode !== 200) {
             const body = await readBody(r).catch(() => '');
             logger.error(

--- a/test/unit/client/socket.test.ts
+++ b/test/unit/client/socket.test.ts
@@ -275,7 +275,8 @@ describe('createWebSocket - renew auth behaviour', () => {
   });
 
   describe('Client error case (4XX status)', () => {
-    it('should log fatal and exit process on 403 Forbidden (no retry)', async () => {
+    it('should not exit on a single 4XX; warns and reschedules', async () => {
+      const mockLoggerWarn = jest.spyOn(logger, 'warn').mockImplementation();
       const clientOpts = createMockClientOpts();
       const identifyingMetadata = createMockIdentifyingMetadata();
 
@@ -291,19 +292,22 @@ describe('createWebSocket - renew auth behaviour', () => {
 
       await jest.advanceTimersByTimeAsync(expectedTimeoutMs);
 
-      clearTimeout(ws.timeoutHandlerId);
-
-      expect(mockRenewBrokerServerConnection).toHaveBeenCalledTimes(1);
-      expect(mockInvalidateToken).not.toHaveBeenCalled();
-      expect(mockLoggerFatal).toHaveBeenCalledWith(
+      expect(mockLoggerFatal).not.toHaveBeenCalled();
+      expect(mockProcessExit).not.toHaveBeenCalled();
+      // A non-401 failure must still drop the token so the next attempt refreshes.
+      expect(mockInvalidateToken).toHaveBeenCalled();
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
         expect.objectContaining({
           connection: expect.any(String),
           role: Role.primary,
           responseCode: 403,
+          consecutiveAuthFailures: 1,
         }),
-        'Failed to renew connection due to a client error. Exiting...',
+        'Failed to renew connection.',
       );
-      expect(mockProcessExit).toHaveBeenCalledWith(1);
+      expect(ws.timeoutHandlerId).toBeDefined();
+
+      clearTimeout(ws.timeoutHandlerId);
     });
 
     it('should retry once on 401 and succeed without exiting', async () => {
@@ -328,7 +332,7 @@ describe('createWebSocket - renew auth behaviour', () => {
       expect(mockProcessExit).not.toHaveBeenCalled();
     });
 
-    it('should log fatal and exit when 401 retry also returns 401', async () => {
+    it('should count a 401 that survives its retry as a single failure (no exit)', async () => {
       const clientOpts = createMockClientOpts();
       const identifyingMetadata = createMockIdentifyingMetadata();
 
@@ -344,19 +348,69 @@ describe('createWebSocket - renew auth behaviour', () => {
 
       await jest.advanceTimersByTimeAsync(expectedTimeoutMs);
 
-      clearTimeout(ws.timeoutHandlerId);
-
       expect(mockRenewBrokerServerConnection).toHaveBeenCalledTimes(2);
-      expect(mockInvalidateToken).toHaveBeenCalledTimes(1);
+      // Once in the in-cycle 401 retry, once in the catch so the next cycle refreshes.
+      expect(mockInvalidateToken).toHaveBeenCalledTimes(2);
+      expect(mockLoggerFatal).not.toHaveBeenCalled();
+      expect(mockProcessExit).not.toHaveBeenCalled();
+
+      clearTimeout(ws.timeoutHandlerId);
+    });
+
+    it('should exit with oauth_token_unavailable after N consecutive failures and reset on success', async () => {
+      const recordProcessExitSpy = jest.spyOn(
+        require('../../../lib/hybrid-sdk/client/metrics/noopClient').NoopClient
+          .prototype,
+        'recordProcessExit',
+      );
+      const clientOpts = createMockClientOpts();
+      const identifyingMetadata = createMockIdentifyingMetadata();
+
+      const ws = createWebSocket(clientOpts, identifyingMetadata, Role.primary);
+
+      const expectedTimeoutMs = 10 * 60 * 1000;
+      const fail = () =>
+        mockRenewBrokerServerConnection.mockResolvedValue({
+          statusCode: 403,
+          headers: {},
+          body: '{}',
+        });
+      const succeed = () =>
+        mockRenewBrokerServerConnection.mockResolvedValue({
+          statusCode: 200,
+          headers: {},
+          body: '{}',
+        });
+
+      // Two failures, then a success resets the counter.
+      fail();
+      await jest.advanceTimersByTimeAsync(expectedTimeoutMs);
+      await jest.advanceTimersByTimeAsync(expectedTimeoutMs);
+      succeed();
+      await jest.advanceTimersByTimeAsync(expectedTimeoutMs);
+      expect(mockProcessExit).not.toHaveBeenCalled();
+
+      // Three consecutive failures from a reset counter trips the exit.
+      fail();
+      await jest.advanceTimersByTimeAsync(expectedTimeoutMs);
+      await jest.advanceTimersByTimeAsync(expectedTimeoutMs);
+      expect(mockProcessExit).not.toHaveBeenCalled();
+      await jest.advanceTimersByTimeAsync(expectedTimeoutMs);
+
       expect(mockLoggerFatal).toHaveBeenCalledWith(
         expect.objectContaining({
           connection: expect.any(String),
           role: Role.primary,
-          responseCode: 401,
+          responseCode: 403,
         }),
-        'Failed to renew connection due to a client error. Exiting...',
+        expect.stringContaining('consecutive times. Exiting...'),
+      );
+      expect(recordProcessExitSpy).toHaveBeenCalledWith(
+        'oauth_token_unavailable',
       );
       expect(mockProcessExit).toHaveBeenCalledWith(1);
+
+      clearTimeout(ws.timeoutHandlerId);
     });
   });
 
@@ -442,6 +496,27 @@ describe('createWebSocket - renew auth behaviour', () => {
       // Second tick: loop survived and the 200 response is honored.
       await jest.advanceTimersByTimeAsync(expectedTimeoutMs);
       expect(mockRenewBrokerServerConnection).toHaveBeenCalledTimes(2);
+
+      clearTimeout(ws.timeoutHandlerId);
+    });
+  });
+
+  describe('error handling', () => {
+    it('invalidates the cached token on a websocket error when OAuth is in use', async () => {
+      const clientOpts = createMockClientOpts();
+      const identifyingMetadata = createMockIdentifyingMetadata();
+      const ws = createWebSocket(clientOpts, identifyingMetadata, Role.primary);
+
+      const errorHandlers = (ws.on as jest.Mock).mock.calls
+        .filter(([event]) => event === 'error')
+        .map(([, handler]) => handler);
+      expect(errorHandlers.length).toBeGreaterThan(0);
+
+      errorHandlers.forEach((handler) =>
+        handler({ type: 'TransportError', description: 'boom' }),
+      );
+
+      expect(mockInvalidateToken).toHaveBeenCalled();
 
       clearTimeout(ws.timeoutHandlerId);
     });


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

A single 4xx during auth renewal previously killed the broker client, taking down a healthy client that would have recovered next cycle. This trades aggressive fail-fast for self-healing, cutting avoidable restarts while still surfacing persistent auth problems.

Auth failures now get several chances to refresh a fresh token before giving up; each failure drops the cached token so the next attempt truly re-authenticates, and only sustained failure restarts the process for a clean supervisor relaunch. 401s seen while posting data or reconnecting also force a refresh instead of reusing a rejected token.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
