### PR TITLE
fix: honor HTTPS_PROXY for all outbound requests

### DIFF
--- a/lib/hybrid-sdk/client/index.ts
+++ b/lib/hybrid-sdk/client/index.ts
@@ -29,6 +29,7 @@ import { manageWebsocketConnections } from './connectionsManager/manager';
 import { findPluginFolder } from '../common/config/config';
 import { retrieveAndLoadFilters } from './utils/filterLoading';
 import { probeIpv6WithIpv4Fallback } from './utils/probeIpv6WithIpv4Fallback';
+import { initGlobalProxy } from '../common/utils/proxy';
 import * as metrics from './metrics';
 import { emitShutdown } from './events';
 import { PROCESS_EXIT_REASONS, safeNodeErrno } from '../common/types/telemetry';
@@ -105,6 +106,9 @@ export const main = async (clientOpts: ClientOpts) => {
       process.env.SNYK_DISPATCHER_URL_PREFIX = '/hidden/brokers';
     }
     await validateMinimalConfig(clientOpts);
+
+    // Initialize global proxy support before the first outbound request.
+    initGlobalProxy(clientOpts.config.apiHostname);
 
     if (clientOpts.config.IPV6_CONNECTIVITY_CHECK_ENABLED !== 'false') {
       const brokerServerHost = new URL(

--- a/lib/hybrid-sdk/common/utils/proxy.ts
+++ b/lib/hybrid-sdk/common/utils/proxy.ts
@@ -1,0 +1,33 @@
+import { getProxyForUrl } from 'proxy-from-env';
+import { bootstrap } from 'global-agent';
+
+/**
+ * Normalize lowercase proxy env vars into their uppercase equivalents so that
+ * downstream consumers (proxy-from-env / global-agent) see a consistent set.
+ */
+export function normalizeProxyEnv(): void {
+  if (process.env.HTTP_PROXY || process.env.http_proxy) {
+    process.env.HTTP_PROXY = process.env.HTTP_PROXY || process.env.http_proxy;
+  }
+  if (process.env.HTTPS_PROXY || process.env.https_proxy) {
+    process.env.HTTPS_PROXY =
+      process.env.HTTPS_PROXY || process.env.https_proxy;
+  }
+  if (process.env.NO_PROXY || process.env.no_proxy) {
+    process.env.NO_PROXY = process.env.NO_PROXY || process.env.no_proxy;
+  }
+}
+
+/**
+ * Node ignores HTTP_PROXY/HTTPS_PROXY until global-agent patches http/https.
+ * Call before outbound requests so they route through the proxy (respects
+ * NO_PROXY); idempotent.
+ */
+export function initGlobalProxy(url: string): void {
+  normalizeProxyEnv();
+  if (url && getProxyForUrl(url)) {
+    bootstrap({
+      environmentVariableNamespace: '',
+    });
+  }
+}

--- a/lib/hybrid-sdk/common/utils/proxy.ts
+++ b/lib/hybrid-sdk/common/utils/proxy.ts
@@ -23,7 +23,7 @@ export function normalizeProxyEnv(): void {
  * Call before outbound requests so they route through the proxy (respects
  * NO_PROXY); idempotent.
  */
-export function initGlobalProxy(url: string): void {
+export function initGlobalProxy(url: string | undefined): void {
   normalizeProxyEnv();
   if (url && getProxyForUrl(url)) {
     bootstrap({

--- a/lib/hybrid-sdk/http/downstream-post-stream-to-server.ts
+++ b/lib/hybrid-sdk/http/downstream-post-stream-to-server.ts
@@ -4,8 +4,7 @@ import { pipeline } from 'stream/promises';
 
 import version from '../common/utils/version';
 
-import { getProxyForUrl } from 'proxy-from-env';
-import { bootstrap } from 'global-agent';
+import { initGlobalProxy } from '../common/utils/proxy';
 import https from 'https';
 import http from 'http';
 
@@ -35,21 +34,7 @@ const CONNECTION_RETRY_DELAY_MS = 500;
 
 const client = getConfig().brokerServerUrl?.startsWith('https') ? https : http;
 
-if (process.env.HTTP_PROXY || process.env.http_proxy) {
-  process.env.HTTP_PROXY = process.env.HTTP_PROXY || process.env.http_proxy;
-}
-if (process.env.HTTPS_PROXY || process.env.https_proxy) {
-  process.env.HTTPS_PROXY = process.env.HTTPS_PROXY || process.env.https_proxy;
-}
-if (process.env.NO_PROXY || process.env.no_proxy) {
-  process.env.NO_PROXY = process.env.NO_PROXY || process.env.no_proxy;
-}
-const proxyUri = getProxyForUrl(getConfig().brokerServerUrl);
-if (proxyUri) {
-  bootstrap({
-    environmentVariableNamespace: '',
-  });
-}
+initGlobalProxy(getConfig().brokerServerUrl);
 
 interface Logger {
   debug(message: string): void;

--- a/lib/hybrid-sdk/http/request.ts
+++ b/lib/hybrid-sdk/http/request.ts
@@ -2,8 +2,7 @@ import { randomUUID } from 'crypto';
 import http from 'node:http';
 import https from 'node:https';
 import { performance } from 'node:perf_hooks';
-import { getProxyForUrl } from 'proxy-from-env';
-import { bootstrap } from 'global-agent';
+import { initGlobalProxy } from '../common/utils/proxy';
 import { log as logger } from '../../logs/logger';
 import { PostFilterPreparedRequest } from '../../broker-workload/prepareRequest';
 import { getConfig } from '../common/config/config';
@@ -19,16 +18,6 @@ export interface HttpResponse {
 }
 const MAX_RETRY = getConfig().MAX_RETRY || 3;
 
-if (process.env.HTTP_PROXY || process.env.http_proxy) {
-  process.env.HTTP_PROXY = process.env.HTTP_PROXY || process.env.http_proxy;
-}
-if (process.env.HTTPS_PROXY || process.env.https_proxy) {
-  process.env.HTTPS_PROXY = process.env.HTTPS_PROXY || process.env.https_proxy;
-}
-if (process.env.NO_PROXY || process.env.no_proxy) {
-  process.env.NO_PROXY = process.env.NO_PROXY || process.env.no_proxy;
-}
-
 export const makeRequestToDownstream = async (
   req: PostFilterPreparedRequest,
   retries = MAX_RETRY,
@@ -41,12 +30,7 @@ export const makeRequestToDownstream = async (
   if (config.INSECURE_DOWNSTREAM) {
     localRequest.url = switchToInsecure(localRequest.url);
   }
-  const proxyUri = getProxyForUrl(localRequest.url);
-  if (proxyUri) {
-    bootstrap({
-      environmentVariableNamespace: '',
-    });
-  }
+  initGlobalProxy(localRequest.url);
   localRequest.headers['x-broker-origin-ua'] =
     localRequest.headers['user-agent'] ?? 'not-provided';
   localRequest.headers['user-agent'] = `Snyk Broker Client ${version}`;
@@ -177,12 +161,7 @@ export const makeStreamingRequestToDownstream = (
   if (config.INSECURE_DOWNSTREAM) {
     localRequest.url = switchToInsecure(localRequest.url);
   }
-  const proxyUri = getProxyForUrl(localRequest.url);
-  if (proxyUri) {
-    bootstrap({
-      environmentVariableNamespace: '',
-    });
-  }
+  initGlobalProxy(localRequest.url);
   localRequest.headers['x-broker-origin-ua'] =
     localRequest.headers['user-agent'] ?? 'not-provided';
   localRequest.headers['user-agent'] = `Snyk Broker Client ${version}`;
@@ -303,12 +282,7 @@ export const makeSingleRawRequestToDownstream = async (
   if (config.INSECURE_DOWNSTREAM) {
     localRequest.url = switchToInsecure(localRequest.url);
   }
-  const proxyUri = getProxyForUrl(localRequest.url);
-  if (proxyUri) {
-    bootstrap({
-      environmentVariableNamespace: '',
-    });
-  }
+  initGlobalProxy(localRequest.url);
   localRequest.headers['x-broker-origin-ua'] =
     localRequest.headers['user-agent'] ?? 'not-provided';
   localRequest.headers['user-agent'] = `Snyk Broker Client ${version}`;

--- a/test/unit/client/proxy-init.test.ts
+++ b/test/unit/client/proxy-init.test.ts
@@ -1,0 +1,81 @@
+import {
+  initGlobalProxy,
+  normalizeProxyEnv,
+} from '../../../lib/hybrid-sdk/common/utils/proxy';
+
+const PROXY_ENV_KEYS = [
+  'HTTP_PROXY',
+  'http_proxy',
+  'HTTPS_PROXY',
+  'https_proxy',
+  'NO_PROXY',
+  'no_proxy',
+];
+
+// global-agent records its config on global.GLOBAL_AGENT once bootstrap() runs;
+// its presence is the observable signal that proxy support was installed.
+const globalAgent = () => (global as any).GLOBAL_AGENT;
+
+describe('common/utils/proxy initGlobalProxy', () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {};
+    for (const key of PROXY_ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    delete (global as any).GLOBAL_AGENT;
+  });
+
+  afterEach(() => {
+    for (const key of PROXY_ENV_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+    delete (global as any).GLOBAL_AGENT;
+  });
+
+  it('bootstraps global-agent when a proxy applies to the url', () => {
+    process.env.HTTP_PROXY = 'http://proxy:10224';
+    process.env.HTTPS_PROXY = 'http://proxy:10224';
+
+    initGlobalProxy('https://api.snyk.io');
+
+    expect(globalAgent()).toBeDefined();
+  });
+
+  it('does not bootstrap when the url is excluded via NO_PROXY', () => {
+    process.env.HTTP_PROXY = 'http://proxy:10224';
+    process.env.HTTPS_PROXY = 'http://proxy:10224';
+    process.env.NO_PROXY = 'api.snyk.io';
+
+    initGlobalProxy('https://api.snyk.io');
+
+    expect(globalAgent()).toBeUndefined();
+  });
+
+  it('is a no-op when no proxy env is configured', () => {
+    expect(() => initGlobalProxy('https://api.snyk.io')).not.toThrow();
+    expect(globalAgent()).toBeUndefined();
+  });
+
+  it('can be called repeatedly without throwing (idempotent)', () => {
+    process.env.HTTPS_PROXY = 'http://proxy:10224';
+
+    initGlobalProxy('https://api.snyk.io');
+    expect(() => initGlobalProxy('https://api.snyk.io')).not.toThrow();
+    expect(globalAgent()).toBeDefined();
+  });
+
+  it('normalizes lowercase proxy env vars to uppercase', () => {
+    process.env.https_proxy = 'http://proxy:10224';
+
+    normalizeProxyEnv();
+
+    expect(process.env.HTTPS_PROXY).toBe('http://proxy:10224');
+  });
+});

--- a/test/unit/client/proxy-init.test.ts
+++ b/test/unit/client/proxy-init.test.ts
@@ -1,7 +1,14 @@
+// Mock global-agent so bootstrap() cannot patch shared http/https and leak
+// into sibling test files.
+jest.mock('global-agent', () => ({ bootstrap: jest.fn() }));
+
+import { bootstrap } from 'global-agent';
 import {
   initGlobalProxy,
   normalizeProxyEnv,
 } from '../../../lib/hybrid-sdk/common/utils/proxy';
+
+const bootstrapMock = bootstrap as unknown as jest.Mock;
 
 const PROXY_ENV_KEYS = [
   'HTTP_PROXY',
@@ -12,10 +19,6 @@ const PROXY_ENV_KEYS = [
   'no_proxy',
 ];
 
-// global-agent records its config on global.GLOBAL_AGENT once bootstrap() runs;
-// its presence is the observable signal that proxy support was installed.
-const globalAgent = () => (global as any).GLOBAL_AGENT;
-
 describe('common/utils/proxy initGlobalProxy', () => {
   let savedEnv: Record<string, string | undefined>;
 
@@ -25,7 +28,7 @@ describe('common/utils/proxy initGlobalProxy', () => {
       savedEnv[key] = process.env[key];
       delete process.env[key];
     }
-    delete (global as any).GLOBAL_AGENT;
+    bootstrapMock.mockClear();
   });
 
   afterEach(() => {
@@ -36,39 +39,39 @@ describe('common/utils/proxy initGlobalProxy', () => {
         process.env[key] = savedEnv[key];
       }
     }
-    delete (global as any).GLOBAL_AGENT;
   });
 
   it('bootstraps global-agent when a proxy applies to the url', () => {
-    process.env.HTTP_PROXY = 'http://proxy:10224';
     process.env.HTTPS_PROXY = 'http://proxy:10224';
 
     initGlobalProxy('https://api.snyk.io');
 
-    expect(globalAgent()).toBeDefined();
+    expect(bootstrapMock).toHaveBeenCalledWith({
+      environmentVariableNamespace: '',
+    });
   });
 
   it('does not bootstrap when the url is excluded via NO_PROXY', () => {
-    process.env.HTTP_PROXY = 'http://proxy:10224';
     process.env.HTTPS_PROXY = 'http://proxy:10224';
     process.env.NO_PROXY = 'api.snyk.io';
 
     initGlobalProxy('https://api.snyk.io');
 
-    expect(globalAgent()).toBeUndefined();
+    expect(bootstrapMock).not.toHaveBeenCalled();
   });
 
-  it('is a no-op when no proxy env is configured', () => {
-    expect(() => initGlobalProxy('https://api.snyk.io')).not.toThrow();
-    expect(globalAgent()).toBeUndefined();
+  it('does not bootstrap when no proxy env is configured', () => {
+    initGlobalProxy('https://api.snyk.io');
+
+    expect(bootstrapMock).not.toHaveBeenCalled();
   });
 
-  it('can be called repeatedly without throwing (idempotent)', () => {
+  it('does not bootstrap when the url is undefined', () => {
     process.env.HTTPS_PROXY = 'http://proxy:10224';
 
-    initGlobalProxy('https://api.snyk.io');
-    expect(() => initGlobalProxy('https://api.snyk.io')).not.toThrow();
-    expect(globalAgent()).toBeDefined();
+    initGlobalProxy(undefined);
+
+    expect(bootstrapMock).not.toHaveBeenCalled();
   });
 
   it('normalizes lowercase proxy env vars to uppercase', () => {

--- a/test/unit/client/proxy-tunnel.test.ts
+++ b/test/unit/client/proxy-tunnel.test.ts
@@ -1,0 +1,98 @@
+import http from 'http';
+import https from 'https';
+import net from 'net';
+import { initGlobalProxy } from '../../../lib/hybrid-sdk/common/utils/proxy';
+
+const PROXY_ENV_KEYS = [
+  'HTTP_PROXY',
+  'http_proxy',
+  'HTTPS_PROXY',
+  'https_proxy',
+  'NO_PROXY',
+  'no_proxy',
+];
+
+// A caller that sets its own agent must still be routed through the proxy;
+// otherwise proxied environments silently lose connectivity.
+describe('initGlobalProxy makes explicit-agent https requests tunnel via the proxy', () => {
+  let proxy: http.Server;
+  let proxyPort: number;
+  const connectTargets: string[] = [];
+  const openSockets = new Set<net.Socket>();
+
+  // Captured pristine so afterAll can undo the global patching and not leak it
+  // into sibling test files.
+  const orig = {
+    httpRequest: http.request,
+    httpGet: http.get,
+    httpsRequest: https.request,
+    httpsGet: https.get,
+    httpAgent: http.globalAgent,
+    httpsAgent: https.globalAgent,
+  };
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeAll((done) => {
+    savedEnv = {};
+    for (const k of PROXY_ENV_KEYS) {
+      savedEnv[k] = process.env[k];
+      delete process.env[k];
+    }
+    proxy = http.createServer();
+    proxy.on('connection', (socket) => {
+      openSockets.add(socket);
+      socket.on('close', () => openSockets.delete(socket));
+    });
+    proxy.on('connect', (req, socket) => {
+      connectTargets.push(req.url ?? '');
+      // We only care that the CONNECT reached the proxy.
+      socket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+      socket.destroy();
+    });
+    proxy.listen(0, '127.0.0.1', () => {
+      proxyPort = (proxy.address() as net.AddressInfo).port;
+      done();
+    });
+  });
+
+  afterAll((done) => {
+    (http as any).request = orig.httpRequest;
+    (http as any).get = orig.httpGet;
+    (https as any).request = orig.httpsRequest;
+    (https as any).get = orig.httpsGet;
+    http.globalAgent = orig.httpAgent;
+    https.globalAgent = orig.httpsAgent;
+    delete (global as any).GLOBAL_AGENT;
+    for (const k of PROXY_ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+    for (const socket of openSockets) socket.destroy();
+    proxy.close(() => done());
+  });
+
+  it('sends a CONNECT for the target host to the configured proxy', async () => {
+    process.env.HTTPS_PROXY = `http://127.0.0.1:${proxyPort}`;
+
+    initGlobalProxy('https://api.test.local');
+
+    await new Promise<void>((resolve) => {
+      const req = https.request(
+        'https://api.test.local/oauth2/token',
+        { method: 'POST', agent: new https.Agent({ maxSockets: Infinity }) },
+        (res) => {
+          res.resume();
+          res.on('end', resolve);
+        },
+      );
+      req.setTimeout(3000, () => {
+        req.destroy();
+        resolve();
+      });
+      req.on('error', () => resolve());
+      req.end();
+    });
+
+    expect(connectTargets).toContain('api.test.local:443');
+  });
+});


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Bootstrap global-agent once, early in client startup, before any outbound HTTP, via a shared initGlobalProxy() helper.

This fixes a bug where the first outbound call, OAuth token fetch, connected directly and bypassed the configured proxy and future-proofs against future regressions.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
