### PR TITLE
fix: cache compiled regexes in filter and log-redaction hot paths

### DIFF
--- a/lib/hybrid-sdk/common/filter/filtersAsync.ts
+++ b/lib/hybrid-sdk/common/filter/filtersAsync.ts
@@ -95,9 +95,20 @@ export const loadFilters: LOADEDFILTER = (
     method = (method || 'get').toLowerCase();
 
     const bodyFilters = valid ? valid.filter((v) => !!v.path && !v.regex) : [];
-    const bodyRegexFilters = valid
-      ? valid.filter((v) => !!v.path && !!v.regex)
-      : [];
+    const bodyRegexFilters = (
+      valid ? valid.filter((v) => !!v.path && !!v.regex) : []
+    ).map((v) => {
+      let compiledRegex: RegExp | undefined;
+      try {
+        compiledRegex = new RegExp(v.regex!); //paths without regexes got filtered out earlier, hence the !
+      } catch (error) {
+        logger.error(
+          { error, path: v.path, regex: v.regex },
+          'failed to compile regex rule',
+        );
+      }
+      return { ...v, compiledRegex };
+    });
     const queryFilters = valid ? valid.filter((v) => !!v.queryParam) : [];
     const headerFilters = valid ? valid.filter((v) => !!v.header) : [];
 
@@ -174,18 +185,22 @@ export const loadFilters: LOADEDFILTER = (
           parsedBody = parsedBody || tryJSONParse(req.body);
 
           // validate against the body by regex
-          isValid = bodyRegexFilters.some(({ path: filterPath, regex }) => {
-            try {
-              const re = new RegExp(regex!); //paths without regexes got filtered out earlier, hence the !
-              return re.test(undefsafe(parsedBody, filterPath!));
-            } catch (error) {
-              logger.error(
-                { error, path: filterPath, regex },
-                'failed to test regex rule',
-              );
-              return false;
-            }
-          });
+          isValid = bodyRegexFilters.some(
+            ({ path: filterPath, compiledRegex }) => {
+              if (!compiledRegex) {
+                return false;
+              }
+              try {
+                return compiledRegex.test(undefsafe(parsedBody, filterPath!));
+              } catch (error) {
+                logger.error(
+                  { error, path: filterPath },
+                  'failed to test regex rule',
+                );
+                return false;
+              }
+            },
+          );
         }
 
         // no need to check query filters if the request is already valid

--- a/lib/logs/logger.ts
+++ b/lib/logs/logger.ts
@@ -20,18 +20,24 @@ const universalBrokerConnectionsVariables: readonly string[] = [
   ...PER_CONNECTION_CREDENTIAL_ENV_VARS,
 ];
 
+// Global regexes are safe to reuse: replace() resets lastIndex to 0 each call.
+const compiledRedactionRegexes = new Map<string, RegExp>();
+
+const getRedactionRegex = (value: string): RegExp => {
+  let regex = compiledRedactionRegexes.get(value);
+  if (!regex) {
+    regex = new RegExp(escapeRegExp(value), 'igm');
+    compiledRedactionRegexes.set(value, regex);
+  }
+  return regex;
+};
+
 const sanitiseConfigVariable = (raw: string, variable: string) =>
-  raw.replace(
-    new RegExp(escapeRegExp(getConfig()[variable]), 'igm'),
-    '${' + variable + '}',
-  );
+  raw.replace(getRedactionRegex(getConfig()[variable]), '${' + variable + '}');
 
 const sanitiseConfigVariables = (raw: string, variable: string) => {
   for (const pool of getConfig()[variable]) {
-    raw = raw.replace(
-      new RegExp(escapeRegExp(pool), 'igm'),
-      '${' + variable + '}',
-    );
+    raw = raw.replace(getRedactionRegex(pool), '${' + variable + '}');
   }
 
   return raw;
@@ -46,7 +52,7 @@ const sanitiseConnectionConfigVariables = (
   for (const cfgVar of Object.keys(connections[connectionKey])) {
     if (cfgVar == variable) {
       raw = raw.replace(
-        new RegExp(escapeRegExp(connections[connectionKey][cfgVar]), 'igm'),
+        getRedactionRegex(connections[connectionKey][cfgVar]),
         '${' + variable + '}',
       );
     }
@@ -68,11 +74,8 @@ const sanitiseConnectionContextConfigVariables = (
       )) {
         if (cfgVar == variable) {
           raw = raw.replace(
-            new RegExp(
-              escapeRegExp(
-                connections[connectionKey].contexts[contextKey][cfgVar],
-              ),
-              'igm',
+            getRedactionRegex(
+              connections[connectionKey].contexts[contextKey][cfgVar],
             ),
             '${' + variable + '}',
           );
@@ -92,7 +95,7 @@ const sanitisePluginsConfigVariables = (
   for (const cfgVar of Object.keys(pluginConfig)) {
     if (cfgVar == variable) {
       raw = raw.replace(
-        new RegExp(escapeRegExp(pluginConfig[cfgVar]), 'igm'),
+        getRedactionRegex(pluginConfig[cfgVar]),
         '${' + variable + '}',
       );
     }

--- a/test/fixtures/relay.json
+++ b/test/fixtures/relay.json
@@ -115,6 +115,28 @@
     ]
   },
   {
+    "//": "used to test body-regex filtering in isolation",
+    "method": "POST",
+    "path": "/filtered-on-body-regex",
+    "valid": [
+      {
+        "path": "message",
+        "regex": "^allowed-.*"
+      }
+    ]
+  },
+  {
+    "//": "only rule is a malformed regex - should never match, not crash",
+    "method": "POST",
+    "path": "/filtered-on-malformed-body-regex",
+    "valid": [
+      {
+        "path": "message",
+        "regex": "INVALID regex ("
+      }
+    ]
+  },
+  {
     "//": "basic auth route",
     "method": "GET",
     "path": "/basic-auth",

--- a/test/unit/filters-and-interpolates.test.ts
+++ b/test/unit/filters-and-interpolates.test.ts
@@ -1276,6 +1276,41 @@ describe('filters and interpolates', () => {
       expect(filterResponse).toBeFalsy();
     });
 
+    describe('body regex', () => {
+      it('allows requests whose body value matches the regex', () => {
+        const filterResponse = filter({
+          url: '/filtered-on-body-regex',
+          method: 'POST',
+          body: jsonBuffer({ message: 'allowed-value' }),
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        });
+        expect(filterResponse).toBeTruthy();
+      });
+
+      it('blocks requests whose body value does not match the regex', () => {
+        const filterResponse = filter({
+          url: '/filtered-on-body-regex',
+          method: 'POST',
+          body: jsonBuffer({ message: 'blocked-value' }),
+          requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        });
+        expect(filterResponse).toBeFalsy();
+      });
+
+      it('blocks requests where the only regex rule failed to compile, without throwing', () => {
+        const callFilter = () =>
+          filter({
+            url: '/filtered-on-malformed-body-regex',
+            method: 'POST',
+            body: jsonBuffer({ message: 'anything' }),
+            requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+          });
+
+        expect(callFilter).not.toThrow();
+        expect(callFilter()).toBeFalsy();
+      });
+    });
+
     describe('graphql', () => {
       it('find globs - valid query', () => {
         const filterResponse = filter({

--- a/test/unit/log.test.ts
+++ b/test/unit/log.test.ts
@@ -31,7 +31,16 @@ const gpgPassphrase = (process.env.GPG_PASSPHRASE = 'GPG_PASS_DO_NOT_LEAK');
 
 import { Writable } from 'stream';
 import { log } from '../../lib/logs/logger';
-import { loadBrokerConfig } from '../../lib/hybrid-sdk/common/config/config';
+import {
+  loadBrokerConfig,
+  getConfig,
+  setConfig,
+} from '../../lib/hybrid-sdk/common/config/config';
+import {
+  getPluginConfigByConnectionKey,
+  setPluginConfigKey,
+  setPluginConfigParamByConnectionKey,
+} from '../../lib/hybrid-sdk/common/config/pluginsConfig';
 
 describe('log', () => {
   beforeAll(async () => {
@@ -140,5 +149,60 @@ describe('log', () => {
     expect(logged).toMatch(sanitizedGitUsername);
     expect(logged).toMatch(sanitizedGitPassword);
     expect(logged).toMatch(sanitizedGitClientUrl);
+  });
+
+  it('sanitizes universal-broker connection, context and plugin credentials', () => {
+    const connectionClientId = 'CONN_CLIENT_ID_SECRET';
+    const contextClientId = 'CTX_CLIENT_ID_SECRET';
+    const pluginToken = 'PLUGIN_TOKEN_SECRET';
+    const connectionKey = 'test-connection';
+
+    const originalConfig = Object.assign({}, getConfig());
+    const originalPluginConfig = getPluginConfigByConnectionKey(connectionKey);
+
+    setConfig({
+      ...originalConfig,
+      universalBrokerEnabled: true,
+      connections: {
+        [connectionKey]: {
+          identifier: 'test-connection-id',
+          GITHUB_APP_CLIENT_ID: connectionClientId,
+          contexts: {
+            ctx1: {
+              GITHUB_APP_CLIENT_ID: contextClientId,
+            },
+          },
+        },
+      },
+    });
+    setPluginConfigParamByConnectionKey(
+      connectionKey,
+      'GHA_ACCESS_TOKEN',
+      pluginToken,
+    );
+
+    try {
+      const logs: string[] = [];
+      const testStream = new Writable();
+      testStream._write = function (chunk, encoding, done) {
+        logs.push(chunk.toString());
+        done();
+      };
+      log.addStream({ stream: testStream });
+
+      log.info({
+        token: [connectionClientId, contextClientId, pluginToken].join(),
+      });
+
+      const logged = logs[0];
+      expect(logged).not.toMatch(connectionClientId);
+      expect(logged).not.toMatch(contextClientId);
+      expect(logged).not.toMatch(pluginToken);
+      expect(logged.match(/\$\{GITHUB_APP_CLIENT_ID\}/g)).toHaveLength(2);
+      expect(logged).toMatch('${GHA_ACCESS_TOKEN}');
+    } finally {
+      setConfig(originalConfig);
+      setPluginConfigKey(connectionKey, originalPluginConfig);
+    }
   });
 });


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/main/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Compile each RegExp object once at startup rather than on every request/log call. Adds test coverage for the changed body-regex path and for previously-untested universal-broker log redaction.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
