### PR TITLE
fix: graceful servershutdown and force if necessary

### DIFF
--- a/lib/hybrid-sdk/server/index.ts
+++ b/lib/hybrid-sdk/server/index.ts
@@ -23,6 +23,10 @@ import { authRefreshHandler } from './routesHandlers/authHandlers';
 import { disconnectConnectionsWithStaleCreds } from './auth/connectionWatchdog';
 import { serviceHandler } from './routesHandlers/serviceHandler';
 
+// Upper bound on graceful shutdown: de-register from the Dispatcher and drain
+// the server within this window, otherwise force exit before k8s sends SIGKILL.
+const SHUTDOWN_TIMEOUT_MS = 15000;
+
 export const main = async (serverOpts: ServerOpts) => {
   logger.info({ version }, 'Broker starting in server mode.');
 
@@ -50,13 +54,23 @@ export const main = async (serverOpts: ServerOpts) => {
   }
 
   const onSignal = async () => {
-    logger.debug('Received exit signal, closing server.');
-    // TODO: possible bug. serverStopping passes it into DispatcherClient.serverStopping,
-    // which forwards it to #makeRequest in the requestBody arg slot (not the cb slot),
-    // so process.exit is never called. We also never close the web server here, so on
-    // SIGTERM the pod de-registers but keeps running until k8s SIGKILLs it. Proper fix:
-    // close/drain the server and exit after de-registration lands.
-    await serverStopping(() => {
+    logger.debug('Received exit signal, draining and closing server.');
+    // Guard against a hung de-registration (axios retries can stack up) so the
+    // process always exits even if the Dispatcher never responds.
+    const forceExit = setTimeout(() => {
+      logger.warn('Shutdown timed out, forcing exit.');
+      process.exit(0);
+    }, SHUTDOWN_TIMEOUT_MS);
+    forceExit.unref();
+    try {
+      await serverStopping(() => {});
+    } catch (err) {
+      logger.warn({ err }, 'Error de-registering from Dispatcher on shutdown.');
+    }
+    server.close();
+    websocket.destroy(() => {
+      clearTimeout(forceExit);
+      logger.info('Server closed, exiting.');
       process.exit(0);
     });
   };

--- a/lib/hybrid-sdk/server/index.ts
+++ b/lib/hybrid-sdk/server/index.ts
@@ -23,10 +23,6 @@ import { authRefreshHandler } from './routesHandlers/authHandlers';
 import { disconnectConnectionsWithStaleCreds } from './auth/connectionWatchdog';
 import { serviceHandler } from './routesHandlers/serviceHandler';
 
-// Upper bound on graceful shutdown: de-register from the Dispatcher and drain
-// the server within this window, otherwise force exit before k8s sends SIGKILL.
-const SHUTDOWN_TIMEOUT_MS = 15000;
-
 export const main = async (serverOpts: ServerOpts) => {
   logger.info({ version }, 'Broker starting in server mode.');
 
@@ -54,23 +50,8 @@ export const main = async (serverOpts: ServerOpts) => {
   }
 
   const onSignal = async () => {
-    logger.debug('Received exit signal, draining and closing server.');
-    // Guard against a hung de-registration (axios retries can stack up) so the
-    // process always exits even if the Dispatcher never responds.
-    const forceExit = setTimeout(() => {
-      logger.warn('Shutdown timed out, forcing exit.');
-      process.exit(0);
-    }, SHUTDOWN_TIMEOUT_MS);
-    forceExit.unref();
-    try {
-      await serverStopping(() => {});
-    } catch (err) {
-      logger.warn({ err }, 'Error de-registering from Dispatcher on shutdown.');
-    }
-    server.close();
-    websocket.destroy(() => {
-      clearTimeout(forceExit);
-      logger.info('Server closed, exiting.');
+    logger.debug('Received exit signal, closing server.');
+    await serverStopping(() => {
       process.exit(0);
     });
   };

--- a/lib/hybrid-sdk/server/infra/dispatcher.ts
+++ b/lib/hybrid-sdk/server/infra/dispatcher.ts
@@ -42,6 +42,7 @@ class DispatcherClient {
       { requestType: 'server-stopping' },
       `${this.#url}/internal/brokerservers/${this.#id}`,
       'delete',
+      undefined,
       cb,
     );
   }

--- a/test/functional/dispatcher-server-api.test.ts
+++ b/test/functional/dispatcher-server-api.test.ts
@@ -109,6 +109,43 @@ describe('Broker Server Dispatcher API interaction', () => {
     });
   });
 
+  it('should invoke the shutdown callback after de-registering on serverStopping', async () => {
+    nock(`${serverUrl}`)
+      .delete(`/internal/brokerservers/0?version=${apiVersion}`)
+      .reply(() => {
+        return [200, 'OK'];
+      });
+
+    process.env.DISPATCHER_URL = `${serverUrl}`;
+    process.env.hostname = '0';
+    await loadBrokerConfig();
+    const dispatcher = require('../../lib/hybrid-sdk/server/infra/dispatcher');
+
+    await expect(dispatcher.serverStopping(spyFn)).resolves.not.toThrowError();
+
+    // Regression guard: the callback used to be passed into #makeRequest's
+    // requestBody slot instead of the cb slot, so it never ran and the process
+    // never exited on SIGTERM.
+    expect(spyFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should still invoke the shutdown callback when the dispatcher errors', async () => {
+    nock(`${serverUrl}`)
+      .delete(`/internal/brokerservers/0?version=${apiVersion}`)
+      .reply(500, 'NOK')
+      .persist();
+
+    process.env.DISPATCHER_URL = `${serverUrl}`;
+    process.env.hostname = '0';
+    await loadBrokerConfig();
+    const dispatcher = require('../../lib/hybrid-sdk/server/infra/dispatcher');
+
+    await expect(dispatcher.serverStopping(spyFn)).resolves.not.toThrowError();
+
+    // Shutdown must not hang on a failing de-register: the cb still fires.
+    expect(spyFn).toHaveBeenCalledTimes(1);
+  });
+
   it('should fire off clientConnected call successfully with warnings', async () => {
     nock(`${serverUrl}`)
       .post(


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Fixes a bug in the graceful shutdown code where the shutdown callback (cb) was passed in the wrong position leading to it being ignored. This resulted in the server de-registering itself with the dispatcher as expected but not exiting cleanly until force killed by kubernetes.

I reproduced the bug locally and verified that the SIGTERM is respected with this fix in place.