### PR TITLE
feat: Audit request headers in broker logs

### DIFF
--- a/lib/logs/logger.ts
+++ b/lib/logs/logger.ts
@@ -191,12 +191,12 @@ function sanitisePlugins(pluginData) {
 
 function sanitiseHeaders(headers) {
   const hdrs = JSON.parse(JSON.stringify(headers));
-  
+
   // Iterate through all headers and sanitize those matching credential patterns
   for (const key in hdrs) {
     if (hdrs.hasOwnProperty(key)) {
       const lowerKey = key.toLowerCase();
-      
+
       // Check if the header name matches known credential patterns
       if (CREDENTIAL_KEY_PATTERN.test(key)) {
         // Only sanitize if the value is truthy (preserve empty/falsy values for debugging)
@@ -209,15 +209,14 @@ function sanitiseHeaders(headers) {
         if (hdrs[key]) {
           hdrs[key] = '${AUTHORIZATION}';
         }
-      }
-      else if (lowerKey === 'x-broker-token') {
+      } else if (lowerKey === 'x-broker-token') {
         if (hdrs[key]) {
           hdrs[key] = '${BROKER_TOKEN}';
         }
       }
     }
   }
-  
+
   return sanitiseObject(hdrs);
 }
 

--- a/lib/logs/logger.ts
+++ b/lib/logs/logger.ts
@@ -10,6 +10,7 @@ import {
   COMMON_CREDENTIAL_ENV_VARS,
   PER_CONNECTION_CREDENTIAL_ENV_VARS,
   PER_PLUGIN_CREDENTIAL_ENV_VARS,
+  CREDENTIAL_KEY_PATTERN,
 } from './redact';
 
 // Pre-compute the per-connection list once at module load, not per sanitise()
@@ -190,15 +191,33 @@ function sanitisePlugins(pluginData) {
 
 function sanitiseHeaders(headers) {
   const hdrs = JSON.parse(JSON.stringify(headers));
-  if (hdrs.authorization) {
-    hdrs.authorization = '${AUTHORIZATION}';
+  
+  // Iterate through all headers and sanitize those matching credential patterns
+  for (const key in hdrs) {
+    if (hdrs.hasOwnProperty(key)) {
+      const lowerKey = key.toLowerCase();
+      
+      // Check if the header name matches known credential patterns
+      if (CREDENTIAL_KEY_PATTERN.test(key)) {
+        // Only sanitize if the value is truthy (preserve empty/falsy values for debugging)
+        if (hdrs[key]) {
+          hdrs[key] = '${' + key.toUpperCase().replace(/-/g, '_') + '}';
+        }
+      }
+      // Explicit handling for common authentication headers (case-insensitive)
+      else if (lowerKey === 'authorization') {
+        if (hdrs[key]) {
+          hdrs[key] = '${AUTHORIZATION}';
+        }
+      }
+      else if (lowerKey === 'x-broker-token') {
+        if (hdrs[key]) {
+          hdrs[key] = '${BROKER_TOKEN}';
+        }
+      }
+    }
   }
-  if (hdrs['X-Broker-Token']) {
-    hdrs['X-Broker-Token'] = '${BROKER_TOKEN}';
-  }
-  if (hdrs['x-broker-token']) {
-    hdrs['x-broker-token'] = '${BROKER_TOKEN}';
-  }
+  
   return sanitiseObject(hdrs);
 }
 

--- a/test/unit/log.test.ts
+++ b/test/unit/log.test.ts
@@ -154,7 +154,7 @@ describe('log', () => {
 
     // Test headers with various sensitive patterns
     const sensitiveHeaders = {
-      'authorization': 'Bearer secret-token-12345',
+      authorization: 'Bearer secret-token-12345',
       'x-broker-token': 'broker-secret-98765',
       'X-Api-Token': 'api-token-secret',
       'private-token': 'gitlab-private-token',
@@ -201,7 +201,7 @@ describe('log', () => {
 
     // Test headers with empty/falsy values
     const headersWithFalsyValues = {
-      'authorization': '',
+      authorization: '',
       'x-api-token': null,
       'private-token': undefined,
       'content-type': 'application/json',

--- a/test/unit/log.test.ts
+++ b/test/unit/log.test.ts
@@ -141,4 +141,78 @@ describe('log', () => {
     expect(logged).toMatch(sanitizedGitPassword);
     expect(logged).toMatch(sanitizedGitClientUrl);
   });
+
+  it('sanitizes request headers with sensitive information', () => {
+    // setup logger output capturing
+    const logs: string[] = [];
+    const testStream = new Writable();
+    testStream._write = function (chunk, encoding, done) {
+      logs.push(chunk.toString());
+      done();
+    };
+    log.addStream({ stream: testStream });
+
+    // Test headers with various sensitive patterns
+    const sensitiveHeaders = {
+      'authorization': 'Bearer secret-token-12345',
+      'x-broker-token': 'broker-secret-98765',
+      'X-Api-Token': 'api-token-secret',
+      'private-token': 'gitlab-private-token',
+      'x-auth-password': 'super-secret-password',
+      'x-api-secret': 'api-secret-value',
+      'github-token': 'ghp_secrettoken123',
+      'content-type': 'application/json',
+      'user-agent': 'test-agent',
+      'x-request-id': 'request-123',
+    };
+
+    log.info({ requestHeaders: sensitiveHeaders });
+
+    const logged = logs[logs.length - 1];
+
+    // Assert sensitive header values are not logged
+    expect(logged).not.toMatch('secret-token-12345');
+    expect(logged).not.toMatch('broker-secret-98765');
+    expect(logged).not.toMatch('api-token-secret');
+    expect(logged).not.toMatch('gitlab-private-token');
+    expect(logged).not.toMatch('super-secret-password');
+    expect(logged).not.toMatch('api-secret-value');
+    expect(logged).not.toMatch('ghp_secrettoken123');
+
+    // Assert non-sensitive header values are still logged
+    expect(logged).toMatch('application/json');
+    expect(logged).toMatch('test-agent');
+    expect(logged).toMatch('request-123');
+
+    // Assert sensitive headers are masked with placeholder
+    expect(logged).toMatch('AUTHORIZATION');
+    expect(logged).toMatch('BROKER_TOKEN');
+  });
+
+  it('sanitizes headers while preserving empty/falsy values', () => {
+    // setup logger output capturing
+    const logs: string[] = [];
+    const testStream = new Writable();
+    testStream._write = function (chunk, encoding, done) {
+      logs.push(chunk.toString());
+      done();
+    };
+    log.addStream({ stream: testStream });
+
+    // Test headers with empty/falsy values
+    const headersWithFalsyValues = {
+      'authorization': '',
+      'x-api-token': null,
+      'private-token': undefined,
+      'content-type': 'application/json',
+    };
+
+    log.info({ requestHeaders: headersWithFalsyValues });
+
+    const logged = logs[logs.length - 1];
+
+    // Falsy values should be preserved (not replaced with placeholder)
+    // This helps support distinguish "not set" from "redacted"
+    expect(logged).toMatch('application/json');
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- [ ] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR enhances the header sanitization in broker logs to properly audit and redact sensitive information from request headers. Previously, only `authorization` and `x-broker-token` headers were sanitized. Now, any header matching credential patterns (TOKEN, PASSWORD, SECRET, AUTHORIZATION, etc.) is automatically sanitized.

#### Where should the reviewer start?

1. Review the changes to `lib/logs/logger.ts` - specifically the enhanced `sanitiseHeaders` function
2. Review the new tests in `test/unit/log.test.ts` that verify the sanitization behavior
3. Note that the change is backward compatible and all existing tests pass

#### How should this be manually tested?

1. Run the broker with logging enabled
2. Send requests with various headers containing sensitive information (e.g., `private-token`, `x-api-secret`, `github-token`)
3. Verify that these headers are sanitized in the logs while non-sensitive headers (e.g., `content-type`, `user-agent`) remain visible
4. Verify that empty/falsy values are preserved (helps distinguish "not set" from "redacted")

#### Any background context you want to provide?

This addresses ACC-3318 which requested auditing of the `req.headers` log line. The previous implementation only sanitized a few explicit headers, which could lead to sensitive information being logged in production. The new implementation uses the existing `CREDENTIAL_KEY_PATTERN` from the redaction module to comprehensively detect and sanitize any header that could contain credentials.

**Before:**
- Only `authorization`, `X-Broker-Token`, and `x-broker-token` were sanitized

**After:**
- Any header matching patterns like TOKEN, PASSWORD, SECRET, AUTHORIZATION, PASSPHRASE, PEM, CREDENTIALS, PRIVATE_KEY is sanitized
- Examples: `private-token`, `x-api-secret`, `github-token`, `x-auth-password`, etc.
- Falsy values preserved for debugging

#### Screenshots

N/A - this is a logging enhancement

#### Additional questions

None. All existing tests pass plus two new tests specifically for header sanitization.

**Fixes:** ACC-3318
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61aefd4c-22f7-4a4e-960a-36995efbf547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61aefd4c-22f7-4a4e-960a-36995efbf547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

