### PR TITLE
fix: block symlinks in GitHub tree requests [ACC-3174]

### DIFF
--- a/lib/broker-workload/websocketRequests.ts
+++ b/lib/broker-workload/websocketRequests.ts
@@ -175,6 +175,12 @@ export class BrokerWorkload extends Workload<WorkloadType.remoteServer> {
         this.connectionIdentifier,
         this.websocketConnectionHandler?.socketType,
       );
+      if (preparedRequest.error) {
+        return responseHandler.sendResponse({
+          status: preparedRequest.error.status,
+          body: preparedRequest.error.errorMsg,
+        });
+      }
       if (this.options.config.universalBrokerEnabled) {
         preparedRequest.req = await runPreRequestPlugins(
           this.options,

--- a/lib/hybrid-sdk/client/scm/github/tree.ts
+++ b/lib/hybrid-sdk/client/scm/github/tree.ts
@@ -32,9 +32,12 @@ export function convertBodyToGitHubTreePayload(
 export function validateForSymlinksInCreateTree(
   createTree: GitHubCreateTreePayload,
 ): void {
-  const treesWithSymlink = createTree.tree.filter(
-    (tree) => tree.mode === '120000' && tree.type === 'commit',
-  );
+  const treesWithSymlink = createTree.tree.filter((tree) => {
+    // GitHub uses sha: null without content to delete an existing entry.
+    // Removing a symlink is safe; any entry that could create one is not.
+    const isDeletion = tree.sha === null && tree.content === undefined;
+    return tree.mode === '120000' && !isDeletion;
+  });
 
   if (treesWithSymlink.length > 0) {
     const paths = treesWithSymlink.map((tree) => tree.path).join(', ');

--- a/lib/hybrid-sdk/client/scm/github/types.ts
+++ b/lib/hybrid-sdk/client/scm/github/types.ts
@@ -21,7 +21,8 @@ export type GitHubCreateTreePayload = {
 };
 
 export type GitHubTree = {
-  content: string;
+  content?: string;
+  sha?: string | null;
   mode: '040000' | '100644' | '100755' | '120000' | '160000';
   path: string;
   type: 'blob' | 'commit' | 'tree';

--- a/test/unit/client/scm/github/tree.test.ts
+++ b/test/unit/client/scm/github/tree.test.ts
@@ -56,13 +56,13 @@ describe('client/scm/github/tree.ts', () => {
     {
       "path": "package.json",
       "content":"bla-bla-bla",
-      "type":"commit",
+      "type":"blob",
       "mode":"100644"
     },
     {
       "path":"package-lock.json",
       "content":"bla-bla-bla-lock",
-      "type":"commit",
+      "type":"blob",
       "mode":"100644"
     }
   ]
@@ -77,13 +77,13 @@ describe('client/scm/github/tree.ts', () => {
           {
             path: 'package.json',
             content: 'bla-bla-bla',
-            type: 'commit',
+            type: 'blob',
             mode: '100644',
           },
           {
             path: 'package-lock.json',
             content: 'bla-bla-bla-lock',
-            type: 'commit',
+            type: 'blob',
             mode: '100644',
           },
         ],
@@ -102,19 +102,19 @@ describe('client/scm/github/tree.ts', () => {
           {
             path: 'aaa.txt',
             content: 'content',
-            type: 'commit',
+            type: 'blob',
             mode: '120000',
           },
           {
             path: 'bbb.txt',
             content: 'content',
-            type: 'commit',
+            type: 'blob',
             mode: '100644',
           },
           {
             path: 'ccc.txt',
             content: 'content',
-            type: 'commit',
+            type: 'blob',
             mode: '120000',
           },
         ],
@@ -122,6 +122,9 @@ describe('client/scm/github/tree.ts', () => {
 
       expect(() => validateForSymlinksInCreateTree(createTree)).toThrowError(
         GitHubTreeValidationError,
+      );
+      expect(() => validateForSymlinksInCreateTree(createTree)).toThrowError(
+        'Symlinks are not allowed in GitHub tree payload: aaa.txt, ccc.txt',
       );
     });
 
@@ -134,14 +137,26 @@ describe('client/scm/github/tree.ts', () => {
           {
             path: 'aaa.txt',
             content: 'content',
-            type: 'commit',
+            type: 'blob',
             mode: '100644',
           },
           {
             path: 'bbb.txt',
             content: 'content',
-            type: 'commit',
+            type: 'blob',
             mode: '100755',
+          },
+          {
+            path: 'nested',
+            sha: '1111111111111111111111111111111111111111',
+            type: 'tree',
+            mode: '040000',
+          },
+          {
+            path: 'vendor/dependency',
+            sha: '2222222222222222222222222222222222222222',
+            type: 'commit',
+            mode: '160000',
           },
         ],
       } satisfies GitHubCreateTreePayload;
@@ -149,6 +164,47 @@ describe('client/scm/github/tree.ts', () => {
       expect(() =>
         validateForSymlinksInCreateTree(createTree),
       ).not.toThrowError(GitHubTreeValidationError);
+    });
+
+    it('should allow deleting an existing symlink', () => {
+      const createTree = {
+        owner: 'owner',
+        repo: 'repo',
+        base_tree: '0000000000000000000000000000000000000000',
+        tree: [
+          {
+            path: 'obsolete-link',
+            sha: null,
+            type: 'blob',
+            mode: '120000',
+          },
+        ],
+      } satisfies GitHubCreateTreePayload;
+
+      expect(() =>
+        validateForSymlinksInCreateTree(createTree),
+      ).not.toThrowError(GitHubTreeValidationError);
+    });
+
+    it('should reject a symlink with both null sha and content', () => {
+      const createTree = {
+        owner: 'owner',
+        repo: 'repo',
+        base_tree: '0000000000000000000000000000000000000000',
+        tree: [
+          {
+            path: 'ambiguous-link',
+            sha: null,
+            content: '/etc/passwd',
+            type: 'blob',
+            mode: '120000',
+          },
+        ],
+      } satisfies GitHubCreateTreePayload;
+
+      expect(() => validateForSymlinksInCreateTree(createTree)).toThrowError(
+        'Symlinks are not allowed in GitHub tree payload: ambiguous-link',
+      );
     });
   });
 });

--- a/test/unit/client/scm/scm.test.ts
+++ b/test/unit/client/scm/scm.test.ts
@@ -2,7 +2,9 @@ import { aConfig } from '../../../helpers/test-factories';
 import {
   commitSigningEnabled,
   signGitHubCommit,
+  validateGitHubTreePayload,
 } from '../../../../lib/hybrid-sdk/client/scm';
+import { GitHubTreeValidationError } from '../../../../lib/hybrid-sdk/client/scm/github/errors';
 
 describe('client/scm', () => {
   describe('commitSigningEnabled()', () => {
@@ -117,6 +119,42 @@ describe('client/scm', () => {
       await expect(signGitHubCommit({}, 123456)).rejects.toThrowError(
         'body must be string or Uint8Array',
       );
+    });
+  });
+
+  describe('validateGitHubTreePayload()', () => {
+    it('rejects a symlink represented in the GitHub Trees API format', () => {
+      const body = JSON.stringify({
+        base_tree: '0000000000000000000000000000000000000000',
+        tree: [
+          {
+            path: 'config/malicious_link',
+            mode: '120000',
+            type: 'blob',
+            content: '/etc/passwd',
+          },
+        ],
+      });
+
+      expect(() => validateGitHubTreePayload(body)).toThrowError(
+        GitHubTreeValidationError,
+      );
+    });
+
+    it('accepts a regular blob represented in the GitHub Trees API format', () => {
+      const body = JSON.stringify({
+        base_tree: '0000000000000000000000000000000000000000',
+        tree: [
+          {
+            path: 'config/settings.json',
+            mode: '100644',
+            type: 'blob',
+            content: '{}',
+          },
+        ],
+      });
+
+      expect(() => validateGitHubTreePayload(body)).not.toThrowError();
     });
   });
 });

--- a/test/unit/lib/broker-workload/prepareRequest.test.ts
+++ b/test/unit/lib/broker-workload/prepareRequest.test.ts
@@ -1,12 +1,25 @@
 import { prepareRequest } from '../../../../lib/broker-workload/prepareRequest';
+import {
+  gitHubTreeCheckNeeded,
+  validateGitHubTreePayload,
+} from '../../../../lib/hybrid-sdk/client/scm';
 
 jest.mock('../../../../lib/logs/logger');
 jest.mock('../../../../lib/hybrid-sdk/client/scm', () => ({
-  gitHubCommitSigningEnabled: () => false,
-  gitHubTreeCheckNeeded: () => false,
+  gitHubCommitSigningEnabled: jest.fn(() => false),
+  gitHubTreeCheckNeeded: jest.fn(() => false),
   signGitHubCommit: jest.fn(),
   validateGitHubTreePayload: jest.fn(),
 }));
+
+const mockGitHubTreeCheckNeeded = jest.mocked(gitHubTreeCheckNeeded);
+const mockValidateGitHubTreePayload = jest.mocked(validateGitHubTreePayload);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGitHubTreeCheckNeeded.mockReturnValue(false);
+  mockValidateGitHubTreePayload.mockReset();
+});
 
 describe('prepareRequest — requestId propagation', () => {
   const baseResult = { url: 'https://example.com/path' } as any;
@@ -115,5 +128,100 @@ describe('prepareRequest — downstream x-request-id mirror', () => {
       'client',
     );
     expect(req.headers['x-request-id']).toBeUndefined();
+  });
+});
+
+describe('prepareRequest — GitHub create tree validation', () => {
+  const baseResult = {
+    url: 'https://api.github.com/repos/owner/repo/git/trees',
+  } as any;
+  const baseOptions = {
+    config: { removeXForwardedHeaders: 'false', universalBrokerEnabled: false },
+  } as any;
+  const logContext: any = {};
+  const treeBody = JSON.stringify({
+    base_tree: '0000000000000000000000000000000000000000',
+    tree: [
+      {
+        path: 'config/malicious_link',
+        mode: '120000',
+        type: 'blob',
+        content: '/etc/passwd',
+      },
+    ],
+  });
+
+  it('returns the existing preparation error when tree validation fails', async () => {
+    mockGitHubTreeCheckNeeded.mockReturnValue(true);
+    mockValidateGitHubTreePayload.mockImplementation(() => {
+      throw new Error(
+        'Symlinks are not allowed in GitHub tree payload: config/malicious_link',
+      );
+    });
+    const payload = {
+      method: 'POST',
+      url: '/repos/owner/repo/git/trees',
+      headers: {},
+      body: treeBody,
+    };
+
+    const { error } = await prepareRequest(
+      { ...baseResult },
+      payload,
+      logContext,
+      baseOptions,
+      'tok',
+      'client',
+    );
+
+    expect(error).toEqual({
+      status: 401,
+      errorMsg:
+        'Symlinks are not allowed in GitHub tree payload: config/malicious_link',
+    });
+    expect(mockValidateGitHubTreePayload).toHaveBeenCalledWith(treeBody);
+  });
+
+  it('returns no preparation error when tree validation succeeds', async () => {
+    mockGitHubTreeCheckNeeded.mockReturnValue(true);
+    const payload = {
+      method: 'POST',
+      url: '/repos/owner/repo/git/trees',
+      headers: {},
+      body: treeBody,
+    };
+
+    const { error } = await prepareRequest(
+      { ...baseResult },
+      payload,
+      logContext,
+      baseOptions,
+      'tok',
+      'client',
+    );
+
+    expect(error).toBeNull();
+    expect(mockValidateGitHubTreePayload).toHaveBeenCalledWith(treeBody);
+  });
+
+  it('does not validate tree payloads when the commit-signing check is disabled', async () => {
+    const payload = {
+      method: 'POST',
+      url: '/repos/owner/repo/git/trees',
+      headers: {},
+      body: treeBody,
+    };
+
+    const { error } = await prepareRequest(
+      { ...baseResult },
+      payload,
+      logContext,
+      baseOptions,
+      'tok',
+      'client',
+    );
+
+    expect(error).toBeNull();
+    expect(mockValidateGitHubTreePayload).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/lib/broker-workload/websocketRequests.test.ts
+++ b/test/unit/lib/broker-workload/websocketRequests.test.ts
@@ -9,6 +9,7 @@ import {
   makeStreamingRequestToDownstream,
 } from '../../../../lib/hybrid-sdk/http/request';
 import { emitError } from '../../../../lib/hybrid-sdk/client/events';
+import { prepareRequest } from '../../../../lib/broker-workload/prepareRequest';
 
 const mockSendResponse = jest.fn();
 const mockStreamDataResponse = jest.fn();
@@ -32,6 +33,7 @@ jest.mock('../../../../lib/hybrid-sdk/http/request', () => ({
 jest.mock('../../../../lib/broker-workload/prepareRequest', () => ({
   prepareRequest: jest.fn(async () => ({
     req: { url: 'http://downstream.example', headers: {}, method: 'GET' },
+    error: null,
   })),
 }));
 jest.mock(
@@ -53,6 +55,9 @@ const mockMakeStreamingRequest =
   makeStreamingRequestToDownstream as jest.MockedFunction<
     typeof makeStreamingRequestToDownstream
   >;
+const mockPrepareRequest = prepareRequest as jest.MockedFunction<
+  typeof prepareRequest
+>;
 
 // snyk-request-id is pre-populated in fixtures to reflect production reality:
 // forwardWebSocketRequest guarantees the header is a valid UUID before
@@ -185,6 +190,42 @@ describe('BrokerWorkload', () => {
           }),
         }),
       );
+    });
+
+    it('returns a preparation error without calling the downstream GitHub API', async () => {
+      mockFilterRequest.mockReturnValue(matchedRule);
+      mockPrepareRequest.mockResolvedValueOnce({
+        req: {
+          url: 'https://api.github.com/repos/owner/repo/git/trees',
+          headers: {},
+          method: 'POST',
+        },
+        error: {
+          status: 401,
+          errorMsg:
+            'Symlinks are not allowed in GitHub tree payload: config/malicious_link',
+        },
+      });
+      const workload = new BrokerWorkload(
+        connectionIdentifier,
+        options,
+        websocketConnectionHandler,
+      );
+      const payload = {
+        url: '/repos/owner/repo/git/trees',
+        method: 'POST',
+        headers: { 'snyk-request-id': '99999999-9999-4999-8999-999999999999' },
+        streamingID: '',
+      };
+
+      await workload.handler({ payload, websocketHandler: jest.fn() });
+
+      expect(mockSendResponse).toHaveBeenCalledWith({
+        status: 401,
+        body: 'Symlinks are not allowed in GitHub tree payload: config/malicious_link',
+      });
+      expect(mockMakeRequest).not.toHaveBeenCalled();
+      expect(mockMakeStreamingRequest).not.toHaveBeenCalled();
     });
 
     it('non-streaming ECONNREFUSED returns DOWNSTREAM_UNREACHABLE with 502', async () => {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/main/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR fixes GitHub tree symlink validation to match real API payloads and prevent rejected requests from reaching GitHub. Explicit symlink deletion remains allowed.

Validated with focused tests and a [successful signed-commit E2E](https://github.com/pavel-snyk/nodejs-goof/pull/8/changes/7b274bd82489f754da14e7c3e638c0c2c64b7c92).

