### PR TITLE
fix: correct universal broker nexus/nexus2 systemcheck validation url

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -458,12 +458,7 @@
     "nexus": {
       "validations": [
         {
-          "url": "https://$BASE_NEXUS_URL/service/rest/v1/status/check/api/system/ping",
-          "auth": {
-            "type": "basic",
-            "username": "$NEXUS_USERNAME",
-            "password": "$NEXUS_PASSWORD"
-          }
+          "url": "$BASE_NEXUS_URL/service/rest/v1/status/check"
         }
       ],
       "default": {
@@ -478,12 +473,7 @@
     "nexus2": {
       "validations": [
         {
-          "url": "https://$BASE_NEXUS2_URL/nexus/service/local/status",
-          "auth": {
-            "type": "basic",
-            "username": "$NEXUS2_USERNAME",
-            "password": "$NEXUS2_PASSWORD"
-          }
+          "url": "$BASE_NEXUS2_URL/nexus/service/local/status"
         }
       ],
       "default": {

--- a/config.default.jsontest
+++ b/config.default.jsontest
@@ -431,12 +431,7 @@
     "nexus": {
       "validations": [
         {
-          "url": "https://$BASE_NEXUS_URL/service/rest/v1/status/check/api/system/ping",
-          "auth": {
-            "type": "basic",
-            "username": "$NEXUS_USERNAME",
-            "password": "$NEXUS_PASSWORD"
-          }
+          "url": "$BASE_NEXUS_URL/service/rest/v1/status/check"
         }
       ],
       "default": {
@@ -451,12 +446,7 @@
     "nexus2": {
       "validations": [
         {
-          "url": "https://$BASE_NEXUS2_URL/nexus/service/local/status",
-          "auth": {
-            "type": "basic",
-            "username": "$NEXUS2_USERNAME",
-            "password": "$NEXUS2_PASSWORD"
-          }
+          "url": "$BASE_NEXUS2_URL/nexus/service/local/status"
         }
       ],
       "default": {

--- a/test/functional/systemcheck-universal.test.ts
+++ b/test/functional/systemcheck-universal.test.ts
@@ -117,8 +117,8 @@ describe('broker client systemcheck endpoint', () => {
     process.env.CLIENT_ID = 'clienid';
     process.env.CLIENT_SECRET = 'clientsecret';
     process.env.MY_ARTIFACTORY_URL = 'user:name@artifactory.local/artifactory';
-    process.env.MY_BASE_NEXUS_URL = 'user:name@nexus.local';
-    process.env.MY_BASE_NEXUS2_URL = 'user:name@nexus2.local';
+    process.env.MY_BASE_NEXUS_URL = 'https://user:name@nexus.local';
+    process.env.MY_BASE_NEXUS2_URL = 'https://user:name@nexus2.local';
 
     process.env.SNYK_BROKER_CLIENT_CONFIGURATION__common__default__BROKER_SERVER_URL = `http://localhost:${bs.port}`;
     process.env.SNYK_FILTER_RULES_PATHS__artifactory = clientAccept;
@@ -133,7 +133,7 @@ describe('broker client systemcheck endpoint', () => {
       });
     nock('https://nexus.local')
       .persist()
-      .get('/service/rest/v1/status/check/api/system/ping')
+      .get('/service/rest/v1/status/check')
       .reply(() => {
         return [500, 'nexus - failed healthcheck'];
       });
@@ -174,7 +174,7 @@ describe('broker client systemcheck endpoint', () => {
           {
             data: 'nexus - failed healthcheck',
             statusCode: 500,
-            url: 'https://${BASE_NEXUS_URL}/service/rest/v1/status/check/api/system/ping',
+            url: '${BASE_NEXUS_URL}/service/rest/v1/status/check',
           },
         ],
         validated: false,
@@ -187,7 +187,7 @@ describe('broker client systemcheck endpoint', () => {
           {
             data: 'nexus2 - failed healthcheck',
             statusCode: 500,
-            url: 'https://${BASE_NEXUS2_URL}/nexus/service/local/status',
+            url: '${BASE_NEXUS2_URL}/nexus/service/local/status',
           },
         ],
         validated: false,


### PR DESCRIPTION
Universal `/systemcheck` for nexus/nexus2 could never pass: the validation url hardcoded `https://` in front of the already-schemed `$BASE_NEXUS_URL` (-> `https://https://…` -> ENOTFOUND hostname:"https"), the nexus url appended a bogus `/api/system/ping` (-> 404), and the `auth` block used undefined `$NEXUS_USERNAME`/`$NEXUS_PASSWORD` vars (-> 401).

Drop the hardcoded scheme, the phantom path, and the auth block for both nexus and nexus2 so validation uses the creds embedded in `BASE_NEXUS_URL`.

ref: 
- Nexus endpoint: https://help.sonatype.com/en/status-api.html
