### PR TITLE
fix: always send oauth auth header on universal websocket handshake

### DIFF
--- a/lib/hybrid-sdk/client/auth/oauth.ts
+++ b/lib/hybrid-sdk/client/auth/oauth.ts
@@ -87,32 +87,6 @@ function formatAccessToken(accessToken: AccessToken): string {
   return `${raw.token_type} ${raw.access_token}`;
 }
 
-/**
- * Returns a cached token synchronously. Triggers a background refresh when the
- * cached token is within the expiry threshold (or absent/expired) so that
- * subsequent sync reads see a fresh token. When the token is within the
- * threshold but not yet expired, the still-valid token is returned for the
- * current caller — better than returning undefined and forcing an unauth'd
- * request.
- */
-export function getCachedAccessToken(): string | undefined {
-  if (!client) {
-    return undefined;
-  }
-  if (!token || token.expired(0)) {
-    void refreshToken().catch(() => {
-      /* failure already logged and recorded in refreshToken */
-    });
-    return undefined;
-  }
-  if (token.expired(thresholdSeconds)) {
-    void refreshToken().catch(() => {
-      /* failure already logged and recorded in refreshToken */
-    });
-  }
-  return formatAccessToken(token);
-}
-
 export async function getAccessToken(): Promise<string> {
   return formatAccessToken(await ensureToken());
 }

--- a/lib/hybrid-sdk/client/socket.ts
+++ b/lib/hybrid-sdk/client/socket.ts
@@ -21,7 +21,6 @@ import { LoadedClientOpts } from '../common/types/options';
 import { maskToken } from '../common/utils/token';
 import {
   getAccessToken,
-  getCachedAccessToken,
   invalidateToken,
   isOAuthClientInitialized,
 } from './auth/oauth';
@@ -41,6 +40,17 @@ import {
 } from '../common/types/telemetry';
 
 const MAX_CONSECUTIVE_AUTH_FAILURES = 3;
