### PR TITLE
fix: remediate medium Snyk Code (SAST) findings

### DIFF
--- a/lib/hybrid-sdk/common/http/webserver.ts
+++ b/lib/hybrid-sdk/common/http/webserver.ts
@@ -74,7 +74,8 @@ export const webserver = (config, altPort: number) => {
   }
 
   const server = isHttp
-    ? createHttpServer(app)
+    ? // deepcode ignore HttpToHttps: plain HTTP is used only when no TLS cert/key is configured; the broker terminates TLS at the customer's ingress/network boundary
+      createHttpServer(app)
     : createHttpsServer(
         {
           key: fs.readFileSync(httpsKey),

--- a/lib/hybrid-sdk/server/routesHandlers/authHandlers.ts
+++ b/lib/hybrid-sdk/server/routesHandlers/authHandlers.ts
@@ -69,8 +69,10 @@ export const authRefreshHandler = async (req: Request, res: Response) => {
   } catch (err) {
     currentClient?.socket?.end();
     if (err instanceof BrokerAuthError) {
-      return res.status(401).send(err.message);
+      return res.status(401).json({ message: err.message });
     }
-    return res.status(500).send(`Unable to complete auth refresh: ${err}.`);
+    return res
+      .status(500)
+      .json({ message: 'Unable to complete auth refresh.' });
   }
 };

--- a/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.ts
+++ b/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.ts
@@ -45,11 +45,9 @@ export const handlePostResponse = (req: Request, res: Response) => {
       res.status(401).json({ message: 'Invalid Broker client credentials.' });
       return;
     }
-    const decodedJwt = credentials
-      ? decode(credentials!.replace(/bearer /i, ''), {
-          complete: true,
-        })
-      : null;
+    const bearerToken = credentials.replace(/bearer /i, '');
+    // deepcode ignore JwtDecodeMethod: signature is validated remotely by Snyk's authorization service; decode only extracts the azp claim for a defence-in-depth match against the stream's stored, already-validated brokerAppClientId
+    const decodedJwt = decode(bearerToken, { complete: true });
 
     const brokerAppClientId = decodedJwt ? decodedJwt?.payload['azp'] : '';
     if (

--- a/lib/hybrid-sdk/server/socket.ts
+++ b/lib/hybrid-sdk/server/socket.ts
@@ -66,6 +66,7 @@ const socket = ({ server, loadedServerOpts }): SocketHandler => {
             req.headers,
             connectionIdentifier,
           );
+        // deepcode ignore JwtDecodeMethod: credentials were just validated by validateBrokerClientCredentials (remote Snyk authorization service); decode only extracts the azp claim
         const decodedJwt = decode(credentials, { complete: true });
         const brokerAppClientId = decodedJwt?.payload['azp'] ?? '';
         const nowDate = new Date().toISOString();


### PR DESCRIPTION
## What

Resolves the four medium-severity Snyk Code (SAST) findings in the broker server code.

| Finding | File | Action |
|---|---|---|
| XSS (CWE-79) | `authHandlers.ts` | **Code fix** — return errors via `res.json({ message })` instead of `res.send(<string>)`, so error text is no longer reflected with an HTML content-type. |
| JwtDecodeMethod (CWE-347) | `socket.ts`, `postResponseHandler.ts` | **Suppress w/ justification** — JWT signatures are validated remotely by Snyk's authorization service (`validateBrokerClientCredentials` → `/auth/validate`); `decode()` only extracts the `azp` claim. No local key material exists to `verify()` with. |
| HttpToHttps (CWE-319) | `webserver.ts` | **Suppress w/ justification** — plain HTTP is used only when no TLS cert/key is configured; TLS terminates at the customer boundary. Removing it would break the default deployment. |

Suppressions use the repo's existing `// deepcode ignore <Rule>: <reason>` convention. Also dropped a dead `credentials ? … : null` ternary in `postResponseHandler.ts` (`credentials` is already guaranteed by the guard above).

## Verify

- `snyk code test` → 0 warning/error findings in the main tree
- `npm run build`, `npm run test:unit` (908 pass), `npm run lint` all clean

Split out from the `ws` dependency bump (separate branch `fix/bump-ws-8.21.1`).