### PR TITLE
chore: allow Jira group picker requests

### DIFF
--- a/client-templates/jira-bearer-auth/accept.json.sample
+++ b/client-templates/jira-bearer-auth/accept.json.sample
@@ -124,6 +124,16 @@
       }
     },
     {
+      "//": "used to find groups for group picker",
+      "method": "GET",
+      "path": "/rest/api/2/groups/picker",
+      "origin": "https://${JIRA_HOSTNAME}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${JIRA_PAT}"
+      }
+    },
+    {
       "//": "used to get available components",
       "method": "GET",
       "path": "/rest/api/2/project/:project/components",

--- a/client-templates/jira/accept.json.sample
+++ b/client-templates/jira/accept.json.sample
@@ -133,6 +133,17 @@
       }
     },
     {
+      "//": "used to find groups for group picker",
+      "method": "GET",
+      "path": "/rest/api/2/groups/picker",
+      "origin": "https://${JIRA_HOSTNAME}",
+      "auth": {
+        "scheme": "basic",
+        "username": "${JIRA_USERNAME}",
+        "password": "${JIRA_PASSWORD}"
+      }
+    },
+    {
       "//": "used to get available components",
       "method": "GET",
       "path": "/rest/api/2/project/:project/components",

--- a/defaultFilters/jira-bearer-auth.json
+++ b/defaultFilters/jira-bearer-auth.json
@@ -124,6 +124,16 @@
         }
       },
       {
+        "//": "used to find groups for group picker",
+        "method": "GET",
+        "path": "/rest/api/2/groups/picker",
+        "origin": "https://${JIRA_HOSTNAME}",
+        "auth": {
+          "scheme": "bearer",
+          "token": "${JIRA_PAT}"
+        }
+      },
+      {
         "//": "used to get available components",
         "method": "GET",
         "path": "/rest/api/2/project/:project/components",

--- a/defaultFilters/jira.json
+++ b/defaultFilters/jira.json
@@ -133,6 +133,17 @@
         }
       },
       {
+        "//": "used to find groups for group picker",
+        "method": "GET",
+        "path": "/rest/api/2/groups/picker",
+        "origin": "https://${JIRA_HOSTNAME}",
+        "auth": {
+          "scheme": "basic",
+          "username": "${JIRA_USERNAME}",
+          "password": "${JIRA_PASSWORD}"
+        }
+      },
+      {
         "//": "used to get available components",
         "method": "GET",
         "path": "/rest/api/2/project/:project/components",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/main/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adds an allow rule for the Jira REST endpoint `GET /rest/api/2/groups/picker` to the default Jira broker filters.
This endpoint is used when Snyk needs to search or list Jira groups, for example, when creating issues that include a group picker custom field. Without this rule, the broker blocks the request and group selection fails.

#### Where should the reviewer start?

Review the four JSON files above. Each adds one new filter entry with the appropriate auth scheme (basic or bearer). No application code changes.

#### How should this be manually tested?
N/A

#### Any background context you want to provide?

The Jira allowlist already includes similar lookup endpoints (e.g. assignable users, components, createmeta).

**Note for existing deployments:** customers with a custom `accept.json` will need to add this rule manually or refresh from the updated default filters.

#### Screenshots
N/A - configuration change only

#### Additional questions
N/A