### PR TITLE
feat: add server stale-creds-sweep metrics via shared OTel plumbing

### DIFF
--- a/lib/hybrid-sdk/client/metrics/config.ts
+++ b/lib/hybrid-sdk/client/metrics/config.ts
@@ -1,42 +1,20 @@
-/**
- * Raw string input for metrics configuration.
- * All values are optional strings; type coercion happens in {@link parse}.
- */
-export interface RawConfig {
-  metricsOtelEndpoint?: string;
-  metricsOtelExportIntervalMs?: string;
-}
+import {
+  OtelConfig,
+  parseOtelConfig,
+  RawOtelConfig,
+} from '../../common/metrics/otel';
 
-/** Validated and typed metrics configuration. */
-export interface Config {
-  /** OTLP/gRPC endpoint for the metric exporter. Undefined when metrics are disabled. */
-  otelEndpoint?: URL;
-  /** How often (ms) the periodic metric reader exports collected metrics. */
-  otelExportIntervalMs: number;
-}
-
-const DEFAULT_EXPORT_INTERVAL_MS = 10_000;
+export type RawConfig = RawOtelConfig;
+export type Config = OtelConfig;
 
 /**
- * Parse and validate raw string input into a typed {@link Config}.
- * Coerces the export interval to a number, falling back to 10 000 ms.
+ * Parse and validate raw string input into a typed Config.
+ * Delegates to the shared parseOtelConfig.
+ *
+ * @param raw - Raw string config values (e.g. from env vars).
+ * @returns The validated, typed config.
+ * @throws If metricsOtelEndpoint is set but not a valid URL.
  */
 export function parse(raw: RawConfig): Config {
-  const rawEndpoint = raw.metricsOtelEndpoint;
-
-  let otelEndpoint: URL | undefined;
-  if (rawEndpoint) {
-    try {
-      otelEndpoint = new URL(rawEndpoint);
-    } catch {
-      throw new Error(
-        `Invalid metricsOtelEndpoint: "${rawEndpoint}" is not a valid URL`,
-      );
-    }
-  }
-
-  const otelExportIntervalMs =
-    Number(raw.metricsOtelExportIntervalMs) || DEFAULT_EXPORT_INTERVAL_MS;
-
-  return { otelEndpoint, otelExportIntervalMs };
+  return parseOtelConfig(raw);
 }

