### PR TITLE
feat: send error codes to server via websocket

### DIFF
--- a/lib/broker-workload/clientLocalRequests.ts
+++ b/lib/broker-workload/clientLocalRequests.ts
@@ -13,7 +13,7 @@ import { ExtendedLogContext } from '../hybrid-sdk/common/types/log';
 import {
   BROKER_ERROR_CODES,
   statusForErrorCode,
-} from '../hybrid-sdk/common/types/errorCodes';
+} from '../hybrid-sdk/common/types/telemetry';
 import { incrementHttpRequestsTotal } from '../hybrid-sdk/common/utils/metrics';
 import type { Client as MetricsClient } from '../hybrid-sdk/client/metrics/client';
 import { NoopClient } from '../hybrid-sdk/client/metrics/noopClient';

--- a/lib/broker-workload/websocketRequests.ts
+++ b/lib/broker-workload/websocketRequests.ts
@@ -23,7 +23,7 @@ import {
   BROKER_ERROR_CODES,
   classifyDownstreamError,
   statusForErrorCode,
-} from '../hybrid-sdk/common/types/errorCodes';
+} from '../hybrid-sdk/common/types/telemetry';
 import {
   incrementWebSocketRequestsTotal,
   incrementHttpRequestsTotal,

--- a/lib/broker-workload/websocketRequests.ts
+++ b/lib/broker-workload/websocketRequests.ts
@@ -18,6 +18,7 @@ import {
   WorkloadType,
 } from '../hybrid-sdk/workloadFactory';
 import { prepareRequest } from './prepareRequest';
+import { emitError } from '../hybrid-sdk/client/events';
 import { ExtendedLogContext } from '../hybrid-sdk/common/types/log';
 import {
   BROKER_ERROR_CODES,
@@ -223,6 +224,12 @@ export class BrokerWorkload extends Workload<WorkloadType.remoteServer> {
               '[Downstream] Caught error making streaming request to downstream ',
             );
             const code = classifyDownstreamError(e);
+            // Bounded classification only — never the downstream message/body.
+            emitError({
+              errorCode: code,
+              requestId: logContext.requestId,
+              integrationType: logContext.connectionName,
+            });
             return responseHandler.sendResponse({
               status: statusForErrorCode(code),
               errorType: code,

--- a/lib/broker-workload/websocketRequests.ts
+++ b/lib/broker-workload/websocketRequests.ts
@@ -272,6 +272,10 @@ export class BrokerWorkload extends Workload<WorkloadType.remoteServer> {
             metricsClient?.recordDownstreamStatus('5xx');
             logError(logContext, error);
             const code = classifyDownstreamError(error);
+            // emitError is intentionally absent here: the caller receives a
+            // structured HTTP error response, making the failure observable
+            // via the response path. Only the streaming catch emits, because
+            // streaming failures are otherwise silent to the server.
             return responseHandler.sendResponse({
               status: statusForErrorCode(code),
               errorType: code,

--- a/lib/hybrid-sdk/client/auth/oauth.ts
+++ b/lib/hybrid-sdk/client/auth/oauth.ts
@@ -1,6 +1,8 @@
 import { AccessToken, ClientCredentials, ModuleOptions } from 'simple-oauth2';
 import { log as logger } from '../../../logs/logger';
 import type { Client as MetricsClient } from '../metrics/client';
+import { emitError } from '../events';
+import { BROKER_ERROR_CODES } from '../../common/types/telemetry';
 
 export interface InitOAuthClientOptions {
   apiHostname: string;
@@ -58,6 +60,7 @@ function refreshToken(): Promise<AccessToken> {
       return token;
     } catch (err) {
       metrics?.recordJwtRefreshFailure();
+      emitError({ errorCode: BROKER_ERROR_CODES.JWT_REFRESH_FAILED });
       logger.error({ err }, 'Unable to retrieve JWT');
       throw err;
     } finally {

--- a/lib/hybrid-sdk/client/events.ts
+++ b/lib/hybrid-sdk/client/events.ts
@@ -7,31 +7,32 @@ import {
 } from '../common/types/telemetry';
 import { log as logger } from '../../logs/logger';
 
-// The socket is registered on WS 'open' and cleared on 'close', so a non-null
-// eventSocket is always connected — hence emit() needs no readyState check.
+// One entry per live websocket connection, added on 'open' and removed on 'close'.
 
 interface EventSocket {
   send(event: string, data: unknown): void;
 }
 
-let eventSocket: EventSocket | null = null;
+const eventSockets = new Set<EventSocket>();
 
 export const registerEventSocket = (socket: EventSocket): void => {
-  eventSocket = socket;
+  eventSockets.add(socket);
 };
 
-export const clearEventSocket = (): void => {
-  eventSocket = null;
+export const clearEventSocket = (socket: EventSocket): void => {
+  eventSockets.delete(socket);
 };
 
+// emit selects a single websocket to send the event.
 const emit = (event: ClientEvent): void => {
-  if (!eventSocket) return;
+  const socket = eventSockets.values().next().value;
+  if (!socket) return;
   const envelope: ClientEventEnvelope = {
     ts: Date.now(),
     event,
   };
   try {
-    eventSocket.send(CLIENT_EVENT_MESSAGE, envelope);
+    socket.send(CLIENT_EVENT_MESSAGE, envelope);
   } catch (err) {
     logger.debug({ err }, 'Failed to emit broker client event');
   }

--- a/lib/hybrid-sdk/client/events.ts
+++ b/lib/hybrid-sdk/client/events.ts
@@ -1,0 +1,51 @@
+import {
+  BrokerErrorCode,
+  CLIENT_EVENT_MESSAGE,
+  ClientEvent,
+  ClientEventEnvelope,
+  ClientShutdownReason,
+} from '../common/types/telemetry';
+import { log as logger } from '../../logs/logger';
+
+// Best-effort, fire-and-forget emission of client events over the existing
+// websocket. Events are only sent while connected, never queued. A failure
+// to emit must never disrupt request handling.
+
+interface EventSocket {
+  send(event: string, data: unknown): void;
+}
+
+let eventSocket: EventSocket | null = null;
+
+export const registerEventSocket = (socket: EventSocket): void => {
+  eventSocket = socket;
+};
+
+export const clearEventSocket = (): void => {
+  eventSocket = null;
+};
+
+const emit = (event: ClientEvent): void => {
+  if (!eventSocket) return;
+  const envelope: ClientEventEnvelope = {
+    ts: Date.now(),
+    event,
+  };
+  try {
+    eventSocket.send(CLIENT_EVENT_MESSAGE, envelope);
+  } catch (err) {
+    logger.debug({ err }, 'Failed to emit broker client event');
+  }
+};
+
+export const emitError = (error: {
+  errorCode: BrokerErrorCode;
+  requestId?: string;
+  integrationType?: string;
+}): void => emit({ type: 'client-error', ...error });
+
+export const emitShutdown = (shutdown: {
+  reason: ClientShutdownReason;
+  uptimeSeconds: number;
+  errorCode?: string;
+}): void => emit({ type: 'client-shutdown', ...shutdown });

--- a/lib/hybrid-sdk/client/events.ts
+++ b/lib/hybrid-sdk/client/events.ts
@@ -4,6 +4,7 @@ import {
   ClientEvent,
   ClientEventEnvelope,
   ClientShutdownReason,
+  SafeNodeErrno,
 } from '../common/types/telemetry';
 import { log as logger } from '../../logs/logger';
 
@@ -47,5 +48,5 @@ export const emitError = (error: {
 export const emitShutdown = (shutdown: {
   reason: ClientShutdownReason;
   uptimeSeconds: number;
-  errorCode?: string;
+  errorCode?: SafeNodeErrno;
 }): void => emit({ type: 'client-shutdown', ...shutdown });

--- a/lib/hybrid-sdk/client/events.ts
+++ b/lib/hybrid-sdk/client/events.ts
@@ -7,9 +7,8 @@ import {
 } from '../common/types/telemetry';
 import { log as logger } from '../../logs/logger';
 
-// Best-effort, fire-and-forget emission of client events over the existing
-// websocket. Events are only sent while connected, never queued. A failure
-// to emit must never disrupt request handling.
+// The socket is registered on WS 'open' and cleared on 'close', so a non-null
+// eventSocket is always connected — hence emit() needs no readyState check.
 
 interface EventSocket {
   send(event: string, data: unknown): void;

--- a/lib/hybrid-sdk/client/index.ts
+++ b/lib/hybrid-sdk/client/index.ts
@@ -31,7 +31,7 @@ import { retrieveAndLoadFilters } from './utils/filterLoading';
 import { probeIpv6WithIpv4Fallback } from './utils/probeIpv6WithIpv4Fallback';
 import * as metrics from './metrics';
 import { emitShutdown } from './events';
-import { PROCESS_EXIT_REASONS } from '../common/types/telemetry';
+import { PROCESS_EXIT_REASONS, safeNodeErrno } from '../common/types/telemetry';
 
 const ONEDAY = 24 * 3600 * 1000; // 24h in ms
 
@@ -294,11 +294,11 @@ export const handleUncaughtException = (
     );
   } else {
     metricsClient.recordProcessExit(PROCESS_EXIT_REASONS.UNCAUGHT_EXCEPTION);
-    // Bounded Node errno only — never error.message (free-form).
+    // safeNodeErrno strips non-standard .code values (e.g. library-defined ERR_* strings).
     emitShutdown({
       reason: PROCESS_EXIT_REASONS.UNCAUGHT_EXCEPTION,
       uptimeSeconds: Math.round(process.uptime()),
-      errorCode: (error as NodeJS.ErrnoException).code,
+      errorCode: safeNodeErrno((error as NodeJS.ErrnoException).code),
     });
     logger.error(
       { msg: error.message, stackTrace: error.stack },

--- a/lib/hybrid-sdk/client/index.ts
+++ b/lib/hybrid-sdk/client/index.ts
@@ -30,6 +30,8 @@ import { findPluginFolder } from '../common/config/config';
 import { retrieveAndLoadFilters } from './utils/filterLoading';
 import { probeIpv6WithIpv4Fallback } from './utils/probeIpv6WithIpv4Fallback';
 import * as metrics from './metrics';
+import { emitShutdown } from './events';
+import { PROCESS_EXIT_REASONS } from '../common/types/telemetry';
 
 const ONEDAY = 24 * 3600 * 1000; // 24h in ms
 
@@ -291,7 +293,13 @@ export const handleUncaughtException = (
       error.message,
     );
   } else {
-    metricsClient.recordProcessExit('uncaught_exception');
+    metricsClient.recordProcessExit(PROCESS_EXIT_REASONS.UNCAUGHT_EXCEPTION);
+    // Bounded Node errno only — never error.message (free-form).
+    emitShutdown({
+      reason: PROCESS_EXIT_REASONS.UNCAUGHT_EXCEPTION,
+      uptimeSeconds: Math.round(process.uptime()),
+      errorCode: (error as NodeJS.ErrnoException).code,
+    });
     logger.error(
       { msg: error.message, stackTrace: error.stack },
       'Uncaught exception:',

--- a/lib/hybrid-sdk/client/metrics/client.ts
+++ b/lib/hybrid-sdk/client/metrics/client.ts
@@ -1,3 +1,8 @@
+import {
+  ConnectionState,
+  ProcessExitReason,
+} from '../../common/types/telemetry';
+
 /** Backend-agnostic interface for emitting broker client metrics. */
 export interface Client {
   /** Record a broker client initialization event. */
@@ -14,10 +19,7 @@ export interface Client {
    * Sets the active state to 1 and all other states to 0 on the
    * broker.client.connection.state gauge.
    */
-  setConnectionState(
-    state: 'connected' | 'reconnecting' | 'failed',
-    role: string,
-  ): void;
+  setConnectionState(state: ConnectionState, role: string): void;
 
   /** Increment broker.client.reconnect.total on each retry attempt. */
   recordReconnect(): void;
@@ -26,13 +28,7 @@ export interface Client {
    * Increment broker.client.process_exit.total before process.exit().
    * Best-effort — call forceFlush() if in an async context.
    */
-  recordProcessExit(
-    reason:
-      | 'reconnect_exhaustion'
-      | 'auth_4xx'
-      | 'oauth_token_unavailable'
-      | 'uncaught_exception',
-  ): void;
+  recordProcessExit(reason: ProcessExitReason): void;
 
   /** Increment broker.client.auth_renewal_failure.total for non-2xx auth renewal responses. */
   recordAuthRenewalFailure(statusCode: number): void;

--- a/lib/hybrid-sdk/client/metrics/otelClient.ts
+++ b/lib/hybrid-sdk/client/metrics/otelClient.ts
@@ -16,8 +16,11 @@ import {
   AggregationType,
 } from '@opentelemetry/sdk-metrics';
 import { Client } from './client';
-
-const CONNECTION_STATES = ['connected', 'reconnecting', 'failed'] as const;
+import {
+  CONNECTION_STATES,
+  ConnectionState,
+  ProcessExitReason,
+} from '../../common/types/telemetry';
 
 /** Constructor options for {@link OtelClient}. */
 export interface OtelClientConfig {
@@ -286,10 +289,7 @@ export class OtelClient implements Client {
    * Set the connection state gauge for a given role.
    * Sets the active state attribute to 1 and all other state attributes to 0.
    */
-  setConnectionState(
-    state: 'connected' | 'reconnecting' | 'failed',
-    role: string,
-  ): void {
+  setConnectionState(state: ConnectionState, role: string): void {
     for (const s of CONNECTION_STATES) {
       this.connectionStateGauge.record(s === state ? 1 : 0, {
         state: s,
@@ -302,13 +302,7 @@ export class OtelClient implements Client {
     this.reconnectCounter.add(1);
   }
 
-  recordProcessExit(
-    reason:
-      | 'reconnect_exhaustion'
-      | 'auth_4xx'
-      | 'oauth_token_unavailable'
-      | 'uncaught_exception',
-  ): void {
+  recordProcessExit(reason: ProcessExitReason): void {
     this.processExitCounter.add(1, { reason });
   }
 

--- a/lib/hybrid-sdk/client/metrics/otelClient.ts
+++ b/lib/hybrid-sdk/client/metrics/otelClient.ts
@@ -136,7 +136,7 @@ export class OtelClient implements Client {
       'broker.client.process_exit.total',
       {
         description:
-          'Count of process exits by reason (reconnect_exhaustion, auth_4xx, oauth_token_unavailable, uncaught_exception).',
+          'Count of process exits by reason (reconnect_exhaustion, oauth_token_unavailable, uncaught_exception).',
         valueType: ValueType.INT,
       },
     );

--- a/lib/hybrid-sdk/client/socket.ts
+++ b/lib/hybrid-sdk/client/socket.ts
@@ -34,7 +34,7 @@ import { AuthRenewalError } from './auth/errors';
 import version from '../common/utils/version';
 import { addServerIdAndRoleQS } from '../http/utils';
 import { serviceHandler } from './socketHandlers/serviceHandler';
-import { emitError } from './events';
+import { emitError, emitShutdown } from './events';
 import {
   BROKER_ERROR_CODES,
   PROCESS_EXIT_REASONS,
@@ -281,6 +281,10 @@ export const createWebSocket = (
           metricsClient.recordProcessExit(
             PROCESS_EXIT_REASONS.OAUTH_TOKEN_UNAVAILABLE,
           );
+          emitShutdown({
+            reason: PROCESS_EXIT_REASONS.OAUTH_TOKEN_UNAVAILABLE,
+            uptimeSeconds: Math.round(process.uptime()),
+          });
           await metricsClient.forceFlush().catch((flushErr) => {
             logger.warn(
               { ...commonLogFields, err: flushErr },
@@ -342,6 +346,10 @@ export const createWebSocket = (
 
   websocket.on('reconnect failed', () => {
     metricsClient.setConnectionState('failed', identifyingMetadata.role);
+    // No client-shutdown event here: 'close' already fired and cleared the
+    // event socket, and the transport is permanently down — the event could
+    // never be delivered. The reason is still observable via the
+    // process_exit metric, which flushes over the OTLP channel, not the WS.
     metricsClient.recordProcessExit(PROCESS_EXIT_REASONS.RECONNECT_EXHAUSTION);
     metricsClient.forceFlush().catch((err) => {
       logger.warn({ err }, 'Failed to flush metrics before exit');

--- a/lib/hybrid-sdk/client/socket.ts
+++ b/lib/hybrid-sdk/client/socket.ts
@@ -34,6 +34,11 @@ import { AuthRenewalError } from './auth/errors';
 import version from '../common/utils/version';
 import { addServerIdAndRoleQS } from '../http/utils';
 import { serviceHandler } from './socketHandlers/serviceHandler';
+import { emitError } from './events';
+import {
+  BROKER_ERROR_CODES,
+  PROCESS_EXIT_REASONS,
+} from '../common/types/telemetry';
 
 const MAX_CONSECUTIVE_AUTH_FAILURES = 3;
 
@@ -273,7 +278,9 @@ export const createWebSocket = (
             { ...commonLogFields, responseCode: statusCode, err: errField },
             `Failed to renew connection ${consecutiveAuthFailures} consecutive times. Exiting...`,
           );
-          metricsClient.recordProcessExit('oauth_token_unavailable');
+          metricsClient.recordProcessExit(
+            PROCESS_EXIT_REASONS.OAUTH_TOKEN_UNAVAILABLE,
+          );
           await metricsClient.forceFlush().catch((flushErr) => {
             logger.warn(
               { ...commonLogFields, err: flushErr },
@@ -293,6 +300,7 @@ export const createWebSocket = (
           },
           'Failed to renew connection.',
         );
+        emitError({ errorCode: BROKER_ERROR_CODES.AUTH_RENEWAL_FAILED });
       } finally {
         websocket.timeoutHandlerId = setTimeout(
           timeoutHandler,
@@ -334,7 +342,7 @@ export const createWebSocket = (
 
   websocket.on('reconnect failed', () => {
     metricsClient.setConnectionState('failed', identifyingMetadata.role);
-    metricsClient.recordProcessExit('reconnect_exhaustion');
+    metricsClient.recordProcessExit(PROCESS_EXIT_REASONS.RECONNECT_EXHAUSTION);
     metricsClient.forceFlush().catch((err) => {
       logger.warn({ err }, 'Failed to flush metrics before exit');
     });

--- a/lib/hybrid-sdk/client/socketHandlers/closeHandler.ts
+++ b/lib/hybrid-sdk/client/socketHandlers/closeHandler.ts
@@ -10,7 +10,7 @@ export const closeHandler = (
   identifyingMetadata,
   metricsClient: Client,
 ) => {
-  clearEventSocket();
+  clearEventSocket(websocket);
   // default duration of -1 so that it is obvious if this misbehaves
   let durationMs = -1;
   if (websocket.connectionStartTime) {

--- a/lib/hybrid-sdk/client/socketHandlers/closeHandler.ts
+++ b/lib/hybrid-sdk/client/socketHandlers/closeHandler.ts
@@ -2,6 +2,7 @@ import { LoadedClientOpts } from '../../common/types/options';
 import { log as logger } from '../../../logs/logger';
 import { WebSocketConnection } from '../types/client';
 import { Client } from '../metrics/client';
+import { clearEventSocket } from '../events';
 
 export const closeHandler = (
   websocket: WebSocketConnection,
@@ -9,6 +10,7 @@ export const closeHandler = (
   identifyingMetadata,
   metricsClient: Client,
 ) => {
+  clearEventSocket();
   // default duration of -1 so that it is obvious if this misbehaves
   let durationMs = -1;
   if (websocket.connectionStartTime) {

--- a/lib/hybrid-sdk/client/socketHandlers/openHandler.ts
+++ b/lib/hybrid-sdk/client/socketHandlers/openHandler.ts
@@ -3,6 +3,7 @@ import { hashToken } from '../../common/utils/token';
 import { log as logger } from '../../../logs/logger';
 import { IdentifyingMetadata } from '../types/client';
 import { Client } from '../metrics/client';
+import { registerEventSocket } from '../events';
 
 export const openHandler = (
   io,
@@ -21,6 +22,7 @@ export const openHandler = (
     clientConfig: identifyingMetadata.clientConfig,
     filters: identifyingMetadata.filters ?? {},
     role: identifyingMetadata.role,
+    deploymentId: clientOps.config.deploymentId,
   };
   if (clientOps.config.universalBrokerEnabled) {
     metadata['supportedIntegrationType'] =
@@ -52,4 +54,5 @@ export const openHandler = (
     metadata: metadata,
   };
   io.send('identify', clientData);
+  registerEventSocket(io);
 };

--- a/lib/hybrid-sdk/client/types/client.ts
+++ b/lib/hybrid-sdk/client/types/client.ts
@@ -35,6 +35,7 @@ export interface IdentifyingMetadata {
   version: string;
   serverId?: string;
   identifier?: string;
+  deploymentId?: string;
   id: string;
   isDisabled: boolean;
   supportedIntegrationType?: string;

--- a/lib/hybrid-sdk/common/types/telemetry.ts
+++ b/lib/hybrid-sdk/common/types/telemetry.ts
@@ -11,7 +11,7 @@ export const BROKER_ERROR_CODES = {
   DOWNSTREAM_RATE_LIMITED: 'DOWNSTREAM_RATE_LIMITED',
   DOWNSTREAM_SERVER_ERROR: 'DOWNSTREAM_SERVER_ERROR',
   DOWNSTREAM_UNEXPECTED: 'DOWNSTREAM_UNEXPECTED',
-  // Event-only codes (see clientEvents.ts); never a response errorType.
+  // Event-only codes (emitted on client events); never a response errorType.
   SEND_BACK_FAILED: 'SEND_BACK_FAILED',
   JWT_REFRESH_FAILED: 'JWT_REFRESH_FAILED',
   AUTH_RENEWAL_FAILED: 'AUTH_RENEWAL_FAILED',
@@ -69,7 +69,6 @@ export interface BrokerErrorBody {
 // Reasons the client records before process.exit(); a subset feeds client-shutdown events.
 export const PROCESS_EXIT_REASONS = {
   RECONNECT_EXHAUSTION: 'reconnect_exhaustion',
-  AUTH_4XX: 'auth_4xx',
   UNCAUGHT_EXCEPTION: 'uncaught_exception',
   OAUTH_TOKEN_UNAVAILABLE: 'oauth_token_unavailable',
 } as const;

--- a/lib/hybrid-sdk/common/types/telemetry.ts
+++ b/lib/hybrid-sdk/common/types/telemetry.ts
@@ -93,21 +93,21 @@ export type ClientShutdownReason = ProcessExitReason | 'clean';
 export type ClientEvent =
   | {
       type: 'client-error';
-      error_code: BrokerErrorCode;
-      request_id?: string;
-      integration_type?: string;
+      errorCode: BrokerErrorCode;
+      requestId?: string;
+      integrationType?: string;
     }
   | {
       type: 'client-shutdown';
       reason: ClientShutdownReason;
-      uptime_seconds: number;
-      error_code?: string; // bounded Node errno, uncaught_exception only
+      uptimeSeconds: number;
+      errorCode?: string; // bounded Node errno, uncaught_exception only
     };
 
 export type ClientEventType = ClientEvent['type'];
 
 export interface ClientEventEnvelope {
-  schema_version: number;
+  schemaVersion: number;
   ts: number; // client clock; server stamps the authoritative receipt time
   event: ClientEvent;
 }

--- a/lib/hybrid-sdk/common/types/telemetry.ts
+++ b/lib/hybrid-sdk/common/types/telemetry.ts
@@ -11,6 +11,10 @@ export const BROKER_ERROR_CODES = {
   DOWNSTREAM_RATE_LIMITED: 'DOWNSTREAM_RATE_LIMITED',
   DOWNSTREAM_SERVER_ERROR: 'DOWNSTREAM_SERVER_ERROR',
   DOWNSTREAM_UNEXPECTED: 'DOWNSTREAM_UNEXPECTED',
+  // Event-only codes (see clientEvents.ts); never a response errorType.
+  SEND_BACK_FAILED: 'SEND_BACK_FAILED',
+  JWT_REFRESH_FAILED: 'JWT_REFRESH_FAILED',
+  AUTH_RENEWAL_FAILED: 'AUTH_RENEWAL_FAILED',
 } as const;
 
 export type BrokerErrorCode =
@@ -60,4 +64,50 @@ export const classifyDownstreamStatus = (
 export interface BrokerErrorBody {
   code: BrokerErrorCode;
   message: string;
+}
+
+// Reasons the client records before process.exit(); a subset feeds client-shutdown events.
+export const PROCESS_EXIT_REASONS = [
+  'reconnect_exhaustion',
+  'auth_4xx',
+  'uncaught_exception',
+  'oauth_token_unavailable',
+] as const;
+export type ProcessExitReason = (typeof PROCESS_EXIT_REASONS)[number];
+
+export const CONNECTION_STATES = [
+  'connected',
+  'reconnecting',
+  'failed',
+] as const;
+export type ConnectionState = (typeof CONNECTION_STATES)[number];
+
+// Structured events the broker client emits over the existing websocket.
+// Every field must stay bounded (enums, ids, numbers) — never free-form
+// strings — so customer data cannot reach server logs.
+export const CLIENT_EVENT_MESSAGE = 'client-event';
+
+// A process exit (fatal) or a clean shutdown.
+export type ClientShutdownReason = ProcessExitReason | 'clean';
+
+export type ClientEvent =
+  | {
+      type: 'client-error';
+      error_code: BrokerErrorCode;
+      request_id?: string;
+      integration_type?: string;
+    }
+  | {
+      type: 'client-shutdown';
+      reason: ClientShutdownReason;
+      uptime_seconds: number;
+      error_code?: string; // bounded Node errno, uncaught_exception only
+    };
+
+export type ClientEventType = ClientEvent['type'];
+
+export interface ClientEventEnvelope {
+  schema_version: number;
+  ts: number; // client clock; server stamps the authoritative receipt time
+  event: ClientEvent;
 }

--- a/lib/hybrid-sdk/common/types/telemetry.ts
+++ b/lib/hybrid-sdk/common/types/telemetry.ts
@@ -67,13 +67,15 @@ export interface BrokerErrorBody {
 }
 
 // Reasons the client records before process.exit(); a subset feeds client-shutdown events.
-export const PROCESS_EXIT_REASONS = [
-  'reconnect_exhaustion',
-  'auth_4xx',
-  'uncaught_exception',
-  'oauth_token_unavailable',
-] as const;
-export type ProcessExitReason = (typeof PROCESS_EXIT_REASONS)[number];
+export const PROCESS_EXIT_REASONS = {
+  RECONNECT_EXHAUSTION: 'reconnect_exhaustion',
+  AUTH_4XX: 'auth_4xx',
+  UNCAUGHT_EXCEPTION: 'uncaught_exception',
+  OAUTH_TOKEN_UNAVAILABLE: 'oauth_token_unavailable',
+} as const;
+
+export type ProcessExitReason =
+  (typeof PROCESS_EXIT_REASONS)[keyof typeof PROCESS_EXIT_REASONS];
 
 export const CONNECTION_STATES = [
   'connected',

--- a/lib/hybrid-sdk/common/types/telemetry.ts
+++ b/lib/hybrid-sdk/common/types/telemetry.ts
@@ -102,7 +102,7 @@ export type ClientEvent =
       type: 'client-shutdown';
       reason: ClientShutdownReason;
       uptimeSeconds: number;
-      errorCode?: string; // bounded Node errno, uncaught_exception only
+      errorCode?: SafeNodeErrno; // callers must use safeNodeErrno(); type enforces this
     };
 
 export type ClientEventType = ClientEvent['type'];
@@ -111,3 +111,33 @@ export interface ClientEventEnvelope {
   ts: number; // client clock; server stamps the authoritative receipt time
   event: ClientEvent;
 }
+
+// OS-level errno codes that are safe to include in server logs.
+// All other values — including library-defined codes like ERR_TLS_CERT_ALTNAME_INVALID
+// — are stripped by safeNodeErrno() before the event is emitted.
+const KNOWN_NODE_ERRNO_LIST = [
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ETIMEDOUT',
+  'ENOTFOUND',
+  'EPIPE',
+  'EADDRINUSE',
+  'EACCES',
+  'ENOENT',
+  'EBUSY',
+  'EMFILE',
+  'ENOMEM',
+  'EPROTO',
+  'ESOCKETTIMEDOUT',
+] as const;
+
+export type SafeNodeErrno = (typeof KNOWN_NODE_ERRNO_LIST)[number];
+export const KNOWN_NODE_ERRNOS = new Set<string>(KNOWN_NODE_ERRNO_LIST);
+
+/** Returns `code` only when it is a known OS-level errno; strips everything else. */
+export const safeNodeErrno = (
+  code: string | undefined,
+): SafeNodeErrno | undefined =>
+  code !== undefined && KNOWN_NODE_ERRNOS.has(code)
+    ? (code as SafeNodeErrno)
+    : undefined;

--- a/lib/hybrid-sdk/common/types/telemetry.ts
+++ b/lib/hybrid-sdk/common/types/telemetry.ts
@@ -107,7 +107,6 @@ export type ClientEvent =
 export type ClientEventType = ClientEvent['type'];
 
 export interface ClientEventEnvelope {
-  schemaVersion: number;
   ts: number; // client clock; server stamps the authoritative receipt time
   event: ClientEvent;
 }

--- a/lib/hybrid-sdk/common/utils/signals.ts
+++ b/lib/hybrid-sdk/common/utils/signals.ts
@@ -1,4 +1,5 @@
 import { getWebsocketConnections } from '../../client';
+import { emitShutdown } from '../../client/events';
 import { log as logger } from '../../../logs/logger';
 
 const intervals: NodeJS.Timeout[] = [];
@@ -66,6 +67,10 @@ export const clearAndRemoveTimeout = (timeoutId: NodeJS.Timeout) => {
 const signalTerminationToServer = (signal) => {
   const [websocket] = getWebsocketConnections();
   if (websocket) {
+    emitShutdown({
+      reason: 'clean',
+      uptimeSeconds: Math.round(process.uptime()),
+    });
     websocket.send('terminate', {
       signal,
     });

--- a/lib/hybrid-sdk/http/downstream-post-stream-to-server.ts
+++ b/lib/hybrid-sdk/http/downstream-post-stream-to-server.ts
@@ -18,7 +18,7 @@ import { addServerIdAndRoleQS } from './utils';
 import { getConfig } from '../common/config/config';
 import type { ExtendedLogContext } from '../common/types/log';
 import { replaceUrlPartialChunk } from '../common/utils/replace-vars';
-import { classifyDownstreamStatus } from '../common/types/errorCodes';
+import { classifyDownstreamStatus } from '../common/types/telemetry';
 import { performance } from 'node:perf_hooks';
 
 const BROKER_CONTENT_TYPE = 'application/vnd.broker.stream+octet-stream';

--- a/lib/hybrid-sdk/responseSenders.ts
+++ b/lib/hybrid-sdk/responseSenders.ts
@@ -14,7 +14,7 @@ import {
   BROKER_ERROR_CODES,
   classifyDownstreamStatus,
   statusForErrorCode,
-} from './common/types/errorCodes';
+} from './common/types/telemetry';
 
 export interface HybridResponse {
   status: number;

--- a/lib/hybrid-sdk/responseSenders.ts
+++ b/lib/hybrid-sdk/responseSenders.ts
@@ -9,6 +9,7 @@ import { RequestMetadata } from './types';
 import { WebSocketConnection } from './client/types/client';
 import { WebSocketServer } from './server/types/socket';
 import { ExtendedLogContext } from './common/types/log';
+import { emitError } from './client/events';
 import {
   BrokerErrorCode,
   BROKER_ERROR_CODES,
@@ -151,6 +152,13 @@ export class HybridResponseHandler {
         { ...this.logContext, err },
         `Error Posting via Emit callback.`,
       );
+      // Silent on the response path: the server's request times out with no
+      // payload. Emit a joinable signal so the timeout has a cause.
+      emitError({
+        errorCode: BROKER_ERROR_CODES.SEND_BACK_FAILED,
+        requestId: this.requestMetadata.requestId,
+        integrationType: this.logContext.connectionName,
+      });
     }
   };
 

--- a/lib/hybrid-sdk/server/socketHandlers/clientEventHandler.ts
+++ b/lib/hybrid-sdk/server/socketHandlers/clientEventHandler.ts
@@ -1,0 +1,53 @@
+import { log as logger } from '../../../logs/logger';
+import { ClientEventEnvelope } from '../../common/types/telemetry';
+
+// Server-owned identity, captured from the connection at identify time and
+// stamped onto every client event. Never taken from the event payload, so a
+// client cannot impersonate another install; hashedToken is the anchor.
+export interface ClientEventIdentity {
+  hashedToken: string;
+  maskedToken: string;
+  clientId?: string;
+  clientVersion?: string;
+  mode: 'universal' | 'legacy';
+  deploymentId?: string;
+}
+
+const FATAL_SHUTDOWN_REASONS = new Set(['uncaught_exception', 'auth_4xx']);
+
+const severityFor = (event: { type?: string; reason?: string }) => {
+  if (event.type === 'client-error') return 'warn' as const;
+  if (event.type === 'client-shutdown') {
+    return FATAL_SHUTDOWN_REASONS.has(event.reason ?? '')
+      ? ('error' as const)
+      : ('info' as const);
+  }
+  return 'info' as const; // unknown/forward-compat types: log, never drop
+};
+
+export const handleClientEvent =
+  (identity: ClientEventIdentity) =>
+  (message: ClientEventEnvelope): void => {
+    const event = message?.event as
+      | (Record<string, unknown> & { type?: string })
+      | undefined;
+    if (!event || typeof event.type !== 'string') {
+      logger.warn(
+        { ...identity, schemaVersion: message?.schemaVersion },
+        'Received malformed broker client event',
+      );
+      return;
+    }
+
+    const { type, ...eventFields } = event;
+    logger[severityFor(event)](
+      {
+        ...eventFields,
+        eventType: type,
+        schemaVersion: message.schemaVersion,
+        clientTs: message.ts,
+        ...identity, // last, so nothing in the payload can override identity
+      },
+      'broker client event',
+    );
+  };

--- a/lib/hybrid-sdk/server/socketHandlers/clientEventHandler.ts
+++ b/lib/hybrid-sdk/server/socketHandlers/clientEventHandler.ts
@@ -1,5 +1,8 @@
 import { log as logger } from '../../../logs/logger';
-import { ClientEventEnvelope } from '../../common/types/telemetry';
+import {
+  ClientEventEnvelope,
+  PROCESS_EXIT_REASONS,
+} from '../../common/types/telemetry';
 
 // Server-owned identity, captured from the connection at identify time and
 // stamped onto every client event. Never taken from the event payload, so a
@@ -13,7 +16,10 @@ export interface ClientEventIdentity {
   deploymentId?: string;
 }
 
-const FATAL_SHUTDOWN_REASONS = new Set(['uncaught_exception', 'auth_4xx']);
+const FATAL_SHUTDOWN_REASONS = new Set<string>([
+  PROCESS_EXIT_REASONS.UNCAUGHT_EXCEPTION,
+  PROCESS_EXIT_REASONS.OAUTH_TOKEN_UNAVAILABLE,
+]);
 
 const severityFor = (event: { type?: string; reason?: string }) => {
   if (event.type === 'client-error') return 'warn' as const;

--- a/lib/hybrid-sdk/server/socketHandlers/clientEventHandler.ts
+++ b/lib/hybrid-sdk/server/socketHandlers/clientEventHandler.ts
@@ -32,10 +32,7 @@ export const handleClientEvent =
       | (Record<string, unknown> & { type?: string })
       | undefined;
     if (!event || typeof event.type !== 'string') {
-      logger.warn(
-        { ...identity, schemaVersion: message?.schemaVersion },
-        'Received malformed broker client event',
-      );
+      logger.warn({ ...identity }, 'Received malformed broker client event');
       return;
     }
 
@@ -44,7 +41,6 @@ export const handleClientEvent =
       {
         ...eventFields,
         eventType: type,
-        schemaVersion: message.schemaVersion,
         clientTs: message.ts,
         ...identity, // last, so nothing in the payload can override identity
       },

--- a/lib/hybrid-sdk/server/socketHandlers/clientEventHandler.ts
+++ b/lib/hybrid-sdk/server/socketHandlers/clientEventHandler.ts
@@ -1,8 +1,51 @@
 import { log as logger } from '../../../logs/logger';
 import {
+  BROKER_ERROR_CODES,
   ClientEventEnvelope,
+  KNOWN_NODE_ERRNOS,
   PROCESS_EXIT_REASONS,
 } from '../../common/types/telemetry';
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const SAFE_LABEL_RE = /^[a-zA-Z0-9_-]{1,64}$/;
+
+// All valid errorCode values: BrokerErrorCode enum members + OS-level errnos.
+const VALID_ERROR_CODES = new Set<string>([
+  ...Object.values(BROKER_ERROR_CODES),
+  ...KNOWN_NODE_ERRNOS,
+]);
+
+const sanitizeEventFields = (
+  fields: Record<string, unknown>,
+): Record<string, unknown> => {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(fields)) {
+    if (k === 'requestId') {
+      if (typeof v === 'string' && UUID_RE.test(v)) out[k] = v;
+    } else if (k === 'integrationType') {
+      if (typeof v === 'string') {
+        const truncated = v.slice(0, 64);
+        if (SAFE_LABEL_RE.test(truncated)) out[k] = truncated;
+      }
+    } else if (k === 'errorCode') {
+      if (typeof v === 'string' && VALID_ERROR_CODES.has(v)) out[k] = v;
+    } else if (k === 'reason') {
+      if (typeof v === 'string' && SAFE_LABEL_RE.test(v)) out[k] = v;
+    } else if (k === 'uptimeSeconds') {
+      if (typeof v === 'number' && Number.isFinite(v) && v >= 0)
+        out[k] = Math.round(v);
+    } else if (typeof v === 'boolean' || v === null) {
+      out[k] = v;
+    } else if (typeof v === 'number' && Number.isFinite(v)) {
+      out[k] = v;
+    } else if (typeof v === 'string') {
+      out[k] = v.slice(0, 256);
+    }
+    // Objects/arrays from unrecognised fields are silently dropped.
+  }
+  return out;
+};
 
 // Server-owned identity, captured from the connection at identify time and
 // stamped onto every client event. Never taken from the event payload, so a
@@ -31,6 +74,10 @@ const severityFor = (event: { type?: string; reason?: string }) => {
   return 'info' as const; // unknown/forward-compat types: log, never drop
 };
 
+// Rate limiting: no per-socket message cap is applied here. client-event is
+// semantically bounded (a handful per connection lifetime), and the overall
+// broker websocket protocol has no per-event-type rate limiting. If high-
+// frequency emission becomes a concern, a per-Spark counter should be added.
 export const handleClientEvent =
   (identity: ClientEventIdentity) =>
   (message: ClientEventEnvelope): void => {
@@ -43,11 +90,22 @@ export const handleClientEvent =
     }
 
     const { type, ...eventFields } = event;
-    logger[severityFor(event)](
+    const rawType = type.slice(0, 64);
+    const eventType = SAFE_LABEL_RE.test(rawType) ? rawType : 'unknown';
+    const clientTs =
+      typeof message.ts === 'number' && Number.isFinite(message.ts)
+        ? message.ts
+        : undefined;
+    const serverTs = Date.now();
+    const safeFields = sanitizeEventFields(eventFields);
+    const safeReason =
+      typeof safeFields.reason === 'string' ? safeFields.reason : undefined;
+    logger[severityFor({ type: eventType, reason: safeReason })](
       {
-        ...eventFields,
-        eventType: type,
-        clientTs: message.ts,
+        ...safeFields,
+        eventType,
+        clientTs,
+        serverTs,
         ...identity, // last, so nothing in the payload can override identity
       },
       'broker client event',

--- a/lib/hybrid-sdk/server/socketHandlers/identifyHandler.ts
+++ b/lib/hybrid-sdk/server/socketHandlers/identifyHandler.ts
@@ -8,6 +8,8 @@ import { getForwardWebSocketRequestHandler } from './initHandlers';
 import semver from 'semver';
 import { legacyStreamResponseHandler } from '../../LegacyStreamResponseHandler';
 import { ISpark } from 'primus';
+import { CLIENT_EVENT_MESSAGE } from '../../common/types/telemetry';
+import { ClientEventIdentity, handleClientEvent } from './clientEventHandler';
 
 let response;
 const minimalSupportedBrokerVersion =
@@ -78,6 +80,17 @@ export const handleIdentifyOnSocket = (
   const { maskedToken, hashedToken } = getDesensitizedToken(token);
   const clientId = clientData.metadata.clientId;
   const clientVersion = clientData.metadata.version;
+  // Server-owned identity for the identify log and every client event.
+  const eventIdentity: ClientEventIdentity = {
+    hashedToken,
+    maskedToken,
+    clientId,
+    clientVersion,
+    mode: clientData.metadata.clientConfig?.universalBroker
+      ? 'universal'
+      : 'legacy',
+    deploymentId: clientData.metadata.deploymentId,
+  };
 
   if (
     clientVersion != 'local' &&
@@ -104,7 +117,10 @@ export const handleIdentifyOnSocket = (
     {
       maskedToken,
       hashedToken,
-      metadata: metadataWithoutFilters(clientData.metadata),
+      metadata: {
+        ...metadataWithoutFilters(clientData.metadata),
+        mode: eventIdentity.mode,
+      },
     },
     'New client connection identified.',
   );
@@ -136,6 +152,7 @@ export const handleIdentifyOnSocket = (
 
   socket.on('chunk', streamingResponse(token));
   socket.on('request', response(token));
+  socket.on(CLIENT_EVENT_MESSAGE, handleClientEvent(eventIdentity));
   socket.on('incoming::ping', (time) => {
     const isTerminating =
       terminatingClientIdsPerToken.get(token)?.includes(clientId) ?? false;

--- a/lib/hybrid-sdk/server/socketHandlers/identifyHandler.ts
+++ b/lib/hybrid-sdk/server/socketHandlers/identifyHandler.ts
@@ -152,6 +152,14 @@ export const handleIdentifyOnSocket = (
 
   socket.on('chunk', streamingResponse(token));
   socket.on('request', response(token));
+  // Primus Spark extends EventEmitter at runtime. CLIENT_EVENT_MESSAGE is
+  // registered only here; removeAllListeners is therefore equivalent to
+  // removeListener on the one function we registered — safe to use because
+  // no other code registers on this event name.
+  // This guard prevents duplicate log writes if a client re-sends 'identify'.
+  (socket as unknown as import('events').EventEmitter).removeAllListeners(
+    CLIENT_EVENT_MESSAGE,
+  );
   socket.on(CLIENT_EVENT_MESSAGE, handleClientEvent(eventIdentity));
   socket.on('incoming::ping', (time) => {
     const isTerminating =

--- a/lib/hybrid-sdk/server/utils/socket.ts
+++ b/lib/hybrid-sdk/server/utils/socket.ts
@@ -1,9 +1,14 @@
-export const metadataWithoutFilters = (metadataWithFilters) => {
+import { IdentifyingMetadata } from '../../client/types/client';
+
+export const metadataWithoutFilters = (
+  metadataWithFilters: IdentifyingMetadata,
+) => {
   return {
     capabilities: metadataWithFilters.capabilities,
     clientId: metadataWithFilters.clientId,
     preflightChecks: metadataWithFilters.preflightChecks,
     version: metadataWithFilters.version,
     clientConfig: metadataWithFilters.clientConfig ?? {},
+    deploymentId: metadataWithFilters.deploymentId,
   };
 };

--- a/test/unit/client/auth/oauth.test.ts
+++ b/test/unit/client/auth/oauth.test.ts
@@ -1,3 +1,8 @@
+jest.mock('../../../../lib/hybrid-sdk/client/events', () => ({
+  emitError: jest.fn(),
+  emitShutdown: jest.fn(),
+}));
+
 import {
   getAccessToken,
   getCachedAccessToken,
@@ -7,6 +12,7 @@ import {
 } from '../../../../lib/hybrid-sdk/client/auth/oauth';
 import { log as logger } from '../../../../lib/logs/logger';
 import type { Client as MetricsClient } from '../../../../lib/hybrid-sdk/client/metrics/client';
+import { emitError } from '../../../../lib/hybrid-sdk/client/events';
 
 const nock = require('nock');
 
@@ -57,6 +63,7 @@ describe('client/auth/oauth (simple-oauth2)', () => {
 
   beforeEach(() => {
     nock.cleanAll();
+    (emitError as jest.Mock).mockClear();
     errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => logger);
   });
 
@@ -167,6 +174,23 @@ describe('client/auth/oauth (simple-oauth2)', () => {
       expect.objectContaining({ err: expect.anything() }),
       'Unable to retrieve JWT',
     );
+    expect(emitError).toHaveBeenCalledWith({ errorCode: 'JWT_REFRESH_FAILED' });
+  });
+
+  it('does NOT emit a client-error when the fetch succeeds', async () => {
+    initOAuthClient({
+      apiHostname: API_HOST,
+      clientId: 'cid',
+      clientSecret: 'csecret',
+    });
+
+    nock(API_HOST)
+      .post(TOKEN_PATH)
+      .reply(200, tokenResponse({ access_token: 'ok' }));
+
+    await getAccessToken();
+
+    expect(emitError).not.toHaveBeenCalled();
   });
 
   it('does NOT fire recordJwtRefreshFailure when fetch succeeds', async () => {

--- a/test/unit/client/metrics/metricsClient.test.ts
+++ b/test/unit/client/metrics/metricsClient.test.ts
@@ -1,6 +1,7 @@
 import * as metrics from '../../../../lib/hybrid-sdk/client/metrics';
 import { parse } from '../../../../lib/hybrid-sdk/client/metrics/config';
 import { DataPointType, MetricReader } from '@opentelemetry/sdk-metrics';
+import { PROCESS_EXIT_REASONS } from '../../../../lib/hybrid-sdk/common/types/telemetry';
 
 class TestMetricReader extends MetricReader {
   protected async onShutdown(): Promise<void> {}
@@ -146,7 +147,7 @@ describe('client/metrics', () => {
     const noopMethods: Array<[string, Parameters<any>]> = [
       ['setConnectionState', ['connected', 'primary']],
       ['recordReconnect', []],
-      ['recordProcessExit', ['reconnect_exhaustion']],
+      ['recordProcessExit', [PROCESS_EXIT_REASONS.RECONNECT_EXHAUSTION]],
       ['recordAuthRenewalFailure', [503]],
       ['recordJwtRefreshFailure', []],
       ['recordUncaughtException', ['ECONNRESET']],
@@ -284,11 +285,11 @@ describe('client/metrics', () => {
     });
 
     it('records broker.client.process_exit.total with reason attribute', async () => {
-      client.recordProcessExit('reconnect_exhaustion');
+      client.recordProcessExit(PROCESS_EXIT_REASONS.RECONNECT_EXHAUSTION);
       const metric = await findMetric('broker.client.process_exit.total');
       expect(metric!.dataPoints[0].value).toBe(1);
       expect(metric!.dataPoints[0].attributes['reason']).toBe(
-        'reconnect_exhaustion',
+        PROCESS_EXIT_REASONS.RECONNECT_EXHAUSTION,
       );
     });
 

--- a/test/unit/client/socket.test.ts
+++ b/test/unit/client/socket.test.ts
@@ -21,7 +21,8 @@ import {
   Role,
 } from '../../../lib/hybrid-sdk/client/types/client';
 import { log as logger } from '../../../lib/logs/logger';
-import { emitError } from '../../../lib/hybrid-sdk/client/events';
+import { emitError, emitShutdown } from '../../../lib/hybrid-sdk/client/events';
+import { PROCESS_EXIT_REASONS } from '../../../lib/hybrid-sdk/common/types/telemetry';
 
 jest.mock('primus', () => {
   const mockSocket = jest.fn().mockImplementation(() => {
@@ -416,8 +417,12 @@ describe('createWebSocket - renew auth behaviour', () => {
         expect.stringContaining('consecutive times. Exiting...'),
       );
       expect(recordProcessExitSpy).toHaveBeenCalledWith(
-        'oauth_token_unavailable',
+        PROCESS_EXIT_REASONS.OAUTH_TOKEN_UNAVAILABLE,
       );
+      expect(emitShutdown).toHaveBeenCalledWith({
+        reason: PROCESS_EXIT_REASONS.OAUTH_TOKEN_UNAVAILABLE,
+        uptimeSeconds: expect.any(Number),
+      });
       expect(mockProcessExit).toHaveBeenCalledWith(1);
 
       clearTimeout(ws.timeoutHandlerId);
@@ -560,6 +565,25 @@ describe('createWebSocket - renew auth behaviour', () => {
         Authorization: 'Bearer cached',
         'snyk-request-id': expect.any(String),
       });
+    });
+  });
+
+  describe('reconnect failed', () => {
+    it('does NOT emit a client-shutdown (socket is already gone — undeliverable)', () => {
+      const clientOpts = createMockClientOpts();
+      const identifyingMetadata = createMockIdentifyingMetadata();
+      const ws = createWebSocket(clientOpts, identifyingMetadata, Role.primary);
+
+      const reconnectFailed = (ws.on as jest.Mock).mock.calls.find(
+        ([event]) => event === 'reconnect failed',
+      )?.[1];
+      expect(reconnectFailed).toBeDefined();
+
+      reconnectFailed();
+
+      // reconnect_exhaustion is reported via the process_exit metric, not a WS
+      // event — by this point 'close' has cleared the event socket.
+      expect(emitShutdown).not.toHaveBeenCalled();
     });
   });
 

--- a/test/unit/client/socket.test.ts
+++ b/test/unit/client/socket.test.ts
@@ -6,6 +6,11 @@ jest.mock('../../../lib/hybrid-sdk/client/auth/oauth', () => ({
   isOAuthClientInitialized: jest.fn().mockReturnValue(true),
 }));
 
+jest.mock('../../../lib/hybrid-sdk/client/events', () => ({
+  emitError: jest.fn(),
+  emitShutdown: jest.fn(),
+}));
+
 import { createWebSocket } from '../../../lib/hybrid-sdk/client/socket';
 import {
   LoadedClientOpts,
@@ -16,6 +21,7 @@ import {
   Role,
 } from '../../../lib/hybrid-sdk/client/types/client';
 import { log as logger } from '../../../lib/logs/logger';
+import { emitError } from '../../../lib/hybrid-sdk/client/events';
 
 jest.mock('primus', () => {
   const mockSocket = jest.fn().mockImplementation(() => {
@@ -305,6 +311,10 @@ describe('createWebSocket - renew auth behaviour', () => {
         }),
         'Failed to renew connection.',
       );
+      // Non-fatal renewal failure surfaces as a client-error event.
+      expect(emitError).toHaveBeenCalledWith({
+        errorCode: 'AUTH_RENEWAL_FAILED',
+      });
       expect(ws.timeoutHandlerId).toBeDefined();
 
       clearTimeout(ws.timeoutHandlerId);

--- a/test/unit/client/socketHandlers/closeHandler.test.ts
+++ b/test/unit/client/socketHandlers/closeHandler.test.ts
@@ -1,8 +1,14 @@
+jest.mock('../../../../lib/hybrid-sdk/client/events', () => ({
+  clearEventSocket: jest.fn(),
+  registerEventSocket: jest.fn(),
+}));
+
 import { closeHandler } from '../../../../lib/hybrid-sdk/client/socketHandlers/closeHandler';
 import { log as logger } from '../../../../lib/logs/logger';
 import { WebSocketConnection } from '../../../../lib/hybrid-sdk/client/types/client';
 import { LoadedClientOpts } from '../../../../lib/hybrid-sdk/common/types/options';
 import { NoopClient } from '../../../../lib/hybrid-sdk/client/metrics';
+import { clearEventSocket } from '../../../../lib/hybrid-sdk/client/events';
 
 jest.mock('../../../../lib/logs/logger');
 
@@ -22,6 +28,11 @@ describe('closeHandler', () => {
         universalBrokerEnabled: false,
       },
     } as unknown as LoadedClientOpts;
+  });
+
+  it('calls clearEventSocket with the websocket before any other close logic', () => {
+    closeHandler(mockWebsocket, mockClientOpts, {}, new NoopClient());
+    expect(clearEventSocket).toHaveBeenCalledWith(mockWebsocket);
   });
 
   it('should log warning with durationMs when connectionStartTime is present', () => {

--- a/test/unit/client/uncaughtExceptionHandler.test.ts
+++ b/test/unit/client/uncaughtExceptionHandler.test.ts
@@ -1,5 +1,12 @@
+jest.mock('../../../lib/hybrid-sdk/client/events', () => ({
+  emitError: jest.fn(),
+  emitShutdown: jest.fn(),
+}));
+
 import { log as logger } from '../../../lib/logs/logger';
 import { handleUncaughtException } from '../../../lib/hybrid-sdk/client/index';
+import { emitShutdown } from '../../../lib/hybrid-sdk/client/events';
+import { PROCESS_EXIT_REASONS } from '../../../lib/hybrid-sdk/common/types/telemetry';
 
 describe('handleUncaughtException — log levels', () => {
   let warnSpy: jest.SpyInstance;
@@ -16,6 +23,7 @@ describe('handleUncaughtException — log levels', () => {
     jest.clearAllMocks();
     warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
     errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+    jest.spyOn(process, 'exit').mockImplementation((() => undefined) as any);
   });
   afterEach(() => jest.restoreAllMocks());
 
@@ -36,5 +44,27 @@ describe('handleUncaughtException — log levels', () => {
     // Sanity: the metrics counter that already covers ECONNRESET observability
     // still runs (we explicitly did NOT add a new counter — see plan).
     expect(metricsClientStub.recordUncaughtException).toHaveBeenCalled();
+  });
+
+  it('does NOT emit a shutdown for a benign read ECONNRESET (no exit)', () => {
+    handleUncaughtException(new Error('read ECONNRESET'), metricsClientStub);
+    expect(emitShutdown).not.toHaveBeenCalled();
+  });
+
+  it('emits an uncaught_exception shutdown carrying the bounded errno code only', () => {
+    const err = Object.assign(new Error('boom with secret detail'), {
+      code: 'ERR_FATAL',
+    });
+
+    handleUncaughtException(err, metricsClientStub);
+
+    expect(emitShutdown).toHaveBeenCalledWith({
+      reason: PROCESS_EXIT_REASONS.UNCAUGHT_EXCEPTION,
+      uptimeSeconds: expect.any(Number),
+      errorCode: 'ERR_FATAL',
+    });
+    // The free-form error message must never ride the event.
+    const emitted = (emitShutdown as jest.Mock).mock.calls[0][0];
+    expect(JSON.stringify(emitted)).not.toContain('secret detail');
   });
 });

--- a/test/unit/client/uncaughtExceptionHandler.test.ts
+++ b/test/unit/client/uncaughtExceptionHandler.test.ts
@@ -53,7 +53,7 @@ describe('handleUncaughtException — log levels', () => {
 
   it('emits an uncaught_exception shutdown carrying the bounded errno code only', () => {
     const err = Object.assign(new Error('boom with secret detail'), {
-      code: 'ERR_FATAL',
+      code: 'ECONNRESET',
     });
 
     handleUncaughtException(err, metricsClientStub);
@@ -61,10 +61,21 @@ describe('handleUncaughtException — log levels', () => {
     expect(emitShutdown).toHaveBeenCalledWith({
       reason: PROCESS_EXIT_REASONS.UNCAUGHT_EXCEPTION,
       uptimeSeconds: expect.any(Number),
-      errorCode: 'ERR_FATAL',
+      errorCode: 'ECONNRESET',
     });
     // The free-form error message must never ride the event.
     const emitted = (emitShutdown as jest.Mock).mock.calls[0][0];
     expect(JSON.stringify(emitted)).not.toContain('secret detail');
+  });
+
+  it('strips a non-standard third-party .code value (not in the known errno allowlist)', () => {
+    const err = Object.assign(new Error('boom'), {
+      code: 'ERR_TLS_CERT_ALTNAME_INVALID',
+    });
+
+    handleUncaughtException(err, metricsClientStub);
+
+    const emitted = (emitShutdown as jest.Mock).mock.calls[0]?.[0];
+    expect(emitted?.errorCode).toBeUndefined();
   });
 });

--- a/test/unit/lib/broker-workload/websocketRequests.test.ts
+++ b/test/unit/lib/broker-workload/websocketRequests.test.ts
@@ -8,6 +8,7 @@ import {
   makeRequestToDownstream,
   makeStreamingRequestToDownstream,
 } from '../../../../lib/hybrid-sdk/http/request';
+import { emitError } from '../../../../lib/hybrid-sdk/client/events';
 
 const mockSendResponse = jest.fn();
 const mockStreamDataResponse = jest.fn();
@@ -37,6 +38,10 @@ jest.mock(
   '../../../../lib/hybrid-sdk/interpolateRequestWithConfigData',
   () => ({ getInterpolatedRequest: jest.fn(() => ({})) }),
 );
+jest.mock('../../../../lib/hybrid-sdk/client/events', () => ({
+  emitError: jest.fn(),
+  emitShutdown: jest.fn(),
+}));
 
 const mockFilterRequest = filterRequest as jest.MockedFunction<
   typeof filterRequest
@@ -264,6 +269,38 @@ describe('BrokerWorkload', () => {
           body: expect.objectContaining({ code: 'DOWNSTREAM_TIMEOUT' }),
         }),
       );
+    });
+
+    it('streaming failure emits a joinable client-error with a bounded code only (no downstream message)', async () => {
+      mockFilterRequest.mockReturnValue(matchedRule);
+      mockMakeStreamingRequest.mockRejectedValueOnce(
+        Object.assign(new Error('secret downstream detail'), {
+          code: 'ECONNREFUSED',
+        }),
+      );
+      const workload = new BrokerWorkload(
+        connectionIdentifier,
+        options,
+        websocketConnectionHandler,
+      );
+      const payload = {
+        url: '/stream',
+        method: 'GET',
+        headers: { 'snyk-request-id': '77777777-7777-4777-8777-777777777777' },
+        requestId: 'req-stream-1',
+        streamingID: 'stream-x',
+      };
+
+      await workload.handler({ payload, websocketHandler: jest.fn() });
+
+      expect(emitError).toHaveBeenCalledWith({
+        errorCode: 'DOWNSTREAM_UNREACHABLE',
+        requestId: 'req-stream-1',
+        integrationType: 'test-connection',
+      });
+      // The free-form downstream message must never ride the event.
+      const emitted = (emitError as jest.Mock).mock.calls[0][0];
+      expect(JSON.stringify(emitted)).not.toContain('secret downstream detail');
     });
   });
 });

--- a/test/unit/lib/broker-workload/websocketRequests.test.ts
+++ b/test/unit/lib/broker-workload/websocketRequests.test.ts
@@ -271,6 +271,33 @@ describe('BrokerWorkload', () => {
       );
     });
 
+    it('non-streaming downstream error does NOT emit a client-error event (observable via HTTP response)', async () => {
+      mockFilterRequest.mockReturnValue(matchedRule);
+      mockMakeRequest.mockRejectedValueOnce(
+        Object.assign(new Error('connect ECONNREFUSED'), {
+          code: 'ECONNREFUSED',
+        }),
+      );
+      const workload = new BrokerWorkload(
+        connectionIdentifier,
+        options,
+        websocketConnectionHandler,
+      );
+      const payload = {
+        url: '/non-stream',
+        method: 'GET',
+        headers: { 'snyk-request-id': '88888888-8888-4888-8888-888888888888' },
+        requestId: 'req-ns-1',
+        streamingID: '',
+      };
+
+      await workload.handler({ payload, websocketHandler: jest.fn() });
+
+      // Non-streaming errors surface as a structured response; the caller can observe
+      // them there. Only streaming failures are silent to the server, hence that path emits.
+      expect(emitError).not.toHaveBeenCalled();
+    });
+
     it('streaming failure emits a joinable client-error with a bounded code only (no downstream message)', async () => {
       mockFilterRequest.mockReturnValue(matchedRule);
       mockMakeStreamingRequest.mockRejectedValueOnce(

--- a/test/unit/lib/hybrid-sdk/client/events.test.ts
+++ b/test/unit/lib/hybrid-sdk/client/events.test.ts
@@ -9,14 +9,22 @@ import {
   PROCESS_EXIT_REASONS,
 } from '../../../../../lib/hybrid-sdk/common/types/telemetry';
 
+// Track every socket handed out so afterEach can remove it from the registry
+// (the registry is module-level and persists across tests).
+const registeredSockets: Array<{ send: jest.Mock }> = [];
+const makeSocket = () => {
+  const socket = { send: jest.fn() };
+  registeredSockets.push(socket);
+  return socket;
+};
+
+afterEach(() => {
+  registeredSockets.forEach((socket) => clearEventSocket(socket));
+  registeredSockets.length = 0;
+  jest.restoreAllMocks();
+});
+
 describe('client/events — emitError', () => {
-  const makeSocket = () => ({ send: jest.fn() });
-
-  afterEach(() => {
-    clearEventSocket();
-    jest.restoreAllMocks();
-  });
-
   it('no-ops (does not throw) when no socket is registered', () => {
     expect(() => emitError({ errorCode: 'JWT_REFRESH_FAILED' })).not.toThrow();
   });
@@ -58,10 +66,10 @@ describe('client/events — emitError', () => {
     expect(Object.keys(envelope.event).sort()).toEqual(['errorCode', 'type']);
   });
 
-  it('stops sending after clearEventSocket', () => {
+  it('stops sending after the registered socket is cleared', () => {
     const socket = makeSocket();
     registerEventSocket(socket);
-    clearEventSocket();
+    clearEventSocket(socket);
 
     emitError({ errorCode: 'AUTH_RENEWAL_FAILED' });
 
@@ -69,25 +77,60 @@ describe('client/events — emitError', () => {
   });
 
   it('swallows a socket.send failure (best-effort, never disrupts the caller)', () => {
-    const socket = {
-      send: jest.fn(() => {
-        throw new Error('socket gone');
-      }),
-    };
+    const socket = makeSocket();
+    socket.send.mockImplementation(() => {
+      throw new Error('socket gone');
+    });
     registerEventSocket(socket);
 
     expect(() => emitError({ errorCode: 'AUTH_RENEWAL_FAILED' })).not.toThrow();
   });
 });
 
-describe('client/events — emitShutdown', () => {
-  const makeSocket = () => ({ send: jest.fn() });
+describe('client/events — multiple concurrent connections', () => {
+  it('keeps emitting over a surviving socket when another connection closes', () => {
+    const closed = makeSocket();
+    const healthy = makeSocket();
+    registerEventSocket(closed);
+    registerEventSocket(healthy);
 
-  afterEach(() => {
-    clearEventSocket();
-    jest.restoreAllMocks();
+    // One connection drops — its socket is removed, the rest stay live.
+    clearEventSocket(closed);
+
+    emitError({ errorCode: 'AUTH_RENEWAL_FAILED' });
+
+    expect(closed.send).not.toHaveBeenCalled();
+    expect(healthy.send).toHaveBeenCalledTimes(1);
   });
 
+  it('emits over exactly one socket (does not broadcast to every connection)', () => {
+    const a = makeSocket();
+    const b = makeSocket();
+    registerEventSocket(a);
+    registerEventSocket(b);
+
+    emitError({ errorCode: 'AUTH_RENEWAL_FAILED' });
+
+    expect(a.send.mock.calls.length + b.send.mock.calls.length).toBe(1);
+  });
+
+  it('goes silent only once every connection has closed', () => {
+    const a = makeSocket();
+    const b = makeSocket();
+    registerEventSocket(a);
+    registerEventSocket(b);
+    clearEventSocket(a);
+    clearEventSocket(b);
+
+    expect(() =>
+      emitShutdown({ reason: 'clean', uptimeSeconds: 1 }),
+    ).not.toThrow();
+    expect(a.send).not.toHaveBeenCalled();
+    expect(b.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('client/events — emitShutdown', () => {
   it('no-ops (does not throw) when no socket is registered', () => {
     expect(() =>
       emitShutdown({ reason: 'clean', uptimeSeconds: 5 }),

--- a/test/unit/lib/hybrid-sdk/client/events.test.ts
+++ b/test/unit/lib/hybrid-sdk/client/events.test.ts
@@ -1,0 +1,81 @@
+import {
+  clearEventSocket,
+  emitError,
+  registerEventSocket,
+} from '../../../../../lib/hybrid-sdk/client/events';
+import { CLIENT_EVENT_MESSAGE } from '../../../../../lib/hybrid-sdk/common/types/telemetry';
+
+describe('client/events — emitError', () => {
+  const makeSocket = () => ({ send: jest.fn() });
+
+  afterEach(() => {
+    clearEventSocket();
+    jest.restoreAllMocks();
+  });
+
+  it('no-ops (does not throw) when no socket is registered', () => {
+    expect(() =>
+      emitError({ errorCode: 'JWT_REFRESH_FAILED' }),
+    ).not.toThrow();
+  });
+
+  it('sends a client-error envelope over the registered socket', () => {
+    const socket = makeSocket();
+    registerEventSocket(socket);
+
+    emitError({
+      errorCode: 'SEND_BACK_FAILED',
+      requestId: 'req-1',
+      integrationType: 'github',
+    });
+
+    expect(socket.send).toHaveBeenCalledTimes(1);
+    const [message, envelope] = socket.send.mock.calls[0];
+    expect(message).toBe(CLIENT_EVENT_MESSAGE);
+    expect(typeof envelope.ts).toBe('number');
+    expect(envelope.event).toEqual({
+      type: 'client-error',
+      errorCode: 'SEND_BACK_FAILED',
+      requestId: 'req-1',
+      integrationType: 'github',
+    });
+  });
+
+  it('omits optional fields when not provided — no free-form / undefined keys', () => {
+    const socket = makeSocket();
+    registerEventSocket(socket);
+
+    emitError({ errorCode: 'JWT_REFRESH_FAILED' });
+
+    const envelope = socket.send.mock.calls[0][1];
+    expect(envelope.event).toEqual({
+      type: 'client-error',
+      errorCode: 'JWT_REFRESH_FAILED',
+    });
+    // Only bounded keys ever reach the wire.
+    expect(Object.keys(envelope.event).sort()).toEqual(['errorCode', 'type']);
+  });
+
+  it('stops sending after clearEventSocket', () => {
+    const socket = makeSocket();
+    registerEventSocket(socket);
+    clearEventSocket();
+
+    emitError({ errorCode: 'AUTH_RENEWAL_FAILED' });
+
+    expect(socket.send).not.toHaveBeenCalled();
+  });
+
+  it('swallows a socket.send failure (best-effort, never disrupts the caller)', () => {
+    const socket = {
+      send: jest.fn(() => {
+        throw new Error('socket gone');
+      }),
+    };
+    registerEventSocket(socket);
+
+    expect(() =>
+      emitError({ errorCode: 'AUTH_RENEWAL_FAILED' }),
+    ).not.toThrow();
+  });
+});

--- a/test/unit/lib/hybrid-sdk/client/events.test.ts
+++ b/test/unit/lib/hybrid-sdk/client/events.test.ts
@@ -1,9 +1,13 @@
 import {
   clearEventSocket,
   emitError,
+  emitShutdown,
   registerEventSocket,
 } from '../../../../../lib/hybrid-sdk/client/events';
-import { CLIENT_EVENT_MESSAGE } from '../../../../../lib/hybrid-sdk/common/types/telemetry';
+import {
+  CLIENT_EVENT_MESSAGE,
+  PROCESS_EXIT_REASONS,
+} from '../../../../../lib/hybrid-sdk/common/types/telemetry';
 
 describe('client/events — emitError', () => {
   const makeSocket = () => ({ send: jest.fn() });
@@ -14,9 +18,7 @@ describe('client/events — emitError', () => {
   });
 
   it('no-ops (does not throw) when no socket is registered', () => {
-    expect(() =>
-      emitError({ errorCode: 'JWT_REFRESH_FAILED' }),
-    ).not.toThrow();
+    expect(() => emitError({ errorCode: 'JWT_REFRESH_FAILED' })).not.toThrow();
   });
 
   it('sends a client-error envelope over the registered socket', () => {
@@ -74,8 +76,60 @@ describe('client/events — emitError', () => {
     };
     registerEventSocket(socket);
 
+    expect(() => emitError({ errorCode: 'AUTH_RENEWAL_FAILED' })).not.toThrow();
+  });
+});
+
+describe('client/events — emitShutdown', () => {
+  const makeSocket = () => ({ send: jest.fn() });
+
+  afterEach(() => {
+    clearEventSocket();
+    jest.restoreAllMocks();
+  });
+
+  it('no-ops (does not throw) when no socket is registered', () => {
     expect(() =>
-      emitError({ errorCode: 'AUTH_RENEWAL_FAILED' }),
+      emitShutdown({ reason: 'clean', uptimeSeconds: 5 }),
     ).not.toThrow();
+  });
+
+  it('sends a client-shutdown envelope over the registered socket', () => {
+    const socket = makeSocket();
+    registerEventSocket(socket);
+
+    emitShutdown({
+      reason: PROCESS_EXIT_REASONS.RECONNECT_EXHAUSTION,
+      uptimeSeconds: 42,
+    });
+
+    expect(socket.send).toHaveBeenCalledTimes(1);
+    const [message, envelope] = socket.send.mock.calls[0];
+    expect(message).toBe(CLIENT_EVENT_MESSAGE);
+    expect(typeof envelope.ts).toBe('number');
+    expect(envelope.event).toEqual({
+      type: 'client-shutdown',
+      reason: PROCESS_EXIT_REASONS.RECONNECT_EXHAUSTION,
+      uptimeSeconds: 42,
+    });
+  });
+
+  it('carries the bounded errno code only when provided (uncaught_exception)', () => {
+    const socket = makeSocket();
+    registerEventSocket(socket);
+
+    emitShutdown({
+      reason: PROCESS_EXIT_REASONS.UNCAUGHT_EXCEPTION,
+      uptimeSeconds: 7,
+      errorCode: 'ECONNRESET',
+    });
+
+    const envelope = socket.send.mock.calls[0][1];
+    expect(envelope.event).toEqual({
+      type: 'client-shutdown',
+      reason: PROCESS_EXIT_REASONS.UNCAUGHT_EXCEPTION,
+      uptimeSeconds: 7,
+      errorCode: 'ECONNRESET',
+    });
   });
 });

--- a/test/unit/lib/hybrid-sdk/common/types/telemetry.test.ts
+++ b/test/unit/lib/hybrid-sdk/common/types/telemetry.test.ts
@@ -3,9 +3,9 @@ import {
   classifyDownstreamError,
   classifyDownstreamStatus,
   statusForErrorCode,
-} from '../../../../../../lib/hybrid-sdk/common/types/errorCodes';
+} from '../../../../../../lib/hybrid-sdk/common/types/telemetry';
 
-describe('errorCodes catalog', () => {
+describe('telemetry catalog', () => {
   describe('classifyDownstreamError', () => {
     it.each([
       ['ETIMEDOUT', BROKER_ERROR_CODES.DOWNSTREAM_TIMEOUT],

--- a/test/unit/lib/hybrid-sdk/common/utils/signals.test.ts
+++ b/test/unit/lib/hybrid-sdk/common/utils/signals.test.ts
@@ -2,6 +2,13 @@ jest.mock('../../../../../../lib/hybrid-sdk/client', () => ({
   getWebsocketConnections: jest.fn(() => [{ send: jest.fn() }]),
 }));
 
+jest.mock('../../../../../../lib/hybrid-sdk/client/events', () => ({
+  emitError: jest.fn(),
+  emitShutdown: jest.fn(),
+}));
+
+import { emitShutdown } from '../../../../../../lib/hybrid-sdk/client/events';
+
 type SignalsModule =
   typeof import('../../../../../../lib/hybrid-sdk/common/utils/signals');
 
@@ -79,6 +86,34 @@ describe('signals', () => {
       });
       process.emit('SIGTERM' as any);
       expect(observedDuringCallback).toBe(true);
+    });
+  });
+
+  describe('clean shutdown event', () => {
+    it('emits a clean client-shutdown when notifying the server on SIGTERM', () => {
+      const signals = loadSignals();
+      signals.handleTerminationSignal(() => {});
+      (emitShutdown as jest.Mock).mockClear();
+
+      process.emit('SIGTERM' as any);
+
+      expect(emitShutdown).toHaveBeenCalledWith({
+        reason: 'clean',
+        uptimeSeconds: expect.any(Number),
+      });
+    });
+
+    it('emits a clean client-shutdown on SIGINT too', () => {
+      const signals = loadSignals();
+      signals.handleTerminationSignal(() => {});
+      (emitShutdown as jest.Mock).mockClear();
+
+      process.emit('SIGINT' as any);
+
+      expect(emitShutdown).toHaveBeenCalledWith({
+        reason: 'clean',
+        uptimeSeconds: expect.any(Number),
+      });
     });
   });
 

--- a/test/unit/lib/hybrid-sdk/responseSenders.test.ts
+++ b/test/unit/lib/hybrid-sdk/responseSenders.test.ts
@@ -1,4 +1,23 @@
+jest.mock('../../../../lib/hybrid-sdk/client/events', () => ({
+  emitError: jest.fn(),
+  emitShutdown: jest.fn(),
+}));
+jest.mock(
+  '../../../../lib/hybrid-sdk/http/downstream-post-stream-to-server',
+  () => ({
+    BrokerServerPostResponseHandler: jest.fn().mockImplementation(() => ({
+      sendData: jest.fn(() => {
+        throw new Error('send-back failed');
+      }),
+      forwardRequest: jest.fn(() => {
+        throw new Error('send-back failed');
+      }),
+    })),
+  }),
+);
+
 import { HybridResponseHandler } from '../../../../lib/hybrid-sdk/responseSenders';
+import { emitError } from '../../../../lib/hybrid-sdk/client/events';
 
 describe('HybridResponseHandler.sendDataResponse — downstream relay classification', () => {
   const createHandler = () => {
@@ -57,4 +76,28 @@ describe('HybridResponseHandler.sendDataResponse — downstream relay classifica
       expect(payload).not.toHaveProperty('errorType');
     },
   );
+});
+
+describe('HybridResponseHandler — send-back failure emits a joinable client-error', () => {
+  beforeEach(() => (emitError as jest.Mock).mockClear());
+
+  it('emits SEND_BACK_FAILED with request id + integration type when the post throws', () => {
+    const handler = new HybridResponseHandler(
+      { connectionIdentifier: 'conn-1', requestId: 'req-77' } as any,
+      { capabilities: ['receive-post-streams'] } as any,
+      undefined as any,
+      { socketMaxResponseLength: '20971520' } as any,
+      { connectionName: 'gitlab' } as any,
+    );
+
+    // Post handler throws (mocked); the response path stays silent, so the
+    // emitted event is the only trace the server can join on request id.
+    handler.sendResponse({ status: 200, body: 'ok' } as any);
+
+    expect(emitError).toHaveBeenCalledWith({
+      errorCode: 'SEND_BACK_FAILED',
+      requestId: 'req-77',
+      integrationType: 'gitlab',
+    });
+  });
 });

--- a/test/unit/lib/hybrid-sdk/server/socketHandlers/clientEventHandler.test.ts
+++ b/test/unit/lib/hybrid-sdk/server/socketHandlers/clientEventHandler.test.ts
@@ -59,7 +59,7 @@ describe('handleClientEvent', () => {
       event: {
         type: 'client-error',
         errorCode: 'SEND_BACK_FAILED',
-        requestId: 'req-1',
+        requestId: '77777777-7777-4777-8777-777777777777',
         integrationType: 'github',
       },
     } as any);
@@ -67,12 +67,321 @@ describe('handleClientEvent', () => {
     expect(warnSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         errorCode: 'SEND_BACK_FAILED',
-        requestId: 'req-1',
+        requestId: '77777777-7777-4777-8777-777777777777',
         integrationType: 'github',
         clientTs: 999,
       }),
       'broker client event',
     );
+  });
+
+  describe('clientTs validation and serverTs', () => {
+    it('passes through a finite numeric clientTs and always logs a numeric serverTs', () => {
+      handleClientEvent(identity)({
+        ts: 1000,
+        event: { type: 'client-error', errorCode: 'JWT_REFRESH_FAILED' },
+      } as any);
+      const loggedObj = warnSpy.mock.calls[0][0];
+      expect(loggedObj.clientTs).toBe(1000);
+      expect(typeof loggedObj.serverTs).toBe('number');
+      expect(Number.isFinite(loggedObj.serverTs)).toBe(true);
+    });
+
+    it('replaces NaN clientTs with undefined and still logs a numeric serverTs', () => {
+      handleClientEvent(identity)({
+        ts: NaN,
+        event: { type: 'client-error', errorCode: 'JWT_REFRESH_FAILED' },
+      } as any);
+      const loggedObj = warnSpy.mock.calls[0][0];
+      expect(loggedObj.clientTs).toBeUndefined();
+      expect(typeof loggedObj.serverTs).toBe('number');
+      expect(Number.isFinite(loggedObj.serverTs)).toBe(true);
+    });
+
+    it('treats a sub-object ts as invalid and strips clientTs', () => {
+      handleClientEvent(identity)({
+        ts: { $gt: 0 } as any,
+        event: { type: 'client-error', errorCode: 'JWT_REFRESH_FAILED' },
+      } as any);
+      const loggedObj = warnSpy.mock.calls[0][0];
+      expect(loggedObj.clientTs).toBeUndefined();
+    });
+  });
+
+  describe('eventType capping and validation', () => {
+    it('caps a very long event type to 64 chars before logging', () => {
+      const longType = 'z'.repeat(200);
+      handleClientEvent(identity)({
+        ts: 1,
+        event: { type: longType, someField: 'x' } as any,
+      } as any);
+      const loggedObj = infoSpy.mock.calls[0][0];
+      expect(loggedObj.eventType).toHaveLength(64);
+      expect(loggedObj.eventType).toBe('z'.repeat(64));
+    });
+
+    it('replaces an eventType containing special characters with "unknown"', () => {
+      handleClientEvent(identity)({
+        ts: 1,
+        event: { type: 'type with spaces', someField: 'x' } as any,
+      } as any);
+      const loggedObj = infoSpy.mock.calls[0][0];
+      expect(loggedObj.eventType).toBe('unknown');
+    });
+
+    it('passes through a future event type that matches the safe-label pattern', () => {
+      handleClientEvent(identity)({
+        ts: 1,
+        event: { type: 'future-event-v2' } as any,
+      } as any);
+      const loggedObj = infoSpy.mock.calls[0][0];
+      expect(loggedObj.eventType).toBe('future-event-v2');
+    });
+  });
+
+  describe('sanitizeEventFields — unknown/forward-compat fields', () => {
+    it('drops an unknown field whose value is an object (only scalars allowed)', () => {
+      handleClientEvent(identity)({
+        ts: 1,
+        event: {
+          type: 'future-event',
+          nestedPayload: { deep: 'data', count: 99 },
+        } as any,
+      } as any);
+      const loggedObj = infoSpy.mock.calls[0][0];
+      expect(loggedObj.nestedPayload).toBeUndefined();
+    });
+
+    it('drops an unknown field whose value is an array', () => {
+      handleClientEvent(identity)({
+        ts: 1,
+        event: {
+          type: 'future-event',
+          tags: ['a', 'b', 'c'],
+        } as any,
+      } as any);
+      const loggedObj = infoSpy.mock.calls[0][0];
+      expect(loggedObj.tags).toBeUndefined();
+    });
+
+    it('passes through an unknown field with a short scalar string value', () => {
+      handleClientEvent(identity)({
+        ts: 1,
+        event: {
+          type: 'future-event',
+          futureLabel: 'some-value',
+        } as any,
+      } as any);
+      const loggedObj = infoSpy.mock.calls[0][0];
+      expect(loggedObj.futureLabel).toBe('some-value');
+    });
+
+    it('caps an unknown string field value at 256 chars', () => {
+      handleClientEvent(identity)({
+        ts: 1,
+        event: {
+          type: 'future-event',
+          longField: 'a'.repeat(500),
+        } as any,
+      } as any);
+      const loggedObj = infoSpy.mock.calls[0][0];
+      expect(loggedObj.longField).toHaveLength(256);
+    });
+
+    it('passes through an unknown boolean field', () => {
+      handleClientEvent(identity)({
+        ts: 1,
+        event: {
+          type: 'future-event',
+          isRetry: true,
+        } as any,
+      } as any);
+      const loggedObj = infoSpy.mock.calls[0][0];
+      expect(loggedObj.isRetry).toBe(true);
+    });
+
+    it('drops an unknown field carrying NaN (not a finite number)', () => {
+      handleClientEvent(identity)({
+        ts: 1,
+        event: {
+          type: 'future-event',
+          count: NaN,
+        } as any,
+      } as any);
+      const loggedObj = infoSpy.mock.calls[0][0];
+      expect(loggedObj.count).toBeUndefined();
+    });
+
+    it('drops an unknown field carrying Infinity', () => {
+      handleClientEvent(identity)({
+        ts: 1,
+        event: {
+          type: 'future-event',
+          count: Infinity,
+        } as any,
+      } as any);
+      const loggedObj = infoSpy.mock.calls[0][0];
+      expect(loggedObj.count).toBeUndefined();
+    });
+
+    it('passes through an unknown field carrying a finite number', () => {
+      handleClientEvent(identity)({
+        ts: 1,
+        event: {
+          type: 'future-event',
+          retryCount: 3,
+        } as any,
+      } as any);
+      const loggedObj = infoSpy.mock.calls[0][0];
+      expect(loggedObj.retryCount).toBe(3);
+    });
+  });
+
+  describe('sanitizeEventFields extended', () => {
+    it('strips an errorCode that is not a known BrokerErrorCode or OS errno', () => {
+      handleClientEvent(identity)({
+        ts: 1,
+        event: {
+          type: 'client-shutdown',
+          reason: 'clean',
+          uptimeSeconds: 5,
+          errorCode: 'ERR_TLS_CERT_ALTNAME_INVALID',
+        },
+      } as any);
+      const loggedObj = infoSpy.mock.calls[0][0];
+      expect(loggedObj.errorCode).toBeUndefined();
+    });
+
+    it('keeps a known OS errno errorCode on client-shutdown', () => {
+      handleClientEvent(identity)({
+        ts: 1,
+        event: {
+          type: 'client-shutdown',
+          reason: 'clean',
+          uptimeSeconds: 5,
+          errorCode: 'ECONNRESET',
+        },
+      } as any);
+      const loggedObj = infoSpy.mock.calls[0][0];
+      expect(loggedObj.errorCode).toBe('ECONNRESET');
+    });
+
+    it('keeps a known BrokerErrorCode on client-error', () => {
+      handleClientEvent(identity)({
+        ts: 1,
+        event: { type: 'client-error', errorCode: 'JWT_REFRESH_FAILED' },
+      } as any);
+      const loggedObj = warnSpy.mock.calls[0][0];
+      expect(loggedObj.errorCode).toBe('JWT_REFRESH_FAILED');
+    });
+
+    it('strips a non-finite uptimeSeconds', () => {
+      handleClientEvent(identity)({
+        ts: 1,
+        event: {
+          type: 'client-shutdown',
+          reason: 'clean',
+          uptimeSeconds: Infinity,
+        },
+      } as any);
+      const loggedObj = infoSpy.mock.calls[0][0];
+      expect(loggedObj.uptimeSeconds).toBeUndefined();
+    });
+
+    it('strips a negative uptimeSeconds', () => {
+      handleClientEvent(identity)({
+        ts: 1,
+        event: { type: 'client-shutdown', reason: 'clean', uptimeSeconds: -1 },
+      } as any);
+      const loggedObj = infoSpy.mock.calls[0][0];
+      expect(loggedObj.uptimeSeconds).toBeUndefined();
+    });
+
+    it('keeps a valid finite non-negative uptimeSeconds', () => {
+      handleClientEvent(identity)({
+        ts: 1,
+        event: { type: 'client-shutdown', reason: 'clean', uptimeSeconds: 42 },
+      } as any);
+      const loggedObj = infoSpy.mock.calls[0][0];
+      expect(loggedObj.uptimeSeconds).toBe(42);
+    });
+
+    it('strips a reason that contains non-alphanumeric characters', () => {
+      handleClientEvent(identity)({
+        ts: 1,
+        event: {
+          type: 'client-shutdown',
+          reason: '<script>alert(1)</script>',
+          uptimeSeconds: 1,
+        },
+      } as any);
+      const loggedObj = infoSpy.mock.calls[0][0];
+      expect(loggedObj.reason).toBeUndefined();
+    });
+
+    it('keeps a valid enum-shaped reason', () => {
+      handleClientEvent(identity)({
+        ts: 1,
+        event: { type: 'client-shutdown', reason: 'clean', uptimeSeconds: 1 },
+      } as any);
+      const loggedObj = infoSpy.mock.calls[0][0];
+      expect(loggedObj.reason).toBe('clean');
+    });
+  });
+
+  describe('sanitizeEventFields', () => {
+    it('truncates an oversized integrationType to 64 chars before logging', () => {
+      const longType = 'a'.repeat(200);
+      handleClientEvent(identity)({
+        ts: 1,
+        event: {
+          type: 'client-error',
+          errorCode: 'JWT_REFRESH_FAILED',
+          integrationType: longType,
+        },
+      } as any);
+      const loggedObj = warnSpy.mock.calls[0][0];
+      expect(loggedObj.integrationType).toHaveLength(64);
+    });
+
+    it('drops an integrationType that contains characters outside alphanumeric/dash/underscore', () => {
+      handleClientEvent(identity)({
+        ts: 1,
+        event: {
+          type: 'client-error',
+          errorCode: 'JWT_REFRESH_FAILED',
+          integrationType: '<script>alert(1)</script>',
+        },
+      } as any);
+      const loggedObj = warnSpy.mock.calls[0][0];
+      expect(loggedObj.integrationType).toBeUndefined();
+    });
+
+    it('strips a requestId that is not a valid UUID', () => {
+      handleClientEvent(identity)({
+        ts: 1,
+        event: {
+          type: 'client-error',
+          errorCode: 'JWT_REFRESH_FAILED',
+          requestId: 'a'.repeat(10000),
+        },
+      } as any);
+      const loggedObj = warnSpy.mock.calls[0][0];
+      expect(loggedObj.requestId).toBeUndefined();
+    });
+
+    it('keeps a valid UUID requestId', () => {
+      handleClientEvent(identity)({
+        ts: 1,
+        event: {
+          type: 'client-error',
+          errorCode: 'JWT_REFRESH_FAILED',
+          requestId: '77777777-7777-4777-8777-777777777777',
+        },
+      } as any);
+      const loggedObj = warnSpy.mock.calls[0][0];
+      expect(loggedObj.requestId).toBe('77777777-7777-4777-8777-777777777777');
+    });
   });
 
   describe('severity', () => {

--- a/test/unit/lib/hybrid-sdk/server/socketHandlers/clientEventHandler.test.ts
+++ b/test/unit/lib/hybrid-sdk/server/socketHandlers/clientEventHandler.test.ts
@@ -1,0 +1,149 @@
+import { log as logger } from '../../../../../../lib/logs/logger';
+import {
+  ClientEventIdentity,
+  handleClientEvent,
+} from '../../../../../../lib/hybrid-sdk/server/socketHandlers/clientEventHandler';
+import { PROCESS_EXIT_REASONS } from '../../../../../../lib/hybrid-sdk/common/types/telemetry';
+
+describe('handleClientEvent', () => {
+  let infoSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  // Server-owned identity captured at identify time.
+  const identity: ClientEventIdentity = {
+    hashedToken: 'server-hash',
+    maskedToken: 'serv-oken',
+    clientId: 'server-client-id',
+    clientVersion: '4.200.0',
+    mode: 'universal',
+    deploymentId: 'deploy-1',
+  };
+
+  beforeEach(() => {
+    infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => logger);
+    warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => logger);
+    errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => logger);
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('stamps server-owned identity LAST, so a spoofed payload cannot override it', () => {
+    handleClientEvent(identity)({
+      ts: 123,
+      event: {
+        type: 'client-error',
+        errorCode: 'JWT_REFRESH_FAILED',
+        // Spoofed identity fields — must be ignored.
+        hashedToken: 'ATTACKER-HASH',
+        clientId: 'attacker',
+        deploymentId: 'attacker-deploy',
+      },
+    } as any);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hashedToken: 'server-hash',
+        clientId: 'server-client-id',
+        deploymentId: 'deploy-1',
+        errorCode: 'JWT_REFRESH_FAILED',
+        eventType: 'client-error',
+        clientTs: 123,
+      }),
+      'broker client event',
+    );
+  });
+
+  it('forwards bounded non-identity fields and the client ts into the log line', () => {
+    handleClientEvent(identity)({
+      ts: 999,
+      event: {
+        type: 'client-error',
+        errorCode: 'SEND_BACK_FAILED',
+        requestId: 'req-1',
+        integrationType: 'github',
+      },
+    } as any);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        errorCode: 'SEND_BACK_FAILED',
+        requestId: 'req-1',
+        integrationType: 'github',
+        clientTs: 999,
+      }),
+      'broker client event',
+    );
+  });
+
+  describe('severity', () => {
+    it('logs client-error at warn', () => {
+      handleClientEvent(identity)({
+        ts: 1,
+        event: { type: 'client-error', errorCode: 'JWT_REFRESH_FAILED' },
+      } as any);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        'broker client event',
+      );
+    });
+
+    it.each([
+      PROCESS_EXIT_REASONS.UNCAUGHT_EXCEPTION,
+      PROCESS_EXIT_REASONS.OAUTH_TOKEN_UNAVAILABLE,
+    ])('logs a fatal client-shutdown (%s) at error', (reason) => {
+      handleClientEvent(identity)({
+        ts: 1,
+        event: { type: 'client-shutdown', reason, uptimeSeconds: 3 },
+      } as any);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ reason, eventType: 'client-shutdown' }),
+        'broker client event',
+      );
+    });
+
+    it.each(['clean', PROCESS_EXIT_REASONS.RECONNECT_EXHAUSTION])(
+      'logs a non-fatal client-shutdown (%s) at info',
+      (reason) => {
+        handleClientEvent(identity)({
+          ts: 1,
+          event: { type: 'client-shutdown', reason, uptimeSeconds: 3 },
+        } as any);
+        expect(infoSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ reason, eventType: 'client-shutdown' }),
+          'broker client event',
+        );
+      },
+    );
+  });
+
+  it('logs an unknown event type under its raw type rather than dropping it', () => {
+    handleClientEvent(identity)({
+      ts: 1,
+      event: { type: 'future-event', someField: 'x' },
+    } as any);
+
+    // Unknown/forward-compat types are logged at info — surfaced, never dropped.
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'future-event',
+        someField: 'x',
+        hashedToken: 'server-hash',
+      }),
+      'broker client event',
+    );
+  });
+
+  it.each([
+    ['a missing event', { ts: 1 }],
+    ['a typeless event', { ts: 1, event: { errorCode: 'X' } }],
+  ])('warns and drops %s as malformed', (_label, message) => {
+    handleClientEvent(identity)(message as any);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ hashedToken: 'server-hash' }),
+      'Received malformed broker client event',
+    );
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This gives the broker server visibility into why a client is unhealthy. The client now emits a small, typed set of structured events over the existing websocket, and the server logs one structured line per event (with server-owned identity).

There are two events:
* `client-error` - covers non-fatal and otherwise-silent failures: JWT refresh, auth renewal, send-back failures, and downstream streaming errors.
*  `client-shutdown` - covers the exit paths: oauth-token-unavailable, uncaught exception, and clean SIGTERM/SIGINT.

On the server side, identity (hashedToken, clientId, version, mode, deploymentId) is stamped from stored connection metadata rather than the payload, so a client can't spoof it. Severity is set by event type and reason, and unknown or forward-compatible event types are logged rather than dropped. The existing "client connection identified" log is also enriched with deploymentId and mode.

On safety: every field is bounded — an enum, a Snyk-generated id, a known version/mode string, or a number — so no free-form strings, error messages, or customer-environment data can reach the logs. Emission is best-effort and fire-and-forget; events are dropped (never queued) when the connection is down and never disrupt request handling.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
