### PR TITLE
fix: route secondary pod forward directly to primary via headless SVC

### DIFF
--- a/lib/hybrid-sdk/server/routesHandlers/connectionStatusHandler.ts
+++ b/lib/hybrid-sdk/server/routesHandlers/connectionStatusHandler.ts
@@ -33,8 +33,10 @@ export const connectionStatusHandler = async (req: Request, res: Response) => {
       localHostname.endsWith('-1') &&
       localHostname.match(regex)
     ) {
-      const url = new URL(`http://${req.hostname}${req.url}`);
-      url.hostname = req.hostname.replace(/-[0-9]{1,2}\./, '.');
+      const primaryPodName = localHostname.replace(/-1$/, '-0');
+      const serviceName = localHostname.replace(/-[0-1]$/, '') + '-headless';
+      const url = new URL(`http://${primaryPodName}.${serviceName}${req.url}`);
+      url.port = req.socket.localPort?.toString() ?? '';
       url.searchParams.append('connection_role', 'primary');
 
       const postFilterPreparedRequest: PostFilterPreparedRequest = {

--- a/lib/hybrid-sdk/server/routesHandlers/connectionStatusHandler.ts
+++ b/lib/hybrid-sdk/server/routesHandlers/connectionStatusHandler.ts
@@ -36,7 +36,7 @@ export const connectionStatusHandler = async (req: Request, res: Response) => {
       const primaryPodName = localHostname.replace(/-1$/, '-0');
       const serviceName = localHostname.replace(/-[0-1]$/, '') + '-headless';
       const url = new URL(`http://${primaryPodName}.${serviceName}${req.url}`);
-      url.port = req.socket.localPort?.toString() ?? '';
+      url.port = req.socket.localPort?.toString() ?? '5000';
       url.searchParams.append('connection_role', 'primary');
 
       const postFilterPreparedRequest: PostFilterPreparedRequest = {

--- a/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.ts
+++ b/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.ts
@@ -33,8 +33,10 @@ export const overloadHttpRequestWithConnectionDetailsMiddleware = async (
       localHostname.endsWith('-1') &&
       localHostname.match(regex)
     ) {
-      const url = new URL(`http://${req.hostname}${req.url}`);
-      url.hostname = req.hostname.replace(/-[0-9]{1,2}\./, '.');
+      const primaryPodName = localHostname.replace(/-1$/, '-0');
+      const serviceName = localHostname.replace(/-[0-1]$/, '') + '-headless';
+      const url = new URL(`http://${primaryPodName}.${serviceName}${req.url}`);
+      url.port = req.socket.localPort?.toString() ?? '';
       url.searchParams.append('connection_role', 'primary');
 
       const postFilterPreparedRequest: PostFilterPreparedRequest = {

--- a/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.ts
+++ b/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.ts
@@ -36,7 +36,7 @@ export const overloadHttpRequestWithConnectionDetailsMiddleware = async (
       const primaryPodName = localHostname.replace(/-1$/, '-0');
       const serviceName = localHostname.replace(/-[0-1]$/, '') + '-headless';
       const url = new URL(`http://${primaryPodName}.${serviceName}${req.url}`);
-      url.port = req.socket.localPort?.toString() ?? '';
+      url.port = req.socket.localPort?.toString() ?? '5000';
       url.searchParams.append('connection_role', 'primary');
 
       const postFilterPreparedRequest: PostFilterPreparedRequest = {

--- a/test/unit/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.test.ts
+++ b/test/unit/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.test.ts
@@ -1,11 +1,21 @@
 import { overloadHttpRequestWithConnectionDetailsMiddleware } from '../../../../../../lib/hybrid-sdk/server/routesHandlers/httpRequestHandler';
 import { getSocketConnections } from '../../../../../../lib/hybrid-sdk/server/socket';
+import { makeStreamingRequestToDownstream } from '../../../../../../lib/hybrid-sdk/http/request';
+import { hostname } from 'node:os';
 import { NextFunction } from 'express';
 import httpMocks from 'node-mocks-http';
 
 jest.mock('../../../../../../lib/hybrid-sdk/server/socket');
+jest.mock('../../../../../../lib/hybrid-sdk/http/request');
+jest.mock('node:os', () => ({
+  ...jest.requireActual('node:os'),
+  hostname: jest.fn(),
+}));
 
 const mockedGetSocketConnections = getSocketConnections as jest.Mock;
+const mockedMakeStreamingRequest =
+  makeStreamingRequestToDownstream as jest.Mock;
+const mockedHostname = hostname as jest.Mock;
 
 describe('overloadHttpRequestWithConnectionDetailsMiddleware', () => {
   let next: NextFunction;
@@ -13,6 +23,8 @@ describe('overloadHttpRequestWithConnectionDetailsMiddleware', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     next = jest.fn();
+    mockedHostname.mockReturnValue('broker-snyk-server-v2-0-0');
+    delete process.env.BROKER_SERVER_MANDATORY_AUTH_ENABLED;
   });
 
   afterEach(() => {
@@ -172,5 +184,187 @@ describe('overloadHttpRequestWithConnectionDetailsMiddleware', () => {
     expect(res.locals.capabilities).toEqual(connection.metadata.capabilities);
     expect(res.locals.socketVersion).toEqual(connection.socketVersion);
     expect(res.locals.brokerAppClientId).toEqual('');
+  });
+
+  describe('secondary pod forwarding to primary via headless DNS', () => {
+    beforeEach(() => {
+      mockedGetSocketConnections.mockReturnValue(new Map());
+    });
+
+    it('should forward to primary pod via headless service DNS (single-digit shard)', async () => {
+      mockedHostname.mockReturnValue('broker-snyk-server-v2-1-1');
+      mockedMakeStreamingRequest.mockResolvedValue({
+        statusCode: 404,
+        headers: { 'x-broker-failure': 'no-connection' },
+        pipe: jest.fn(),
+      });
+      const req = httpMocks.createRequest({
+        params: { token: 'test-token' },
+        url: '/broker/test-token/some/path',
+        hostname: 'broker-snyk-server-v2-1.default.svc.cluster.local',
+        socket: { localPort: 5000 },
+      });
+      const res = httpMocks.createResponse();
+
+      await overloadHttpRequestWithConnectionDetailsMiddleware(req, res, next);
+
+      expect(mockedMakeStreamingRequest).toHaveBeenCalledTimes(1);
+      const forwardedUrl = mockedMakeStreamingRequest.mock.calls[0][0].url;
+      expect(forwardedUrl).toContain(
+        'broker-snyk-server-v2-1-0.broker-snyk-server-v2-1-headless',
+      );
+      expect(forwardedUrl).toContain(':5000');
+      expect(forwardedUrl).toContain('connection_role=primary');
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should forward to primary pod via headless service DNS (double-digit shard)', async () => {
+      mockedHostname.mockReturnValue('broker-snyk-server-v2-15-1');
+      mockedMakeStreamingRequest.mockResolvedValue({
+        statusCode: 404,
+        headers: { 'x-broker-failure': 'no-connection' },
+        pipe: jest.fn(),
+      });
+      const req = httpMocks.createRequest({
+        params: { token: 'test-token' },
+        url: '/broker/test-token/some/path',
+        hostname: 'broker-snyk-server-v2-15.default.svc.cluster.local',
+        socket: { localPort: 5000 },
+      });
+      const res = httpMocks.createResponse();
+
+      await overloadHttpRequestWithConnectionDetailsMiddleware(req, res, next);
+
+      const forwardedUrl = mockedMakeStreamingRequest.mock.calls[0][0].url;
+      expect(forwardedUrl).toContain(
+        'broker-snyk-server-v2-15-0.broker-snyk-server-v2-15-headless',
+      );
+    });
+
+    it('should relay the primary response verbatim (status + headers)', async () => {
+      mockedHostname.mockReturnValue('broker-snyk-server-v2-3-1');
+      const mockPipe = jest.fn();
+      mockedMakeStreamingRequest.mockResolvedValue({
+        statusCode: 404,
+        headers: {
+          'x-broker-failure': 'no-connection',
+          'content-type': 'application/json',
+        },
+        pipe: mockPipe,
+      });
+      const req = httpMocks.createRequest({
+        params: { token: 'test-token' },
+        url: '/broker/test-token/some/path',
+        hostname: 'broker-snyk-server-v2-3.default.svc.cluster.local',
+        socket: { localPort: 5000 },
+      });
+      const res = httpMocks.createResponse();
+
+      await overloadHttpRequestWithConnectionDetailsMiddleware(req, res, next);
+
+      expect(res.statusCode).toBe(404);
+      expect(mockPipe).toHaveBeenCalledWith(res);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should relay a successful response from primary (legacy token found)', async () => {
+      mockedHostname.mockReturnValue('broker-snyk-server-v2-5-1');
+      const mockPipe = jest.fn();
+      mockedMakeStreamingRequest.mockResolvedValue({
+        statusCode: 200,
+        headers: { 'content-type': 'application/json' },
+        pipe: mockPipe,
+      });
+      const req = httpMocks.createRequest({
+        params: { token: 'test-token' },
+        url: '/broker/test-token/some/path',
+        hostname: 'broker-snyk-server-v2-5.default.svc.cluster.local',
+        socket: { localPort: 5000 },
+      });
+      const res = httpMocks.createResponse();
+
+      await overloadHttpRequestWithConnectionDetailsMiddleware(req, res, next);
+
+      expect(res.statusCode).toBe(200);
+      expect(mockPipe).toHaveBeenCalledWith(res);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should return 500 with x-broker-failure when forward to primary fails', async () => {
+      mockedHostname.mockReturnValue('broker-snyk-server-v2-7-1');
+      mockedMakeStreamingRequest.mockRejectedValue(
+        new Error('getaddrinfo NXDOMAIN'),
+      );
+      const req = httpMocks.createRequest({
+        params: { token: 'test-token' },
+        url: '/broker/test-token/some/path',
+        hostname: 'broker-snyk-server-v2-7.default.svc.cluster.local',
+        socket: { localPort: 5000 },
+      });
+      const res = httpMocks.createResponse();
+
+      await overloadHttpRequestWithConnectionDetailsMiddleware(req, res, next);
+
+      expect(res.statusCode).toBe(500);
+      expect(res.getHeader('x-broker-failure')).toBe(
+        'error-forwarding-to-primary',
+      );
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should forward POST body to primary', async () => {
+      mockedHostname.mockReturnValue('broker-snyk-server-v2-2-1');
+      mockedMakeStreamingRequest.mockResolvedValue({
+        statusCode: 200,
+        headers: {},
+        pipe: jest.fn(),
+      });
+      const req = httpMocks.createRequest({
+        method: 'POST',
+        params: { token: 'test-token' },
+        url: '/broker/test-token/some/path',
+        hostname: 'broker-snyk-server-v2-2.default.svc.cluster.local',
+        socket: { localPort: 5000 },
+        body: { key: 'value' },
+      });
+      const res = httpMocks.createResponse();
+
+      await overloadHttpRequestWithConnectionDetailsMiddleware(req, res, next);
+
+      const forwardedReq = mockedMakeStreamingRequest.mock.calls[0][0];
+      expect(forwardedReq.body).toEqual({ key: 'value' });
+      expect(forwardedReq.method).toBe('POST');
+    });
+
+    it('should NOT forward on primary pod (hostname ends with -0)', async () => {
+      mockedHostname.mockReturnValue('broker-snyk-server-v2-1-0');
+      const req = httpMocks.createRequest({
+        params: { token: 'test-token' },
+        url: '/broker/test-token/some/path',
+      });
+      const res = httpMocks.createResponse();
+
+      await overloadHttpRequestWithConnectionDetailsMiddleware(req, res, next);
+
+      expect(mockedMakeStreamingRequest).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(404);
+      expect(res.getHeader('x-broker-failure')).toBe('no-connection');
+    });
+
+    it('should NOT forward when BROKER_SERVER_MANDATORY_AUTH_ENABLED is set (universal)', async () => {
+      process.env.BROKER_SERVER_MANDATORY_AUTH_ENABLED = 'true';
+      mockedHostname.mockReturnValue('broker-snyk-server-v2-1-1');
+      const req = httpMocks.createRequest({
+        params: { token: 'test-token' },
+        url: '/broker/test-token/some/path',
+      });
+      const res = httpMocks.createResponse();
+
+      await overloadHttpRequestWithConnectionDetailsMiddleware(req, res, next);
+
+      expect(mockedMakeStreamingRequest).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(404);
+      expect(res.getHeader('x-broker-failure')).toBe('no-connection');
+    });
   });
 });

--- a/test/unit/old-client-redirect.test.ts
+++ b/test/unit/old-client-redirect.test.ts
@@ -1,10 +1,11 @@
 import bodyParser from 'body-parser';
 import { overloadHttpRequestWithConnectionDetailsMiddleware } from '../../lib/hybrid-sdk/server/routesHandlers/httpRequestHandler';
+import { makeStreamingRequestToDownstream } from '../../lib/hybrid-sdk/http/request';
 import express from 'express';
 import request from 'supertest';
-import nock from 'nock';
 import path from 'path';
 import { readFileSync } from 'node:fs';
+import { PassThrough } from 'stream';
 import { connectionStatusHandler } from '../../lib/hybrid-sdk/server/routesHandlers/connectionStatusHandler';
 
 const fixtures = path.resolve(__dirname, '..', 'fixtures');
@@ -23,9 +24,6 @@ jest.mock('../../lib/hybrid-sdk/server/socket', () => {
       map.set('7fe7a57b-aa0d-416a-97fc-472061737e24', [
         { socket: {}, socketVersion: '1', metadata: { capabilities: {} } },
       ]);
-      // map.set('7fe7a57b-aa0d-416a-97fc-472061737e26', [
-      //   { metadata: {version: '123', filter: {}} },
-      // ]);
       return map;
     },
   };
@@ -43,16 +41,28 @@ jest.mock('node:os', () => {
   };
 });
 
+jest.mock('../../lib/hybrid-sdk/http/request');
+
+const mockedMakeStreamingRequest =
+  makeStreamingRequestToDownstream as jest.Mock;
+
+function createMockResponse(statusCode: number, body: unknown) {
+  const stream = new PassThrough();
+  (stream as any).statusCode = statusCode;
+  (stream as any).headers = { 'content-type': 'application/json' };
+  stream.end(JSON.stringify(body));
+  return stream;
+}
+
 describe('Testing older clients specific logic', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('Testing the old client redirected to primary from secondary pods', async () => {
-    nock(`http://my-server-name.default.svc.cluster`)
-      .persist()
-      .get(
-        '/broker/7fe7a57b-aa0d-416a-97fc-472061737e25/path?connection_role=primary',
-      )
-      .reply(() => {
-        return [200, { test: 'value' }];
-      });
+    mockedMakeStreamingRequest.mockResolvedValue(
+      createMockResponse(200, { test: 'value' }),
+    );
     const app = express();
     app.use(
       bodyParser.raw({
@@ -73,16 +83,17 @@ describe('Testing older clients specific logic', () => {
 
     expect(response.status).toEqual(200);
     expect(response.body).toEqual({ test: 'value' });
+    const forwardedUrl = mockedMakeStreamingRequest.mock.calls[0][0].url;
+    expect(forwardedUrl).toContain(
+      'my-server-name-10-0.my-server-name-10-headless',
+    );
+    expect(forwardedUrl).toContain('connection_role=primary');
   });
+
   it('Testing the old client redirected to primary from secondary pods - POST request', async () => {
-    nock(`http://my-server-name.default.svc.cluster`)
-      .persist()
-      .post(
-        '/broker/7fe7a57b-aa0d-416a-97fc-472061737e25/path?connection_role=primary',
-      )
-      .reply((_uri, requestBody) => {
-        return [200, requestBody];
-      });
+    mockedMakeStreamingRequest.mockResolvedValue(
+      createMockResponse(200, { test: 'value2' }),
+    );
     const app = express();
     app.use(
       bodyParser.raw({
@@ -104,19 +115,16 @@ describe('Testing older clients specific logic', () => {
 
     expect(response.status).toEqual(200);
     expect(response.body).toEqual({ test: 'value2' });
+    expect(mockedMakeStreamingRequest.mock.calls[0][0].method).toBe('POST');
   });
+
   it('Testing the old client redirected to primary from secondary pods - get request', async () => {
     const fileJson = JSON.parse(
       readFileSync(`${fixtures}/accept/ghe.json`).toString(),
     );
-    nock(`http://my-server-name.default.svc.cluster`)
-      .persist()
-      .get(
-        '/broker/7fe7a57b-aa0d-416a-97fc-472061737e25/file?connection_role=primary',
-      )
-      .reply(() => {
-        return [200, fileJson];
-      });
+    mockedMakeStreamingRequest.mockResolvedValue(
+      createMockResponse(200, fileJson),
+    );
     const app = express();
     app.use(
       bodyParser.raw({
@@ -140,14 +148,9 @@ describe('Testing older clients specific logic', () => {
   });
 
   it('Testing the connection-status old client redirected to primary from secondary pods', async () => {
-    nock(`http://my-server-name.default.svc.cluster`)
-      .persist()
-      .get(
-        '/connection-status/7fe7a57b-aa0d-416a-97fc-472061737e26?connection_role=primary',
-      )
-      .reply(() => {
-        return [200, { test: 'value' }];
-      });
+    mockedMakeStreamingRequest.mockResolvedValue(
+      createMockResponse(200, { test: 'value' }),
+    );
     const app = express();
     app.use(
       bodyParser.raw({
@@ -165,5 +168,10 @@ describe('Testing older clients specific logic', () => {
 
     expect(response.status).toEqual(200);
     expect(response.body).toEqual({ test: 'value' });
+    const forwardedUrl = mockedMakeStreamingRequest.mock.calls[0][0].url;
+    expect(forwardedUrl).toContain(
+      'my-server-name-10-0.my-server-name-10-headless',
+    );
+    expect(forwardedUrl).toContain('connection_role=primary');
   });
 });


### PR DESCRIPTION
#### What does this PR do?
The secondary (-1) pod was forwarding requests to the ExternalName service, which looped back through the gateway. This caused universal token 404s to lose the x-broker-failure header, triggering the gateway's re-dial and a coin-flip failure on pod selection.

Forward directly to the primary (-0) pod using StatefulSet headless DNS (pod-0.service-headless), bypassing the gateway entirely. The primary either processes the request (legacy token) or returns 404 with x-broker-failure: no-connection (universal token), preserving the header for correct gateway routing.