+
+// A GA universal client always authenticates.
+// SKIP_REMOTE_CONFIG (local-config) mode never initializes OAuth and is exempt.
+const clientShouldAuthenticate = (
+  config: LoadedClientOpts['config'],
+): boolean =>
+  Boolean(
+    config.universalBrokerEnabled &&
+      config.UNIVERSAL_BROKER_GA &&
+      !config.SKIP_REMOTE_CONFIG,
+  );
 
 /**
  * Creates a pair of WebSocket connections (primary and secondary) for the given connection key.
@@ -109,18 +119,27 @@ export const createWebSocketConnectionPairs = async (
     clientOpts.config.connections[`${socketIdentifyingMetadata.friendlyName}`]
       .serverId ?? '';
 
+  // Ensure a token is fetched before constructing sockets so the initial
+  // handshake carries an Authorization header regardless of the caller.
+  let initialAuthHeader: string | undefined;
+  if (clientShouldAuthenticate(clientOpts.config)) {
+    initialAuthHeader = await getAccessToken();
+  }
+
   return [
     createWebSocket(
       clientOpts,
       socketIdentifyingMetadata,
       Role.primary,
       metricsClient,
+      initialAuthHeader,
     ),
     createWebSocket(
       clientOpts,
       socketIdentifyingMetadata,
       Role.secondary,
       metricsClient,
+      initialAuthHeader,
     ),
   ];
 };
@@ -130,6 +149,7 @@ export const createWebSocket = (
   originalIdentifyingMetadata: IdentifyingMetadata,
   role?: Role,
   metricsClient: Client = new NoopClient(),
+  initialAuthHeader?: string,
 ): WebSocketConnection => {
   const identifyingMetadata = Object.assign({}, originalIdentifyingMetadata);
   identifyingMetadata.role = role ?? Role.primary;
@@ -141,6 +161,20 @@ export const createWebSocket = (
       `Invalid Broker identifier in websocket tunnel creation step.`,
     );
   }
+
+  // Missing OAuth for an authenticating client is fatal rather than a silent
+  // downgrade to an unauthenticated (legacy-routed) connection.
+  const shouldAuthenticate = clientShouldAuthenticate(clientOpts.config);
+  if (shouldAuthenticate && !isOAuthClientInitialized()) {
+    logger.fatal(
+      { connection: maskToken(identifyingMetadata.identifier) },
+      'UNIVERSAL_BROKER_GA is enabled but the OAuth client is not initialized; cannot authenticate.',
+    );
+    throw new Error(
+      'UNIVERSAL_BROKER_GA is enabled but the OAuth client is not initialized.',
+    );
+  }
+
   const Socket = Primus.createSocket({
     transformer: 'engine.io',
     parser: 'EJSON',
@@ -178,6 +212,10 @@ export const createWebSocket = (
   };
 
   let currentRequestId = uuidv4();
+  // Last-known-good auth header. Seeded before the first handshake and refreshed
+  // by the renewal timer and the error handler, so header building stays
+  // synchronous and never drops to unauthenticated for an authenticating client.
+  let lastAuthHeader = initialAuthHeader;
   const buildExtraHeaders = (requestId: string): Record<string, string> => {
     const headers: Record<string, string> = {
       'x-snyk-broker-client-id': identifyingMetadata.clientId,
@@ -185,11 +223,8 @@ export const createWebSocket = (
       'x-broker-client-version': version,
       'snyk-request-id': requestId,
     };
-    if (isOAuthClientInitialized() && clientOpts.config.UNIVERSAL_BROKER_GA) {
-      const authorization = getCachedAccessToken();
-      if (authorization) {
-        headers.Authorization = authorization;
-      }
+    if (shouldAuthenticate && lastAuthHeader) {
+      headers.Authorization = lastAuthHeader;
     }
     return headers;
   };
@@ -214,7 +249,7 @@ export const createWebSocket = (
   websocket.clientConfig = identifyingMetadata.clientConfig;
   websocket.role = identifyingMetadata.role;
 
-  if (isOAuthClientInitialized() && clientOpts.config.UNIVERSAL_BROKER_GA) {
+  if (shouldAuthenticate) {
     // The access token is not sent when making requests over the websocket, so we must re-validate
     // the token periodically to keep the connection alive. Connections that do not re-validate the
     // access token will be marked as stale and closed by the server.
@@ -229,17 +264,19 @@ export const createWebSocket = (
       };
 
       try {
-        const renewOnce = async () =>
-          renewBrokerServerConnection(
+        const renewOnce = async () => {
+          lastAuthHeader = await getAccessToken();
+          return renewBrokerServerConnection(
             {
               connectionIdentifier: identifyingMetadata.identifier!,
               brokerClientId: identifyingMetadata.clientId,
-              authorization: await getAccessToken(),
+              authorization: lastAuthHeader,
               role: identifyingMetadata.role,
               serverId: serverId,
             },
             clientOpts.config,
           );
+        };
 
         logger.debug(commonLogFields, 'Renewing auth.');
         let renewResponse = await renewOnce();
@@ -261,9 +298,8 @@ export const createWebSocket = (
 
         consecutiveAuthFailures = 0;
         logger.debug(commonLogFields, 'Auth renewed.');
-        // Re-read extraHeaders after renewal: the 401-retry path may have
-        // invalidated and refreshed the cached token, and the next reconnect
-        // needs to pick that up via the synchronous cache read.
+        // Rebuild extraHeaders so the next reconnect uses the token just
+        // refreshed into lastAuthHeader (including via the 401-retry path).
         websocket.transport.extraHeaders = buildExtraHeaders(currentRequestId);
       } catch (err) {
         const statusCode = err instanceof AuthRenewalError ? err.statusCode : 0;
@@ -376,9 +412,18 @@ export const createWebSocket = (
   );
   websocket.on('notification', notificationHandler);
   websocket.on('error', errorHandler);
-  if (isOAuthClientInitialized() && clientOpts.config.UNIVERSAL_BROKER_GA) {
-    // Drop the cached token on connection errors so the next reconnect fetches a fresh one.
-    websocket.on('error', () => invalidateToken());
+  if (shouldAuthenticate) {
+    // Refresh the sticky auth header on a connection error so the next backoff
+    // reconnect carries a fresh token; the current header is retained meanwhile.
+    websocket.on('error', () => {
+      void getAccessToken()
+        .then((header) => {
+          lastAuthHeader = header;
+        })
+        .catch(() => {
+          /* failure already logged/recorded in the oauth layer */
+        });
+    });
   }
 
   websocket.on('open', () =>

--- a/test/unit/client/auth/oauth.test.ts
+++ b/test/unit/client/auth/oauth.test.ts
@@ -5,7 +5,6 @@ jest.mock('../../../../lib/hybrid-sdk/client/events', () => ({
 
 import {
   getAccessToken,
-  getCachedAccessToken,
   initOAuthClient,
   invalidateToken,
   isOAuthClientInitialized,
@@ -88,30 +87,6 @@ describe('client/auth/oauth (simple-oauth2)', () => {
 
     expect(header).toBe('Bearer first');
     expect(scope.isDone()).toBe(true);
-  });
-
-  it('returns the cached token synchronously via getCachedAccessToken', async () => {
-    initOAuthClient({
-      apiHostname: API_HOST,
-      clientId: 'cid',
-      clientSecret: 'csecret',
-    });
-
-    nock(API_HOST)
-      .post(TOKEN_PATH)
-      .reply(200, tokenResponse({ access_token: 'sync-cached' }));
-
-    await getAccessToken();
-
-    expect(getCachedAccessToken()).toBe('Bearer sync-cached');
-    expect(nock.pendingMocks()).toHaveLength(0);
-  });
-
-  it('returns undefined from getCachedAccessToken when no token is cached', async () => {
-    await jest.isolateModulesAsync(async () => {
-      const mod = await import('../../../../lib/hybrid-sdk/client/auth/oauth');
-      expect(mod.getCachedAccessToken()).toBeUndefined();
-    });
   });
 
   it('returns the cached token on subsequent calls without re-fetching', async () => {
@@ -268,63 +243,6 @@ describe('client/auth/oauth (simple-oauth2)', () => {
       await expect(mod.getAccessToken()).rejects.toThrow(
         /OAuth client not initialized/,
       );
-    });
-  });
-
-  it('getCachedAccessToken returns the still-valid token when within threshold and kicks off a background refresh', async () => {
-    // Threshold larger than the issued lifetime — the freshly-fetched token is
-    // immediately within the threshold but not actually expired (still valid
-    // for ~3600s).
-    initOAuthClient({
-      apiHostname: API_HOST,
-      clientId: 'cid',
-      clientSecret: 'csecret',
-      expiryThresholdSeconds: 7200,
-    });
-
-    nock(API_HOST)
-      .post(TOKEN_PATH)
-      .reply(200, tokenResponse({ access_token: 'first', expires_in: 3600 }));
-
-    await getAccessToken();
-
-    nock(API_HOST)
-      .post(TOKEN_PATH)
-      .reply(200, tokenResponse({ access_token: 'second', expires_in: 3600 }));
-
-    // Still valid (expires in 3600s, > 0s), so returned synchronously.
-    expect(getCachedAccessToken()).toBe('Bearer first');
-
-    // Background refresh was kicked off. getAccessToken returns the in-flight
-    // promise, so awaiting it deterministically waits for the refresh.
-    expect(await getAccessToken()).toBe('Bearer second');
-    expect(nock.pendingMocks()).toHaveLength(0);
-  });
-
-  it('getCachedAccessToken returns undefined when no token is cached and kicks off a background refresh', async () => {
-    initOAuthClient({
-      apiHostname: API_HOST,
-      clientId: 'cid',
-      clientSecret: 'csecret',
-    });
-
-    nock(API_HOST)
-      .post(TOKEN_PATH)
-      .reply(200, tokenResponse({ access_token: 'fresh', expires_in: 3600 }));
-
-    // No prior fetch — cache is empty.
-    expect(getCachedAccessToken()).toBeUndefined();
-
-    // Background refresh was kicked off; await it via getAccessToken which
-    // returns the in-flight promise.
-    expect(await getAccessToken()).toBe('Bearer fresh');
-    expect(nock.pendingMocks()).toHaveLength(0);
-  });
-
-  it('getCachedAccessToken returns undefined and does nothing when client not initialized', async () => {
-    await jest.isolateModulesAsync(async () => {
-      const mod = await import('../../../../lib/hybrid-sdk/client/auth/oauth');
-      expect(mod.getCachedAccessToken()).toBeUndefined();
     });
   });
 

--- a/test/unit/client/socket.test.ts
+++ b/test/unit/client/socket.test.ts
@@ -1,6 +1,5 @@
 jest.mock('../../../lib/hybrid-sdk/client/auth/oauth', () => ({
   getAccessToken: jest.fn().mockResolvedValue('Bearer test-token'),
-  getCachedAccessToken: jest.fn().mockReturnValue('Bearer test-token'),
   invalidateToken: jest.fn(),
   initOAuthClient: jest.fn(),
   isOAuthClientInitialized: jest.fn().mockReturnValue(true),
@@ -11,7 +10,10 @@ jest.mock('../../../lib/hybrid-sdk/client/events', () => ({
   emitShutdown: jest.fn(),
 }));
 
-import { createWebSocket } from '../../../lib/hybrid-sdk/client/socket';
+import {
+  createWebSocket,
+  createWebSocketConnectionPairs,
+} from '../../../lib/hybrid-sdk/client/socket';
 import {
   LoadedClientOpts,
   CONFIGURATION,
@@ -25,10 +27,10 @@ import { emitError, emitShutdown } from '../../../lib/hybrid-sdk/client/events';
 import { PROCESS_EXIT_REASONS } from '../../../lib/hybrid-sdk/common/types/telemetry';
 
 jest.mock('primus', () => {
-  const mockSocket = jest.fn().mockImplementation(() => {
+  const mockSocket = jest.fn().mockImplementation((_url, settings) => {
     return {
       transport: {
-        extraHeaders: {},
+        extraHeaders: settings?.transport?.extraHeaders ?? {},
       },
       on: jest.fn(),
       emit: jest.fn(),
@@ -106,6 +108,10 @@ jest.mock('../../../lib/hybrid-sdk/client/auth/brokerServerConnection', () => ({
   renewBrokerServerConnection: jest.fn(),
 }));
 
+jest.mock('../../../lib/hybrid-sdk/client/utils/filterSelection', () => ({
+  determineFilterType: jest.fn(() => 'github'),
+}));
+
 jest.useFakeTimers();
 
 describe('createWebSocket - renew auth behaviour', () => {
@@ -124,6 +130,7 @@ describe('createWebSocket - renew auth behaviour', () => {
       brokerServerUrl: 'http://localhost:8000',
       brokerToken: 'test-broker-token',
       API_BASE_URL: 'http://api.example.com',
+      universalBrokerEnabled: true,
       UNIVERSAL_BROKER_GA: 'true',
     };
     return {
@@ -176,8 +183,11 @@ describe('createWebSocket - renew auth behaviour', () => {
       body: '{}',
     });
 
-    mockInvalidateToken =
-      require('../../../lib/hybrid-sdk/client/auth/oauth').invalidateToken;
+    const oauth = require('../../../lib/hybrid-sdk/client/auth/oauth');
+    mockInvalidateToken = oauth.invalidateToken;
+    // clearAllMocks resets call data but not implementations; restore defaults.
+    oauth.getAccessToken.mockResolvedValue('Bearer test-token');
+    oauth.isOAuthClientInitialized.mockReturnValue(true);
 
     mockProcessExit = jest.spyOn(process, 'exit').mockImplementation(() => {
       return undefined as never;
@@ -517,7 +527,9 @@ describe('createWebSocket - renew auth behaviour', () => {
   });
 
   describe('error handling', () => {
-    it('invalidates the cached token on a websocket error when OAuth is in use', async () => {
+    it('does NOT invalidate the cached token on a transient websocket error', async () => {
+      // A transient websocket error does not imply a bad token; invalidating would
+      // force an unnecessary refetch. The sticky header keeps the connection auth'd.
       const clientOpts = createMockClientOpts();
       const identifyingMetadata = createMockIdentifyingMetadata();
       const ws = createWebSocket(clientOpts, identifyingMetadata, Role.primary);
@@ -531,23 +543,123 @@ describe('createWebSocket - renew auth behaviour', () => {
         handler({ type: 'TransportError', description: 'boom' }),
       );
 
-      expect(mockInvalidateToken).toHaveBeenCalled();
+      expect(mockInvalidateToken).not.toHaveBeenCalled();
+
+      clearTimeout(ws.timeoutHandlerId);
+    });
+
+    it('refreshes the sticky auth header on a websocket error', async () => {
+      const {
+        getAccessToken,
+      } = require('../../../lib/hybrid-sdk/client/auth/oauth');
+      (getAccessToken as jest.Mock).mockResolvedValue('Bearer refreshed');
+
+      const clientOpts = createMockClientOpts();
+      const identifyingMetadata = createMockIdentifyingMetadata();
+      const ws = createWebSocket(
+        clientOpts,
+        identifyingMetadata,
+        Role.primary,
+        undefined,
+        'Bearer seeded',
+      );
+
+      const errorHandlers = (ws.on as jest.Mock).mock.calls
+        .filter(([event]) => event === 'error')
+        .map(([, handler]) => handler);
+      errorHandlers.forEach((handler) =>
+        handler({ type: 'TransportError', description: 'boom' }),
+      );
+
+      // Let the async getAccessToken().then update the sticky header.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const reconnectHandler = (ws.on as jest.Mock).mock.calls.find(
+        ([event]) => event === 'reconnect scheduled',
+      )?.[1];
+      reconnectHandler({ attempt: 1, retries: 3, scheduled: 5000 });
+
+      expect(getAccessToken).toHaveBeenCalled();
+      expect(ws.transport.extraHeaders?.Authorization).toBe('Bearer refreshed');
 
       clearTimeout(ws.timeoutHandlerId);
     });
   });
 
-  describe('reconnect scheduled', () => {
-    it('updates extraHeaders synchronously without awaiting getAccessToken', async () => {
+  describe('authentication misconfiguration', () => {
+    it('throws when GA is enabled but the OAuth client is not initialized', () => {
       const {
-        getAccessToken,
-        getCachedAccessToken,
+        isOAuthClientInitialized,
       } = require('../../../lib/hybrid-sdk/client/auth/oauth');
-      (getCachedAccessToken as jest.Mock).mockReturnValue('Bearer cached');
+      (isOAuthClientInitialized as jest.Mock).mockReturnValueOnce(false);
+      const mockLoggerFatal2 = jest.spyOn(logger, 'fatal').mockImplementation();
 
       const clientOpts = createMockClientOpts();
       const identifyingMetadata = createMockIdentifyingMetadata();
+
+      expect(() =>
+        createWebSocket(clientOpts, identifyingMetadata, Role.primary),
+      ).toThrow(/OAuth client is not initialized/);
+      expect(mockLoggerFatal2).toHaveBeenCalled();
+    });
+
+    it('does not require OAuth in SKIP_REMOTE_CONFIG (local-config) mode even if GA is set', () => {
+      const {
+        isOAuthClientInitialized,
+      } = require('../../../lib/hybrid-sdk/client/auth/oauth');
+      (isOAuthClientInitialized as jest.Mock).mockReturnValue(false);
+
+      const baseOpts = createMockClientOpts();
+      const clientOpts = createMockClientOpts({
+        config: { ...baseOpts.config, SKIP_REMOTE_CONFIG: 'true' },
+      });
+      const identifyingMetadata = createMockIdentifyingMetadata();
+
       const ws = createWebSocket(clientOpts, identifyingMetadata, Role.primary);
+      expect(ws).toBeDefined();
+      // No auth header is set and no renewal timer is scheduled.
+      expect(ws.transport.extraHeaders?.Authorization).toBeUndefined();
+      expect(ws.timeoutHandlerId).toBeUndefined();
+
+      (isOAuthClientInitialized as jest.Mock).mockReturnValue(true);
+    });
+
+    it('does not require OAuth for a non-universal (legacy) client even if GA is set', () => {
+      const {
+        isOAuthClientInitialized,
+      } = require('../../../lib/hybrid-sdk/client/auth/oauth');
+      (isOAuthClientInitialized as jest.Mock).mockReturnValue(false);
+
+      const baseOpts = createMockClientOpts();
+      const clientOpts = createMockClientOpts({
+        config: { ...baseOpts.config, universalBrokerEnabled: false },
+      });
+      const identifyingMetadata = createMockIdentifyingMetadata();
+
+      const ws = createWebSocket(clientOpts, identifyingMetadata, Role.primary);
+      expect(ws).toBeDefined();
+
+      (isOAuthClientInitialized as jest.Mock).mockReturnValue(true);
+      clearTimeout(ws.timeoutHandlerId);
+    });
+  });
+
+  describe('reconnect scheduled', () => {
+    it('rebuilds extraHeaders synchronously from the sticky header without awaiting getAccessToken', async () => {
+      const {
+        getAccessToken,
+      } = require('../../../lib/hybrid-sdk/client/auth/oauth');
+
+      const clientOpts = createMockClientOpts();
+      const identifyingMetadata = createMockIdentifyingMetadata();
+      const ws = createWebSocket(
+        clientOpts,
+        identifyingMetadata,
+        Role.primary,
+        undefined,
+        'Bearer seeded',
+      );
 
       const reconnectHandler = (ws.on as jest.Mock).mock.calls.find(
         ([event]) => event === 'reconnect scheduled',
@@ -562,9 +674,34 @@ describe('createWebSocket - renew auth behaviour', () => {
 
       expect(getAccessToken).not.toHaveBeenCalled();
       expect(ws.transport.extraHeaders).toMatchObject({
-        Authorization: 'Bearer cached',
+        Authorization: 'Bearer seeded',
         'snyk-request-id': expect.any(String),
       });
+
+      clearTimeout(ws.timeoutHandlerId);
+    });
+
+    it('retains the last-known-good header across a reconnect', async () => {
+      const clientOpts = createMockClientOpts();
+      const identifyingMetadata = createMockIdentifyingMetadata();
+      const ws = createWebSocket(
+        clientOpts,
+        identifyingMetadata,
+        Role.primary,
+        undefined,
+        'Bearer seeded',
+      );
+
+      const reconnectHandler = (ws.on as jest.Mock).mock.calls.find(
+        ([event]) => event === 'reconnect scheduled',
+      )?.[1];
+      expect(reconnectHandler).toBeDefined();
+
+      reconnectHandler({ attempt: 1, retries: 3, scheduled: 5000 });
+
+      expect(ws.transport.extraHeaders?.Authorization).toBe('Bearer seeded');
+
+      clearTimeout(ws.timeoutHandlerId);
     });
   });
 
@@ -584,6 +721,78 @@ describe('createWebSocket - renew auth behaviour', () => {
       // reconnect_exhaustion is reported via the process_exit metric, not a WS
       // event — by this point 'close' has cleared the event socket.
       expect(emitShutdown).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createWebSocketConnectionPairs - auth backstop', () => {
+    const optsWithConnection = (
+      configOverrides?: Partial<CONFIGURATION>,
+    ): LoadedClientOpts => {
+      const base = createMockClientOpts();
+      return createMockClientOpts({
+        config: {
+          ...base.config,
+          connections: {
+            myconn: {
+              identifier: 'conn-identifier',
+              id: 'conn-id',
+              type: 'github',
+              isDisabled: false,
+            },
+          },
+          ...configOverrides,
+        },
+      });
+    };
+
+    it('awaits getAccessToken and seeds the Authorization header when authenticating', async () => {
+      const {
+        getAccessToken,
+      } = require('../../../lib/hybrid-sdk/client/auth/oauth');
+      (getAccessToken as jest.Mock).mockResolvedValue('Bearer seeded');
+
+      const clientOpts = optsWithConnection();
+      const identifyingMetadata = createMockIdentifyingMetadata();
+
+      const [primary, secondary] = await createWebSocketConnectionPairs(
+        clientOpts,
+        identifyingMetadata,
+        'myconn',
+      );
+
+      expect(getAccessToken).toHaveBeenCalled();
+      expect(primary.transport.extraHeaders?.Authorization).toBe(
+        'Bearer seeded',
+      );
+      expect(secondary.transport.extraHeaders?.Authorization).toBe(
+        'Bearer seeded',
+      );
+
+      clearTimeout(primary.timeoutHandlerId);
+      clearTimeout(secondary.timeoutHandlerId);
+    });
+
+    it('does not fetch a token or set a header in SKIP_REMOTE_CONFIG mode', async () => {
+      const {
+        getAccessToken,
+      } = require('../../../lib/hybrid-sdk/client/auth/oauth');
+      (getAccessToken as jest.Mock).mockClear();
+
+      const clientOpts = optsWithConnection({ SKIP_REMOTE_CONFIG: 'true' });
+      const identifyingMetadata = createMockIdentifyingMetadata();
+
+      const [primary, secondary] = await createWebSocketConnectionPairs(
+        clientOpts,
+        identifyingMetadata,
+        'myconn',
+      );
+
+      expect(getAccessToken).not.toHaveBeenCalled();
+      expect(primary.transport.extraHeaders?.Authorization).toBeUndefined();
+      expect(secondary.transport.extraHeaders?.Authorization).toBeUndefined();
+
+      clearTimeout(primary.timeoutHandlerId);
+      clearTimeout(secondary.timeoutHandlerId);
     });
   });
 


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Ensure a GA universal broker client never opens or reconnects a websocket handshake without its Authorization header. Closes a gap where an auth header will not be sent if the client is in the process of refreshing the auth token.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