--- a/lib/hybrid-sdk/client/metrics/noopClient.ts
+++ b/lib/hybrid-sdk/client/metrics/noopClient.ts
@@ -1,7 +1,7 @@
 import { Client } from './client';
 
 /**
- * {@link Client} that does nothing.
+ * Client implementation that does nothing.
  * Used when no metrics endpoint is configured.
  */
 export class NoopClient implements Client {

--- a/lib/hybrid-sdk/client/metrics/otelClient.ts
+++ b/lib/hybrid-sdk/client/metrics/otelClient.ts
@@ -7,14 +7,12 @@ import {
 } from '@opentelemetry/api';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { RuntimeNodeInstrumentation } from '@opentelemetry/instrumentation-runtime-node';
-import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-grpc';
 import {
-  AggregationTemporality,
   MeterProvider,
   MetricReader,
-  PeriodicExportingMetricReader,
   AggregationType,
 } from '@opentelemetry/sdk-metrics';
+import { createMeterProvider } from '../../common/metrics/otel';
 import { Client } from './client';
 import {
   CONNECTION_STATES,
@@ -22,7 +20,7 @@ import {
   ProcessExitReason,
 } from '../../common/types/telemetry';
 
-/** Constructor options for {@link OtelClient}. */
+/** Constructor options for OtelClient. */
 export interface OtelClientConfig {
   /** OTLP/gRPC collector endpoint URL. */
   endpoint: URL;
@@ -33,15 +31,17 @@ export interface OtelClientConfig {
 }
 
 /**
- * {@link Client} implementation backed by OpenTelemetry.
+ * Client implementation backed by OpenTelemetry.
  * Exports metrics to an OTLP/gRPC endpoint using delta temporality.
  *
  * Automatically registers the Node.js event loop delay p99 metric via
- * {@link RuntimeNodeInstrumentation}, renamed to 'broker.nodejs.eventloop.delay.p99'
+ * RuntimeNodeInstrumentation, renamed to 'broker.nodejs.eventloop.delay.p99'
  * for pipeline compatibility. Other runtime metrics are filtered out.
  *
  * For non-Kubernetes environments, container metrics (CPU, memory, network I/O)
  * are already provided by the infrastructure via cAdvisor.
+ *
+ * @param config - Constructor options.
  */
 export class OtelClient implements Client {
   private readonly meterProvider: MeterProvider;
@@ -67,35 +67,31 @@ export class OtelClient implements Client {
   private readonly pingLatencyHistogram: Histogram;
 
   constructor(config: OtelClientConfig) {
-    const reader =
-      config.reader ??
-      new PeriodicExportingMetricReader({
-        exporter: new OTLPMetricExporter({
-          url: config.endpoint.toString(),
-          temporalityPreference: AggregationTemporality.DELTA,
-        }),
-        exportIntervalMillis: config.exportIntervalMs,
-      });
-
-    this.meterProvider = new MeterProvider({
-      readers: [reader],
-      views: [
-        // Rename p99 event loop delay metric with `broker.` prefix to avoid being filtered out
-        // by the metrics pipeline.
-        {
-          instrumentName: 'nodejs.eventloop.delay.p99',
-          meterName: '@opentelemetry/instrumentation-runtime-node',
-          name: 'broker.nodejs.eventloop.delay.p99',
-        },
-        // Drop all other NodeJS runtime metrics. Infra automatically filter these runtime
-        // metrics out due to the large volume emitted, so we want to be selective.
-        {
-          instrumentName: '*',
-          meterName: '@opentelemetry/instrumentation-runtime-node',
-          aggregation: { type: AggregationType.DROP },
-        },
-      ],
-    });
+    this.meterProvider = createMeterProvider(
+      {
+        otelEndpoint: config.endpoint,
+        otelExportIntervalMs: config.exportIntervalMs,
+      },
+      {
+        reader: config.reader,
+        views: [
+          // Rename p99 event loop delay metric with `broker.` prefix to avoid being filtered out
+          // by the metrics pipeline.
+          {
+            instrumentName: 'nodejs.eventloop.delay.p99',
+            meterName: '@opentelemetry/instrumentation-runtime-node',
+            name: 'broker.nodejs.eventloop.delay.p99',
+          },
+          // Drop all other NodeJS runtime metrics. Infra automatically filter these runtime
+          // metrics out due to the large volume emitted, so we want to be selective.
+          {
+            instrumentName: '*',
+            meterName: '@opentelemetry/instrumentation-runtime-node',
+            aggregation: { type: AggregationType.DROP },
+          },
+        ],
+      },
+    );
 
     this.runtimeInstrumentation = new RuntimeNodeInstrumentation();
     registerInstrumentations({

--- a/lib/hybrid-sdk/common/metrics/otel.ts
+++ b/lib/hybrid-sdk/common/metrics/otel.ts
@@ -1,0 +1,151 @@
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-grpc';
+import {
+  AggregationTemporality,
+  MeterProvider,
+  MetricReader,
+  PeriodicExportingMetricReader,
+  ViewOptions,
+} from '@opentelemetry/sdk-metrics';
+import { log as logger } from '../../../logs/logger';
+
+/**
+ * Raw string input for OTel metrics configuration.
+ * All values are optional strings; type coercion happens in parseOtelConfig.
+ */
+export interface RawOtelConfig {
+  metricsOtelEndpoint?: string;
+  metricsOtelExportIntervalMs?: string;
+}
+
+/** Validated and typed OTel metrics configuration. */
+export interface OtelConfig {
+  /** OTLP/gRPC endpoint for the metric exporter. Undefined when metrics are disabled. */
+  otelEndpoint?: URL;
+  /** How often (ms) the periodic metric reader exports collected metrics. */
+  otelExportIntervalMs: number;
+}
+
+const DEFAULT_EXPORT_INTERVAL_MS = 10_000;
+
+/**
+ * Parse and validate raw string input into a typed OTel metrics config.
+ * Coerces the export interval to a number, falling back to the default for
+ * any unset, non-numeric, zero, or negative value — export cannot be
+ * disabled via this setting.
+ *
+ * @param raw - Raw string config values (e.g. from env vars).
+ * @returns The validated, typed config.
+ * @throws If metricsOtelEndpoint is set but not a valid URL.
+ */
+export function parseOtelConfig(raw: RawOtelConfig): OtelConfig {
+  const rawEndpoint = raw.metricsOtelEndpoint;
+
+  let otelEndpoint: URL | undefined;
+  if (rawEndpoint) {
+    try {
+      otelEndpoint = new URL(rawEndpoint);
+    } catch {
+      throw new Error(
+        `Invalid metricsOtelEndpoint: "${rawEndpoint}" is not a valid URL`,
+      );
+    }
+  }
+
+  // Export cannot be disabled via the interval: zero, negative, and
+  // non-numeric values all fall back to the default rather than being
+  // honoured literally.
+  const parsedIntervalMs = Number(raw.metricsOtelExportIntervalMs);
+  const otelExportIntervalMs =
+    Number.isFinite(parsedIntervalMs) && parsedIntervalMs > 0
+      ? parsedIntervalMs
+      : DEFAULT_EXPORT_INTERVAL_MS;
+
+  return { otelEndpoint, otelExportIntervalMs };
+}
+
+/** Options for createMeterProvider. */
+export interface CreateMeterProviderOpts {
+  /** Views to apply to the meter provider (e.g. renaming or dropping instruments). */
+  views?: ViewOptions[];
+  /** Optional metric reader override (used for testing). */
+  reader?: MetricReader;
+}
+
+/**
+ * Build a MeterProvider exporting to an OTLP/gRPC endpoint using delta
+ * temporality, on a periodic export interval.
+ *
+ * @param config - OTel config with a required endpoint.
+ * @param opts - Optional views/reader overrides.
+ * @returns A configured MeterProvider.
+ */
+export function createMeterProvider(
+  config: OtelConfig & { otelEndpoint: URL },
+  opts: CreateMeterProviderOpts = {},
+): MeterProvider {
+  const reader =
+    opts.reader ??
+    new PeriodicExportingMetricReader({
+      exporter: new OTLPMetricExporter({
+        url: config.otelEndpoint.toString(),
+        temporalityPreference: AggregationTemporality.DELTA,
+      }),
+      exportIntervalMillis: config.otelExportIntervalMs,
+    });
+
+  return new MeterProvider({
+    readers: [reader],
+    views: opts.views ?? [],
+  });
+}
+
+/** Constructor shape shared by the client- and server-side `OtelClient` implementations. */
+export interface OtelClientCtor<T> {
+  new (opts: { endpoint: URL; exportIntervalMs: number }): T;
+}
+
+/**
+ * Shared factory behind the client- and server-side `metrics.createClient()`
+ * entry points: parses raw config and returns a no-op client when no OTel
+ * endpoint is configured, or an OTel-backed client otherwise.
+ *
+ * @param raw - Raw string config values (e.g. from env vars).
+ * @param NoopCtor - Constructor for the no-op client, used when no OTel endpoint is configured.
+ * @param OtelCtor - Constructor for the OTel-backed client, used when an endpoint is configured.
+ * @returns An instance constructed by NoopCtor or OtelCtor.
+ * @throws If parsing the config, or constructing the OTel-backed client, fails.
+ */
+export function createOtelBackedClient<T>(
+  raw: RawOtelConfig,
+  NoopCtor: new () => T,
+  OtelCtor: OtelClientCtor<T>,
+): T {
+  let config: OtelConfig;
+  try {
+    config = parseOtelConfig(raw);
+  } catch (cause) {
+    throw new Error('failed to parse metrics config', { cause });
+  }
+
+  if (!config.otelEndpoint) {
+    logger.info('OTel metrics endpoint not configured, using noop metrics.');
+    return new NoopCtor();
+  }
+
+  logger.info(
+    {
+      endpoint: config.otelEndpoint.toString(),
+      exportIntervalMs: config.otelExportIntervalMs,
+    },
+    'Initializing OTel metrics client.',
+  );
+
+  try {
+    return new OtelCtor({
+      endpoint: config.otelEndpoint,
+      exportIntervalMs: config.otelExportIntervalMs,
+    });
+  } catch (cause) {
+    throw new Error('failed to create OTel metrics client', { cause });
+  }
+}

--- a/lib/hybrid-sdk/server/auth/connectionWatchdog.ts
+++ b/lib/hybrid-sdk/server/auth/connectionWatchdog.ts
@@ -1,26 +1,44 @@
 import { getConfig } from '../../common/config/config';
 import { getSocketConnections } from '../socket';
 import { log as logger } from '../../../logs/logger';
+import { Client } from '../metrics/client';
+import { NoopClient } from '../metrics/noopClient';
 
 const ONE_HOUR_FIVE_MIN_IN_MS = 65 * 60 * 1000;
 const STALE_CONNECTIONS_CLEANUP_FREQUENCY =
   getConfig().STALE_CONNECTIONS_CLEANUP_FREQUENCY ?? ONE_HOUR_FIVE_MIN_IN_MS;
 
-export const disconnectConnectionsWithStaleCreds = async () => {
-  const connections = getSocketConnections();
-  const connectionsIterator = connections.entries();
-  for (const [identifier, connection] of connectionsIterator) {
-    connection.forEach((client) => {
-      if (!isDateWithinAnHourAndFiveSec(client.credsValidationTime!)) {
-        logger.info(
-          {
-            connection: `${identifier}`,
-            credsLastValidated: client.credsValidationTime,
-          },
-          'Disconnecting connection due to stale auth.',
-        );
-        client.socket?.end();
-      }
+export const disconnectConnectionsWithStaleCreds = async (
+  metricsClient: Client = new NoopClient(),
+) => {
+  const start = process.hrtime.bigint();
+  try {
+    const connections = getSocketConnections();
+    const connectionsIterator = connections.entries();
+    for (const [identifier, connection] of connectionsIterator) {
+      connection.forEach((client) => {
+        if (!isDateWithinAnHourAndFiveSec(client.credsValidationTime!)) {
+          logger.info(
+            {
+              connection: `${identifier}`,
+              credsLastValidated: client.credsValidationTime,
+            },
+            'Disconnecting connection due to stale auth.',
+          );
+          client.socket?.end();
+          metricsClient.incrementStaleCredsDisconnected();
+        }
+      });
+    }
+  } finally {
+    const durationSeconds =
+      Number(process.hrtime.bigint() - start) / 1_000_000_000;
+    metricsClient.observeStaleCredsSweepDuration(durationSeconds);
+    // Flush eagerly rather than waiting for the periodic exporter tick: a sweep
+    // long enough to matter here is also long enough to precede a forced
+    // (non-graceful) restart, which gives the periodic exporter no chance to run.
+    metricsClient.forceFlush().catch((err) => {
+      logger.warn({ err }, 'Failed to flush stale-creds watchdog metrics.');
     });
   }
 };

--- a/lib/hybrid-sdk/server/index.ts
+++ b/lib/hybrid-sdk/server/index.ts
@@ -22,9 +22,20 @@ import filterRulesLoader from '../common/filter/filter-rules-loading';
 import { authRefreshHandler } from './routesHandlers/authHandlers';
 import { disconnectConnectionsWithStaleCreds } from './auth/connectionWatchdog';
 import { serviceHandler } from './routesHandlers/serviceHandler';
+import * as metrics from './metrics';
 
 export const main = async (serverOpts: ServerOpts) => {
   logger.info({ version }, 'Broker starting in server mode.');
+
+  let metricsClient: metrics.Client;
+  try {
+    metricsClient = metrics.createClient(
+      serverOpts.config as metrics.RawOtelConfig,
+    );
+  } catch (err) {
+    logger.fatal({ err }, 'Failed to initialize metrics client.');
+    process.exit(1);
+  }
 
   const filters = await filterRulesLoader(serverOpts.config);
   if (!filters) {
@@ -96,7 +107,7 @@ export const main = async (serverOpts: ServerOpts) => {
     );
 
     setInterval(
-      disconnectConnectionsWithStaleCreds,
+      () => disconnectConnectionsWithStaleCreds(metricsClient),
       loadedServerOpts.config.STALE_CONNECTIONS_CLEANUP_FREQUENCY ??
         10 * 60 * 1000,
     );
@@ -115,6 +126,9 @@ export const main = async (serverOpts: ServerOpts) => {
     close: (done) => {
       logger.info('Server websocket is closing.');
       server.close();
+      metricsClient.shutdown().catch((err) => {
+        logger.warn({ err }, 'Error shutting down metrics client.');
+      });
       websocket.destroy(function () {
         logger.info('Server websocket is closed.');
         if (done) {

--- a/lib/hybrid-sdk/server/metrics/client.ts
+++ b/lib/hybrid-sdk/server/metrics/client.ts
@@ -1,0 +1,14 @@
+/** Backend-agnostic interface for emitting broker server metrics. */
+export interface Client {
+  /** Record broker.server.stale_creds.sweep.duration.seconds for a watchdog sweep. */
+  observeStaleCredsSweepDuration(seconds: number): void;
+
+  /** Increment broker.server.stale_creds.disconnected.total for each stale connection closed. */
+  incrementStaleCredsDisconnected(): void;
+
+  /** Force-flush pending metrics without shutting down. */
+  forceFlush(): Promise<void>;
+
+  /** Flush pending metrics and release resources. */
+  shutdown(): Promise<void>;
+}

--- a/lib/hybrid-sdk/server/metrics/index.ts
+++ b/lib/hybrid-sdk/server/metrics/index.ts
@@ -1,5 +1,7 @@
-import { createOtelBackedClient } from '../../common/metrics/otel';
-import { RawConfig } from './config';
+import {
+  createOtelBackedClient,
+  RawOtelConfig,
+} from '../../common/metrics/otel';
 import { Client } from './client';
 import { NoopClient } from './noopClient';
 import { OtelClient } from './otelClient';
@@ -13,11 +15,11 @@ import { OtelClient } from './otelClient';
  * @throws If the raw config is invalid, or constructing the OTel-backed
  *   client fails.
  */
-export function createClient(raw: RawConfig): Client {
+export function createClient(raw: RawOtelConfig): Client {
   return createOtelBackedClient<Client>(raw, NoopClient, OtelClient);
 }
 
-export { RawConfig } from './config';
+export { RawOtelConfig } from '../../common/metrics/otel';
 export { Client } from './client';
 export { NoopClient } from './noopClient';
 export { OtelClient } from './otelClient';

--- a/lib/hybrid-sdk/server/metrics/noopClient.ts
+++ b/lib/hybrid-sdk/server/metrics/noopClient.ts
@@ -1,0 +1,12 @@
+import { Client } from './client';
+
+/**
+ * Client implementation that does nothing.
+ * Used when no metrics endpoint is configured.
+ */
+export class NoopClient implements Client {
+  observeStaleCredsSweepDuration(): void {}
+  incrementStaleCredsDisconnected(): void {}
+  async forceFlush(): Promise<void> {}
+  async shutdown(): Promise<void> {}
+}

--- a/lib/hybrid-sdk/server/metrics/otelClient.ts
+++ b/lib/hybrid-sdk/server/metrics/otelClient.ts
@@ -1,0 +1,77 @@
+import { Counter, Histogram, ValueType } from '@opentelemetry/api';
+import { MeterProvider, MetricReader } from '@opentelemetry/sdk-metrics';
+import { createMeterProvider, OtelConfig } from '../../common/metrics/otel';
+import { Client } from './client';
+
+/** Constructor options for OtelClient. */
+export interface OtelClientConfig {
+  /** OTLP/gRPC collector endpoint URL. */
+  endpoint: URL;
+  /** Periodic export interval in milliseconds. */
+  exportIntervalMs: number;
+  /** Optional metric reader (used for testing). */
+  reader?: MetricReader;
+}
+
+/**
+ * Client implementation backed by OpenTelemetry.
+ * Exports metrics to an OTLP/gRPC endpoint using delta temporality.
+ *
+ * @param config - Constructor options.
+ */
+export class OtelClient implements Client {
+  private readonly meterProvider: MeterProvider;
+  private readonly staleCredsSweepDurationHistogram: Histogram;
+  private readonly staleCredsDisconnectedCounter: Counter;
+
+  constructor(config: OtelClientConfig) {
+    const otelConfig: OtelConfig & { otelEndpoint: URL } = {
+      otelEndpoint: config.endpoint,
+      otelExportIntervalMs: config.exportIntervalMs,
+    };
+    this.meterProvider = createMeterProvider(otelConfig, {
+      reader: config.reader,
+    });
+
+    const meter = this.meterProvider.getMeter('broker-server');
+
+    this.staleCredsSweepDurationHistogram = meter.createHistogram(
+      'broker.server.stale_creds.sweep.duration.seconds',
+      {
+        description:
+          'Duration of the stale-credentials connection watchdog sweep, in seconds.',
+        unit: 's',
+        advice: {
+          explicitBucketBoundaries: [
+            0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10, 30,
+          ],
+        },
+      },
+    );
+
+    this.staleCredsDisconnectedCounter = meter.createCounter(
+      'broker.server.stale_creds.disconnected.total',
+      {
+        description:
+          'Count of connections disconnected by the stale-credentials watchdog sweep.',
+        valueType: ValueType.INT,
+      },
+    );
+  }
+
+  observeStaleCredsSweepDuration(seconds: number): void {
+    this.staleCredsSweepDurationHistogram.record(seconds);
+  }
+
+  incrementStaleCredsDisconnected(): void {
+    this.staleCredsDisconnectedCounter.add(1);
+  }
+
+  async forceFlush(): Promise<void> {
+    await this.meterProvider.forceFlush();
+  }
+
+  async shutdown(): Promise<void> {
+    await this.meterProvider.shutdown();
+  }
+}

--- a/test/unit/lib/hybrid-sdk/common/metrics/otel.test.ts
+++ b/test/unit/lib/hybrid-sdk/common/metrics/otel.test.ts
@@ -1,0 +1,123 @@
+import { MetricReader } from '@opentelemetry/sdk-metrics';
+import {
+  createMeterProvider,
+  parseOtelConfig,
+} from '../../../../../../lib/hybrid-sdk/common/metrics/otel';
+
+class TestMetricReader extends MetricReader {
+  protected async onShutdown(): Promise<void> {}
+  protected async onForceFlush(): Promise<void> {}
+}
+
+describe('common/metrics/otel', () => {
+  describe('parseOtelConfig', () => {
+    it('returns defaults when no raw config is provided', () => {
+      const config = parseOtelConfig({});
+      expect(config.otelEndpoint).toBeUndefined();
+      expect(config.otelExportIntervalMs).toBe(10_000);
+    });
+
+    it('parses endpoint from metricsOtelEndpoint', () => {
+      const config = parseOtelConfig({
+        metricsOtelEndpoint: 'http://collector:4317',
+      });
+      expect(config.otelEndpoint).toEqual(new URL('http://collector:4317'));
+    });
+
+    it('coerces metricsOtelExportIntervalMs to a number', () => {
+      const config = parseOtelConfig({
+        metricsOtelExportIntervalMs: '30000',
+      });
+      expect(config.otelExportIntervalMs).toBe(30_000);
+    });
+
+    it('falls back to default when export interval is not a number', () => {
+      const config = parseOtelConfig({
+        metricsOtelExportIntervalMs: 'notanumber',
+      });
+      expect(config.otelExportIntervalMs).toBe(10_000);
+    });
+
+    it('falls back to default for an explicit export interval of 0 — export cannot be disabled this way', () => {
+      const config = parseOtelConfig({
+        metricsOtelExportIntervalMs: '0',
+      });
+      expect(config.otelExportIntervalMs).toBe(10_000);
+    });
+
+    it('falls back to default for a negative export interval', () => {
+      const config = parseOtelConfig({
+        metricsOtelExportIntervalMs: '-30000',
+      });
+      expect(config.otelExportIntervalMs).toBe(10_000);
+    });
+
+    it('treats empty endpoint as undefined', () => {
+      const config = parseOtelConfig({ metricsOtelEndpoint: '' });
+      expect(config.otelEndpoint).toBeUndefined();
+    });
+
+    it('throws on an invalid endpoint URL', () => {
+      expect(() =>
+        parseOtelConfig({ metricsOtelEndpoint: 'not a url' }),
+      ).toThrow('Invalid metricsOtelEndpoint');
+    });
+  });
+
+  describe('createMeterProvider', () => {
+    it('builds a MeterProvider using the supplied reader', async () => {
+      const reader = new TestMetricReader();
+      const meterProvider = createMeterProvider(
+        {
+          otelEndpoint: new URL('http://localhost:4317'),
+          otelExportIntervalMs: 60_000,
+        },
+        { reader },
+      );
+
+      const meter = meterProvider.getMeter('test-meter');
+      const counter = meter.createCounter('test.counter');
+      counter.add(1);
+
+      const { resourceMetrics } = await reader.collect();
+      const names = resourceMetrics.scopeMetrics
+        .flatMap((sm) => sm.metrics)
+        .map((m) => m.descriptor.name);
+      expect(names).toContain('test.counter');
+
+      await meterProvider.shutdown();
+    });
+
+    it('applies supplied views', async () => {
+      const reader = new TestMetricReader();
+      const meterProvider = createMeterProvider(
+        {
+          otelEndpoint: new URL('http://localhost:4317'),
+          otelExportIntervalMs: 60_000,
+        },
+        {
+          reader,
+          views: [
+            {
+              instrumentName: 'renamed.me',
+              meterName: 'test-meter',
+              name: 'renamed.metric',
+            },
+          ],
+        },
+      );
+
+      const meter = meterProvider.getMeter('test-meter');
+      meter.createCounter('renamed.me').add(1);
+
+      const { resourceMetrics } = await reader.collect();
+      const names = resourceMetrics.scopeMetrics
+        .flatMap((sm) => sm.metrics)
+        .map((m) => m.descriptor.name);
+      expect(names).toContain('renamed.metric');
+      expect(names).not.toContain('renamed.me');
+
+      await meterProvider.shutdown();
+    });
+  });
+});

--- a/test/unit/lib/hybrid-sdk/server/auth/connectionWatchdog.test.ts
+++ b/test/unit/lib/hybrid-sdk/server/auth/connectionWatchdog.test.ts
@@ -1,0 +1,112 @@
+import { getSocketConnections } from '../../../../../../lib/hybrid-sdk/server/socket';
+
+jest.mock('../../../../../../lib/hybrid-sdk/common/config/config', () => ({
+  getConfig: jest.fn(() => ({})),
+}));
+
+jest.mock('../../../../../../lib/hybrid-sdk/server/socket', () => ({
+  getSocketConnections: jest.fn(),
+}));
+
+jest.mock('../../../../../../lib/logs/logger', () => ({
+  log: {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+import { disconnectConnectionsWithStaleCreds } from '../../../../../../lib/hybrid-sdk/server/auth/connectionWatchdog';
+
+const mockedGetSocketConnections = getSocketConnections as jest.MockedFunction<
+  typeof getSocketConnections
+>;
+
+function makeClient(credsValidationTime: string) {
+  return { socket: { end: jest.fn() }, credsValidationTime };
+}
+
+function makeMetricsClient() {
+  return {
+    observeStaleCredsSweepDuration: jest.fn(),
+    incrementStaleCredsDisconnected: jest.fn(),
+    forceFlush: jest.fn().mockResolvedValue(undefined),
+    shutdown: jest.fn(),
+  };
+}
+
+describe('disconnectConnectionsWithStaleCreds', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('disconnects only stale connections and reports counts once per sweep', async () => {
+    const staleTime = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    const freshTime = new Date().toISOString();
+
+    const staleClientA = makeClient(staleTime);
+    const staleClientB = makeClient(staleTime);
+    const freshClient = makeClient(freshTime);
+
+    mockedGetSocketConnections.mockReturnValue(
+      new Map([
+        ['conn-1', [staleClientA, freshClient]],
+        ['conn-2', [staleClientB]],
+      ]) as any,
+    );
+
+    const metricsClient = makeMetricsClient();
+
+    await disconnectConnectionsWithStaleCreds(metricsClient as any);
+
+    expect(staleClientA.socket.end).toHaveBeenCalledTimes(1);
+    expect(staleClientB.socket.end).toHaveBeenCalledTimes(1);
+    expect(freshClient.socket.end).not.toHaveBeenCalled();
+    expect(metricsClient.incrementStaleCredsDisconnected).toHaveBeenCalledTimes(
+      2,
+    );
+    expect(metricsClient.observeStaleCredsSweepDuration).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(metricsClient.forceFlush).toHaveBeenCalledTimes(1);
+  });
+
+  it('still observes a sweep duration with zero stale connections', async () => {
+    const freshTime = new Date().toISOString();
+    const freshClient = makeClient(freshTime);
+
+    mockedGetSocketConnections.mockReturnValue(
+      new Map([['conn-1', [freshClient]]]) as any,
+    );
+
+    const metricsClient = makeMetricsClient();
+
+    await disconnectConnectionsWithStaleCreds(metricsClient as any);
+
+    expect(freshClient.socket.end).not.toHaveBeenCalled();
+    expect(
+      metricsClient.incrementStaleCredsDisconnected,
+    ).not.toHaveBeenCalled();
+    expect(metricsClient.observeStaleCredsSweepDuration).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(metricsClient.forceFlush).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs a warning without throwing when forceFlush rejects', async () => {
+    const freshTime = new Date().toISOString();
+    const freshClient = makeClient(freshTime);
+
+    mockedGetSocketConnections.mockReturnValue(
+      new Map([['conn-1', [freshClient]]]) as any,
+    );
+
+    const metricsClient = makeMetricsClient();
+    metricsClient.forceFlush.mockRejectedValue(new Error('export failed'));
+
+    await expect(
+      disconnectConnectionsWithStaleCreds(metricsClient as any),
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/main/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Add an OTel-backed metrics client for server, sharing config parsing and MeterProvider setup with existing client metrics module.

Add new counter and duration metrics to measure performance of the server's stale credentials sweep, which is suspected of causing an event loop block.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### Screenshots


#### Additional questions
