### PR TITLE
fix: prevent downstream socket error listener leak

### DIFF
--- a/lib/hybrid-sdk/http/downstream-post-stream-to-server.ts
+++ b/lib/hybrid-sdk/http/downstream-post-stream-to-server.ts
@@ -506,17 +506,6 @@ class BrokerServerPostResponseHandler {
     try {
       this.#streamingId = streamingID;
       let prevPartialChunk;
-      response.socket.on('error', (err) => {
-        this.#logger.error(
-          {
-            error: err.message,
-            errDetails: err,
-            stackTrace: new Error('stacktrace generator').stack,
-            streamingID: this.#streamingId,
-          },
-          'Socket Response error in Streaming from downstream',
-        );
-      });
       const downstreamSocket = response.socket;
       this.#logger.debug(
         {

--- a/test/unit/lib/hybrid-sdk/http/downstream-post-stream-to-server.test.ts
+++ b/test/unit/lib/hybrid-sdk/http/downstream-post-stream-to-server.test.ts
@@ -330,6 +330,136 @@ describe('BrokerServerPostResponseHandler', () => {
     });
   });
 
+  describe('downstream socket listener lifecycle', () => {
+    beforeEach(() => {
+      setConfig({
+        brokerServerUrl,
+        universalBrokerEnabled: false,
+        universalBrokerGa: false,
+      });
+    });
+
+    it('returns a reused socket error listener count to baseline after each streamed response', async () => {
+      const responseCount = 100;
+      nock(brokerServerUrl)
+        .post(`/response-data/${brokerToken}/${streamingId}`)
+        .query(true)
+        .times(responseCount)
+        .reply(200, 'OK');
+
+      const sharedSocket = new Socket();
+      const initialErrorListenerCount = sharedSocket.listenerCount('error');
+
+      for (
+        let responseIndex = 0;
+        responseIndex < responseCount;
+        responseIndex++
+      ) {
+        const handler = createHandler();
+        const mockResponse = new http.IncomingMessage(sharedSocket);
+        mockResponse.statusCode = 200;
+        mockResponse.headers = { 'content-type': 'application/json' };
+
+        const forwardPromise = handler.forwardRequest(
+          mockResponse,
+          streamingId,
+        );
+        process.nextTick(() => mockResponse.push(null));
+        await forwardPromise;
+
+        expect(sharedSocket.listenerCount('error')).toBe(
+          initialErrorListenerCount,
+        );
+      }
+
+      sharedSocket.destroy();
+    });
+
+    it('returns the socket listener count to baseline when the pipeline fails', async () => {
+      nock(brokerServerUrl)
+        .post(`/response-data/${brokerToken}/${streamingId}`)
+        .query(true)
+        .reply(200, 'OK');
+
+      const sharedSocket = new Socket();
+      const initialErrorListenerCount = sharedSocket.listenerCount('error');
+      const handler = createHandler();
+      const mockResponse = new http.IncomingMessage(sharedSocket);
+      mockResponse.statusCode = 200;
+      mockResponse.headers = { 'content-type': 'application/json' };
+
+      const forwardPromise = handler.forwardRequest(mockResponse, streamingId);
+      setTimeout(() => {
+        const socketError = Object.assign(new Error('read ECONNRESET'), {
+          code: 'ECONNRESET',
+        });
+        mockResponse.destroy(socketError);
+      }, 50);
+      await forwardPromise;
+
+      expect(sharedSocket.listenerCount('error')).toBe(
+        initialErrorListenerCount,
+      );
+      expect(
+        testLogger.errorCalls.filter(
+          (call) =>
+            call.message ===
+            'received error from downstream request while streaming data to Broker Server',
+        ),
+      ).toHaveLength(1);
+
+      sharedSocket.destroy();
+    });
+
+    it('logs an actual downstream socket failure exactly once', async () => {
+      nock(brokerServerUrl)
+        .post(`/response-data/${brokerToken}/${streamingId}`)
+        .query(true)
+        .reply(200, 'OK');
+
+      const downstreamServer = http.createServer((_req, res) => {
+        res.writeHead(200, { 'content-type': 'text/plain' });
+        res.write('partial response');
+        setTimeout(() => res.socket?.destroy(), 100);
+      });
+      await new Promise<void>((resolve, reject) => {
+        downstreamServer.once('error', reject);
+        downstreamServer.listen(0, '127.0.0.1', () => {
+          downstreamServer.off('error', reject);
+          resolve();
+        });
+      });
+
+      try {
+        const downstreamAddress = downstreamServer.address() as AddressInfo;
+        const response = await new Promise<http.IncomingMessage>(
+          (resolve, reject) => {
+            http
+              .get(`http://127.0.0.1:${downstreamAddress.port}`, resolve)
+              .once('error', reject);
+          },
+        );
+
+        const handler = createHandler();
+        await handler.forwardRequest(response, streamingId);
+
+        expect(
+          testLogger.errorCalls.filter(
+            (call) =>
+              call.message ===
+              'received error from downstream request while streaming data to Broker Server',
+          ),
+        ).toHaveLength(1);
+      } finally {
+        if (downstreamServer.listening) {
+          await new Promise<void>((resolve) =>
+            downstreamServer.close(() => resolve()),
+          );
+        }
+      }
+    });
+  });
+
   describe('duration tracking on successful requests', () => {
     beforeEach(() => {
       setConfig({


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/main/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR prevents downstream socket error listener leak.

  - Remove the per-response `error` listener attached directly to the downstream socket.
  - Continue handling downstream failures through the response stream’s existing error handler.
  - Add regression coverage confirming that socket listener counts return to baseline:
    - after successful streamed responses on a reused socket;
    - when the streaming pipeline fails.
  - Add behavior-preservation coverage confirming that a real downstream socket failure is logged exactly once.

## Why

A downstream socket may be reused across multiple HTTP responses. `forwardRequest()` added a new socket-level error listener for every response but never removed it.

Over time, these listeners accumulated on the pooled socket, retained request-specific state, and produced `MaxListenersExceededWarning` messages.

The removed listener was redundant: downstream socket failures propagate through the `IncomingMessage`, whose existing error handler logs and handles the streaming failure.