### PR TITLE
fix: broker server stale connections [ACC-3561]

### DIFF
--- a/lib/hybrid-sdk/server/auth/authHelpers.ts
+++ b/lib/hybrid-sdk/server/auth/authHelpers.ts
@@ -58,6 +58,31 @@ export interface ValidatedBrokerCredentials {
   role: string;
 }
 
+export interface HandshakeIdentity {
+  brokerClientId: string | undefined;
+  role: string;
+  /**
+   * Identifies one connection attempt. The client sends a fresh
+   * `snyk-request-id` for every attempt, including each reconnect, so this
+   * distinguishes two overlapping handshakes that share a client id and role.
+   */
+  handshakeId: string | undefined;
+}
+
+/**
+ * Reads the handshake identity from the websocket upgrade headers. This is the
+ * only identity available before the client sends `identify`, so it is also the
+ * only way to correlate a socket back to the pool entry the authorize hook
+ * registered for it.
+ */
+export const getHandshakeIdentityFromHeaders = (
+  headers: IncomingHttpHeaders,
+): HandshakeIdentity => ({
+  brokerClientId: getHeader(headers, BROKER_CLIENT_ID_HEADER),
+  role: getHeader(headers, BROKER_CLIENT_ROLE_HEADER) ?? '',
+  handshakeId: getHeader(headers, SNYK_REQUEST_ID_HEADER),
+});
+
 export const validateBrokerClientCredentials = async (
   headers: IncomingHttpHeaders,
   brokerConnectionIdentifier: string,
@@ -65,10 +90,10 @@ export const validateBrokerClientCredentials = async (
   brokerClientId?: string,
 ): Promise<ValidatedBrokerCredentials> => {
   const authHeader = getHeader(headers, AUTHORIZATION_HEADER);
-  brokerClientId =
-    brokerClientId ?? getHeader(headers, BROKER_CLIENT_ID_HEADER);
-  const role = getHeader(headers, BROKER_CLIENT_ROLE_HEADER) ?? '';
-  const requestId = getHeader(headers, SNYK_REQUEST_ID_HEADER) ?? '';
+  const identity = getHandshakeIdentityFromHeaders(headers);
+  brokerClientId = brokerClientId ?? identity.brokerClientId;
+  const role = identity.role;
+  const requestId = identity.handshakeId ?? '';
   const maskedToken = maskToken(brokerConnectionIdentifier);
 
   logger.debug(

--- a/lib/hybrid-sdk/server/routesHandlers/authHandlers.ts
+++ b/lib/hybrid-sdk/server/routesHandlers/authHandlers.ts
@@ -4,7 +4,11 @@ import {
   validateBrokerClientCredentials,
 } from '../auth/authHelpers';
 import { log as logger } from '../../../logs/logger';
-import { type ClientSocket, getSocketConnectionByIdentifier } from '../socket';
+import {
+  type ClientSocket,
+  findClientToRefreshCreds,
+  getSocketConnectionByIdentifier,
+} from '../socket';
 import { maskToken } from '../../common/utils/token';
 
 interface BrokerConnectionAuthRequest {
@@ -35,9 +39,7 @@ export const authRefreshHandler = async (req: Request, res: Response) => {
 
     const connection = getSocketConnectionByIdentifier(identifier);
     currentClient = connection
-      ? connection.find(
-          (x) => x.metadata.clientId === brokerClientId && x.role === role,
-        )
+      ? findClientToRefreshCreds(connection, brokerClientId, role)
       : null;
 
     if (brokerAppClientId === undefined || !connection || !currentClient) {
@@ -55,25 +57,15 @@ export const authRefreshHandler = async (req: Request, res: Response) => {
       true,
       brokerClientId,
     );
-    // Refresh client validation time
-    const nowDate = new Date().toISOString();
-    currentClient.credsValidationTime = nowDate;
-    const currentClientIndex = connection.findIndex(
-      (x) => x.brokerClientId === brokerClientId && x.role === role,
-    );
-    if (currentClientIndex === -1) {
-      throw new Error('Unable to find client connection.');
-    }
-    connection[currentClientIndex] = currentClient;
+    // Update the live pool entry directly so a pending reconnect is not replaced.
+    currentClient.credsValidationTime = new Date().toISOString();
     return res.status(201).send('OK');
   } catch (err) {
     currentClient?.socket?.end();
     if (err instanceof BrokerAuthError) {
       return res.status(401).type('txt').send(err.message);
     }
-    return res
-      .status(500)
-      .type('txt')
-      .send(`Unable to complete auth refresh: ${err}.`);
+    logger.error({ err }, 'Unable to complete auth refresh.');
+    return res.status(500).type('txt').send('Unable to complete auth refresh.');
   }
 };

--- a/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.ts
+++ b/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.ts
@@ -10,6 +10,74 @@ import { makeStreamingRequestToDownstream } from '../../http/request';
 import { retry } from '../../http/exponential-backoff';
 
 const CONNECTION_READY_MAX_RETRIES = 4;
+const CONNECTION_HANDSHAKE_TTL_MS = Number(
+  process.env.BROKER_CONNECTION_HANDSHAKE_TTL_MS ?? 30_000,
+);
+
+const isReady = (client: ClientSocket): boolean =>
+  Boolean(
+    client.socket && client.metadata?.version && client.metadata?.capabilities,
+  );
+
+/**
+ * Drops authorization placeholders that never completed the identify handshake.
+ * Ready connections and legacy entries without a handshake timestamp are kept.
+ */
+const removeExpiredPendingHandshakes = (
+  connections: Map<string, ClientSocket[]>,
+  token: string,
+  now = Date.now(),
+): void => {
+  const activePool = (connections.get(token) ?? []).filter((client) => {
+    if (isReady(client)) {
+      return true;
+    }
+    // Only authorize-only entries are pending. An identified socket with
+    // incomplete metadata must remain tracked and follow the bad-metadata path.
+    if (
+      client.socket ||
+      client.metadata ||
+      client.handshakeStartTime === undefined
+    ) {
+      return true;
+    }
+    return now - client.handshakeStartTime < CONNECTION_HANDSHAKE_TTL_MS;
+  });
+
+  if (activePool.length > 0) {
+    connections.set(token, activePool);
+  } else {
+    connections.delete(token);
+  }
+};
+
+// The pool is newest-first, so find() returns the newest fully-ready connection.
+// This keeps HA clients immune to reconnect churn, which briefly creates a
+// not-yet-ready connection.
+type ConnectionLookup =
+  | { status: 'ready'; client: ClientSocket }
+  | { status: 'no-connection' }
+  | { status: 'bad-metadata' };
+
+const findReadyConnection = (
+  connections: Map<string, ClientSocket[]>,
+  token: string,
+): ConnectionLookup => {
+  removeExpiredPendingHandshakes(connections, token);
+  const pool = connections.get(token) ?? [];
+  if (pool.length === 0) {
+    return { status: 'no-connection' };
+  }
+  const ready = pool.find(isReady);
+  if (ready) {
+    return { status: 'ready', client: ready };
+  }
+  if (pool.some((client) => !client.socket || !client.metadata)) {
+    // Still completing the handshake. Throwing asks retry() for another attempt.
+    throw new Error('client handshake in progress');
+  }
+  return { status: 'bad-metadata' };
+};
 
 export const overloadHttpRequestWithConnectionDetailsMiddleware = async (
   req: Request,
@@ -77,39 +145,13 @@ export const overloadHttpRequestWithConnectionDetailsMiddleware = async (
       return res.status(404).json({ ok: false });
     }
   }
-  // Grab the pool of connections for this token
-  const connection = connections.get(token)!;
-  // Make sure a connection actually exists before proceeding
-  if (connection.length === 0) {
-    logger.warn(
-      { desensitizedToken, requestId },
-      'No connection in pool found.',
-    );
-    res.setHeader('x-broker-failure', 'no-connection');
-    return res.status(404).json({ ok: false });
-  }
-  const isReady = (c: ClientSocket): boolean =>
-    Boolean(c.socket && c.metadata?.version && c.metadata?.capabilities);
-
-  // The pool is newest-first, so find() returns the newest fully-ready
-  // connection. This keeps HA clients immune to reconnect churn, which will
-  // briefly create a not-yet-ready connection. If none is ready yet but a connection is still
-  // completing its handshake, retry with exponential backoff. A permanently-incomplete pool
-  // won't become ready, so return without retrying.
-  let client: ClientSocket | undefined;
+  // If no connection is ready yet but one is still completing its handshake,
+  // retry with exponential backoff. A permanently-incomplete pool won't become
+  // ready, so return without retrying.
+  let lookup: ConnectionLookup;
   try {
-    client = await retry<ClientSocket | undefined>(
-      () => {
-        const pool = connections.get(token) ?? [];
-        const ready = pool.find(isReady);
-        if (ready) {
-          return ready;
-        }
-        if (pool.some((c) => !c.socket || !c.metadata)) {
-          throw new Error('client handshake in progress');
-        }
-        return undefined;
-      },
+    lookup = await retry<ConnectionLookup>(
+      () => findReadyConnection(connections, token),
       {
         retries: CONNECTION_READY_MAX_RETRIES,
         operation: 'await-ready-broker-connection',
@@ -127,7 +169,18 @@ export const overloadHttpRequestWithConnectionDetailsMiddleware = async (
     return res.status(503).json({ ok: false });
   }
 
-  if (!client) {
+  if (lookup.status === 'no-connection') {
+    // The pool was empty on entry, or every entry in it was an expired
+    // handshake and was pruned. Either way there is nothing to serve.
+    logger.warn(
+      { desensitizedToken, requestId },
+      'No connection in pool found.',
+    );
+    res.setHeader('x-broker-failure', 'no-connection');
+    return res.status(404).json({ ok: false });
+  }
+
+  if (lookup.status === 'bad-metadata') {
     // Connections are present but missing required metadata (e.g. a legacy
     // client that never sends capabilities) — permanent for this client, so keep
     // the fast-fail 400 to avoid turning these into retry storms.
@@ -138,6 +191,8 @@ export const overloadHttpRequestWithConnectionDetailsMiddleware = async (
     res.setHeader('x-broker-failure', 'bad-request');
     return res.status(400).json({ ok: false });
   }
+
+  const client = lookup.client;
 
   res.locals.websocket = client.socket;
   res.locals.socketVersion = client.socketVersion;

--- a/lib/hybrid-sdk/server/socket.ts
+++ b/lib/hybrid-sdk/server/socket.ts
@@ -9,6 +9,8 @@ import { log as logger } from '../../logs/logger';
 import { maskToken } from '../common/utils/token';
 import {
   BrokerAuthError,
+  getHandshakeIdentityFromHeaders,
+  type HandshakeIdentity,
   validateBrokerClientCredentials,
 } from './auth/authHelpers';
 
@@ -24,6 +26,8 @@ export interface ClientSocket {
   role: Role;
   metadata?: any;
   credsValidationTime?: string;
+  handshakeStartTime?: number;
+  handshakeId?: string;
 }
 const socketConnections = new Map<string, ClientSocket[]>();
 
@@ -33,6 +37,88 @@ export const getSocketConnections = () => {
 
 export const getSocketConnectionByIdentifier = (identifier: string) => {
   return socketConnections.get(identifier);
+};
+
+/**
+ * Removes the pending entry for a handshake that closed before identifying.
+ *
+ * The handshake id ensures an older connection cannot remove a newer reconnect.
+ * If the client did not send enough identity headers, the entry is left for the
+ * TTL cleanup.
+ *
+ * Returns true if an entry was removed.
+ */
+export const removePendingHandshake = (
+  identifier: string,
+  { brokerClientId, role, handshakeId }: HandshakeIdentity,
+): boolean => {
+  if (!brokerClientId || !handshakeId) {
+    return false;
+  }
+  const clientPool = socketConnections.get(identifier);
+  if (!clientPool) {
+    return false;
+  }
+  const pendingIndex = clientPool.findIndex(
+    (client) =>
+      !client.socket &&
+      client.handshakeId === handshakeId &&
+      client.brokerClientId === brokerClientId &&
+      client.role === role,
+  );
+  if (pendingIndex < 0) {
+    return false;
+  }
+  clientPool.splice(pendingIndex, 1);
+  if (clientPool.length === 0) {
+    socketConnections.delete(identifier);
+  }
+  return true;
+};
+
+/**
+ * Adds a handshake to the connection pool after it has been authorized.
+ *
+ * A reconnect stays separate from the existing live connection, so closing the
+ * old socket cannot remove the new handshake. If there is already a pending
+ * handshake for the same client and role, the newer attempt replaces it.
+ */
+export const addAuthorizedHandshake = (
+  identifier: string,
+  currentClient: ClientSocket,
+): void => {
+  const clientPool = socketConnections.get(identifier) ?? [];
+  const pendingHandshakeIndex = clientPool.findIndex(
+    (client) =>
+      !client.socket &&
+      client.brokerClientId === currentClient.brokerClientId &&
+      client.role === currentClient.role,
+  );
+  if (pendingHandshakeIndex < 0) {
+    // Keep an identified connection separate from its reconnect attempt.
+    // If the old socket closes first, the new handshake must remain seated.
+    clientPool.unshift(currentClient);
+  } else {
+    clientPool[pendingHandshakeIndex] = currentClient;
+  }
+  socketConnections.set(identifier, clientPool);
+};
+
+/**
+ * Finds the connection to update after an auth refresh.
+ * Prefers the live connection when a reconnect is also pending, so the active
+ * socket does not get disconnected for using stale credentials.
+ */
+export const findClientToRefreshCreds = (
+  clientPool: ClientSocket[],
+  brokerClientId: string,
+  role: unknown,
+): ClientSocket | undefined => {
+  const matches = clientPool.filter(
+    (client) =>
+      client.brokerClientId === brokerClientId && client.role === role,
+  );
+  return matches.find((client) => client.socket) ?? matches[0];
 };
 
 const socket = ({ server, loadedServerOpts }): SocketHandler => {
@@ -58,7 +144,10 @@ const socket = ({ server, loadedServerOpts }): SocketHandler => {
         .toLowerCase();
       // Primus authorize callbacks receive the raw HTTP upgrade request before
       // the Express middleware chain runs, so req.requestId is not available here.
-      const requestId = req.headers['snyk-request-id'];
+      // The client sends a fresh snyk-request-id per connection attempt, so it
+      // also identifies this handshake when the socket later closes.
+      const { handshakeId } = getHandshakeIdentityFromHeaders(req.headers);
+      const requestId = handshakeId;
       try {
         const { brokerClientId, credentials, role } =
           // deepcode ignore Ssrf: request URL comes from the filter response, with the origin url being injected by the filtered version
@@ -76,24 +165,10 @@ const socket = ({ server, loadedServerOpts }): SocketHandler => {
           brokerAppClientId,
           role: (role ?? Role.primary) as Role,
           credsValidationTime: nowDate,
+          handshakeStartTime: Date.now(),
+          handshakeId,
         };
-        const connections = getSocketConnections();
-        const clientPool =
-          (connections.get(connectionIdentifier) as Array<ClientSocket>) || [];
-        const currentClientIndex = clientPool.findIndex(
-          (x) =>
-            x.brokerClientId === currentClient.brokerClientId &&
-            x.role === currentClient.role,
-        );
-        if (currentClientIndex < 0) {
-          clientPool.unshift(currentClient);
-        } else {
-          clientPool[currentClientIndex] = {
-            ...clientPool[currentClientIndex],
-            ...currentClient,
-          };
-        }
-        connections.set(connectionIdentifier, clientPool);
+        addAuthorizedHandshake(connectionIdentifier, currentClient);
       } catch (err) {
         if (err instanceof BrokerAuthError) {
           logger.warn(

--- a/lib/hybrid-sdk/server/socketHandlers/closeHandler.ts
+++ b/lib/hybrid-sdk/server/socketHandlers/closeHandler.ts
@@ -1,7 +1,8 @@
 import { decrementSocketConnectionGauge } from '../../common/utils/metrics';
 import { log as logger } from '../../../logs/logger';
 import { clientDisconnected } from '../infra/dispatcher';
-import { getSocketConnections } from '../socket';
+import { getSocketConnections, removePendingHandshake } from '../socket';
+import { getHandshakeIdentityFromHeaders } from '../auth/authHelpers';
 import { getDesensitizedToken } from '../utils/token';
 import { rmClientIdFromTerminationMap } from './identifyHandler';
 import { ISpark } from 'primus';
@@ -38,13 +39,19 @@ export const handleConnectionCloseOnSocket = (
         connections.delete(token);
       }
       decrementSocketConnectionGauge();
+      rmClientIdFromTerminationMap(token, clientId);
+      setImmediate(async () => await clientDisconnected(token, clientId));
     } else {
+      // No pool entry references this socket, because the socket is only
+      // attached by identify. The authorize hook still seated an entry for this
+      // handshake, and nothing else removes it. Without this the entry remains
+      // until an inbound request prunes it by handshake TTL.
+      const identity = getHandshakeIdentityFromHeaders(socket.request.headers);
+      const removed = removePendingHandshake(token, identity);
       logger.warn(
-        { maskedToken, hashedToken },
+        { maskedToken, hashedToken, ...identity, removed },
         'Client disconnected before identifying itself.',
       );
     }
-    rmClientIdFromTerminationMap(token, clientId);
-    setImmediate(async () => await clientDisconnected(token, clientId));
   }
 };

--- a/lib/hybrid-sdk/server/socketHandlers/connectionHandler.ts
+++ b/lib/hybrid-sdk/server/socketHandlers/connectionHandler.ts
@@ -27,8 +27,16 @@ export const handleSocketConnection = (socket: ISpark) => {
     identified = handleIdentifyOnSocket(clientData, socket, token);
   });
 
+  // Primus can emit more than one terminal event for the same socket. Treat
+  // teardown as one lifecycle transition so metrics, dispatcher calls and pool
+  // cleanup happen exactly once.
+  let terminalEventHandled = false;
   ['close', 'end', 'disconnection', 'destroy', 'timeout'].forEach((e) =>
     socket.on(e, () => {
+      if (terminalEventHandled) {
+        return;
+      }
+      terminalEventHandled = true;
       incrementSocketCloseReasonCount(e);
       handleConnectionCloseOnSocket(e, socket, token, clientId!, identified);
     }),

--- a/test/unit/authRefresh.test.ts
+++ b/test/unit/authRefresh.test.ts
@@ -1,0 +1,226 @@
+import { Request, Response } from 'express';
+import { authRefreshHandler } from '../../lib/hybrid-sdk/server/routesHandlers/authHandlers';
+import { Role } from '../../lib/hybrid-sdk/client/types/client';
+
+jest.mock('../../lib/hybrid-sdk/server/socket', () => {
+  const originalModule = jest.requireActual(
+    '../../lib/hybrid-sdk/server/socket',
+  );
+  return {
+    ...originalModule,
+    getSocketConnectionByIdentifier: jest.fn(),
+  };
+});
+
+jest.mock('../../lib/hybrid-sdk/server/auth/authHelpers', () => {
+  const originalModule = jest.requireActual(
+    '../../lib/hybrid-sdk/server/auth/authHelpers',
+  );
+  return {
+    ...originalModule,
+    validateBrokerClientCredentials: jest.fn(),
+  };
+});
+
+import { getSocketConnectionByIdentifier } from '../../lib/hybrid-sdk/server/socket';
+import {
+  BrokerAuthError,
+  validateBrokerClientCredentials,
+} from '../../lib/hybrid-sdk/server/auth/authHelpers';
+
+const IDENTIFIER = '00000000-0000-4000-8000-000000000001';
+const BROKER_CLIENT_ID = '00000000-0000-4000-8000-000000000002';
+
+describe('authRefreshHandler', () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let statusMock: jest.Mock;
+  let typeMock: jest.Mock;
+  let sendMock: jest.Mock;
+
+  const requestForRole = (role: Role): Partial<Request> => ({
+    params: { identifier: IDENTIFIER },
+    query: { connection_role: role },
+    headers: {},
+    body: Buffer.from(
+      JSON.stringify({
+        data: {
+          attributes: { broker_client_id: BROKER_CLIENT_ID },
+          id: IDENTIFIER,
+          type: 'broker_connection',
+        },
+      }),
+    ),
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    statusMock = jest.fn().mockReturnThis();
+    typeMock = jest.fn().mockReturnThis();
+    sendMock = jest.fn().mockReturnThis();
+    mockResponse = { status: statusMock, type: typeMock, send: sendMock };
+    (validateBrokerClientCredentials as jest.Mock).mockResolvedValue(undefined);
+    mockRequest = requestForRole(Role.primary);
+  });
+
+  // The pool is written by two places with different shapes: the websocket auth
+  // hook (socket.ts) stores brokerClientId + role and no metadata, while the
+  // identify hook (identifyHandler.ts) stores brokerClientId + metadata. Reading
+  // metadata.clientId while scanning therefore threw on the metadata-less entry
+  // and the handler answered 500 for a client it could have resolved.
+  it('refreshes a client even when an earlier pool entry has no metadata', async () => {
+    (getSocketConnectionByIdentifier as jest.Mock).mockReturnValue([
+      {
+        socketType: 'server',
+        socketVersion: 1,
+        brokerClientId: BROKER_CLIENT_ID,
+        role: Role.secondary,
+        metadata: undefined,
+      },
+      {
+        socketType: 'server',
+        socketVersion: 1,
+        brokerClientId: BROKER_CLIENT_ID,
+        role: Role.primary,
+        metadata: { clientId: BROKER_CLIENT_ID, version: '4.182.0' },
+      },
+    ]);
+
+    await authRefreshHandler(mockRequest as Request, mockResponse as Response);
+
+    expect(statusMock).toHaveBeenCalledWith(201);
+  });
+
+  it('refreshes a client whose only pool entry has no metadata', async () => {
+    (getSocketConnectionByIdentifier as jest.Mock).mockReturnValue([
+      {
+        socketType: 'server',
+        socketVersion: 1,
+        brokerClientId: BROKER_CLIENT_ID,
+        role: Role.primary,
+        metadata: undefined,
+      },
+    ]);
+
+    await authRefreshHandler(mockRequest as Request, mockResponse as Response);
+
+    expect(statusMock).toHaveBeenCalledWith(201);
+  });
+
+  it('stamps credsValidationTime on the pool entry itself', async () => {
+    const poolEntry = {
+      socketType: 'server',
+      socketVersion: 1,
+      brokerClientId: BROKER_CLIENT_ID,
+      role: Role.primary,
+      metadata: undefined,
+      credsValidationTime: undefined as string | undefined,
+    };
+    (getSocketConnectionByIdentifier as jest.Mock).mockReturnValue([poolEntry]);
+
+    await authRefreshHandler(mockRequest as Request, mockResponse as Response);
+
+    expect(statusMock).toHaveBeenCalledWith(201);
+    expect(poolEntry.credsValidationTime).toEqual(expect.any(String));
+  });
+
+  // A reconnect seats an authorize-only entry ahead of the live connection, so
+  // both entries carry this client id and role. Stamping the placeholder would
+  // leave the live connection's creds stale and the watchdog would close it.
+  it('stamps the live connection, not a pending reconnect seated ahead of it', async () => {
+    const pendingReconnect = {
+      socketType: 'server',
+      socketVersion: 1,
+      brokerClientId: BROKER_CLIENT_ID,
+      role: Role.primary,
+      metadata: undefined,
+      credsValidationTime: undefined as string | undefined,
+    };
+    const liveConnection = {
+      socket: { end: () => undefined },
+      socketType: 'server',
+      socketVersion: 1,
+      brokerClientId: BROKER_CLIENT_ID,
+      role: Role.primary,
+      metadata: { clientId: BROKER_CLIENT_ID, version: '4.182.0' },
+      credsValidationTime: undefined as string | undefined,
+    };
+    const pool = [pendingReconnect, liveConnection];
+    (getSocketConnectionByIdentifier as jest.Mock).mockReturnValue(pool);
+
+    await authRefreshHandler(mockRequest as Request, mockResponse as Response);
+
+    expect(statusMock).toHaveBeenCalledWith(201);
+    expect(liveConnection.credsValidationTime).toEqual(expect.any(String));
+    expect(pendingReconnect.credsValidationTime).toBeUndefined();
+    // The pending entry must survive; it belongs to the in-flight handshake.
+    expect(pool).toEqual([pendingReconnect, liveConnection]);
+  });
+
+  it('ends the live socket, not the pending reconnect, when validation fails', async () => {
+    const endMock = jest.fn();
+    (getSocketConnectionByIdentifier as jest.Mock).mockReturnValue([
+      {
+        socketType: 'server',
+        socketVersion: 1,
+        brokerClientId: BROKER_CLIENT_ID,
+        role: Role.primary,
+        metadata: undefined,
+      },
+      {
+        socket: { end: endMock },
+        socketType: 'server',
+        socketVersion: 1,
+        brokerClientId: BROKER_CLIENT_ID,
+        role: Role.primary,
+        metadata: { clientId: BROKER_CLIENT_ID, version: '4.182.0' },
+      },
+    ]);
+    (validateBrokerClientCredentials as jest.Mock).mockRejectedValue(
+      new BrokerAuthError('Invalid credentials.'),
+    );
+
+    await authRefreshHandler(mockRequest as Request, mockResponse as Response);
+
+    expect(statusMock).toHaveBeenCalledWith(401);
+    expect(endMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('answers 401, not 500, when the role has no matching client', async () => {
+    (getSocketConnectionByIdentifier as jest.Mock).mockReturnValue([
+      {
+        socketType: 'server',
+        socketVersion: 1,
+        brokerClientId: BROKER_CLIENT_ID,
+        role: Role.secondary,
+        metadata: undefined,
+      },
+    ]);
+
+    await authRefreshHandler(mockRequest as Request, mockResponse as Response);
+
+    expect(statusMock).toHaveBeenCalledWith(401);
+  });
+
+  it('answers 401 when the identifier has no connection at all', async () => {
+    (getSocketConnectionByIdentifier as jest.Mock).mockReturnValue(undefined);
+
+    await authRefreshHandler(mockRequest as Request, mockResponse as Response);
+
+    expect(statusMock).toHaveBeenCalledWith(401);
+  });
+
+  it('answers 500 with a generic body that does not leak the cause', async () => {
+    (getSocketConnectionByIdentifier as jest.Mock).mockImplementation(() => {
+      throw new Error('redis exploded');
+    });
+
+    await authRefreshHandler(mockRequest as Request, mockResponse as Response);
+
+    expect(statusMock).toHaveBeenCalledWith(500);
+    expect(sendMock).toHaveBeenCalledWith('Unable to complete auth refresh.');
+    expect(sendMock).not.toHaveBeenCalledWith(
+      expect.stringContaining('redis exploded'),
+    );
+  });
+});

--- a/test/unit/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.test.ts
+++ b/test/unit/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.test.ts
@@ -54,6 +54,7 @@ describe('overloadHttpRequestWithConnectionDetailsMiddleware', () => {
       {
         // mid-handshake: seated but not yet identified
         socketVersion: '1.0',
+        handshakeStartTime: Date.now(),
         // socket and metadata are intentionally missing, and never arrive
       },
     ]);
@@ -84,7 +85,10 @@ describe('overloadHttpRequestWithConnectionDetailsMiddleware', () => {
     jest.useFakeTimers();
     const mockConnections = new Map();
     // Starts mid-handshake; identify() completes after the first backoff.
-    const entry: Record<string, unknown> = { socketVersion: '1.0' };
+    const entry: Record<string, unknown> = {
+      socketVersion: '1.0',
+      handshakeStartTime: Date.now(),
+    };
     mockConnections.set('test-token', [entry]);
     mockedGetSocketConnections.mockReturnValue(mockConnections);
     const req = httpMocks.createRequest({
@@ -119,7 +123,7 @@ describe('overloadHttpRequestWithConnectionDetailsMiddleware', () => {
     };
     mockConnections.set('test-token', [
       // newest-first: an authorize-only entry sits at index 0 during reconnect
-      { socketVersion: '1.0' },
+      { socketVersion: '1.0', handshakeStartTime: Date.now() },
       readyConnection,
     ]);
     mockedGetSocketConnections.mockReturnValue(mockConnections);
@@ -135,6 +139,135 @@ describe('overloadHttpRequestWithConnectionDetailsMiddleware', () => {
     expect(next).toHaveBeenCalled();
     expect(res.locals.websocket).toEqual(readyConnection.socket);
     expect(res.locals.clientVersion).toEqual(readyConnection.metadata.version);
+  });
+
+  it('should prune an expired handshake and return no-connection', async () => {
+    const mockConnections = new Map();
+    mockConnections.set('test-token', [
+      {
+        socketVersion: '1.0',
+        handshakeStartTime: Date.now() - 31_000,
+      },
+    ]);
+    mockedGetSocketConnections.mockReturnValue(mockConnections);
+    const req = httpMocks.createRequest({
+      params: { token: 'test-token' },
+      url: '/broker/test-token/some/path',
+    });
+    const res = httpMocks.createResponse();
+
+    await overloadHttpRequestWithConnectionDetailsMiddleware(req, res, next);
+
+    expect(res.statusCode).toBe(404);
+    expect(res.getHeader('x-broker-failure')).toBe('no-connection');
+    expect(mockConnections.has('test-token')).toBe(false);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  // The handshake is still inside the TTL on the first attempt and crosses it
+  // during the first backoff. The pool empties, so this is a no-connection, not
+  // a bad-request.
+  it('should return 404 when the handshake expires mid-retry', async () => {
+    jest.useFakeTimers();
+    const mockConnections = new Map();
+    mockConnections.set('test-token', [
+      {
+        socketVersion: '1.0',
+        handshakeStartTime: Date.now() - 29_950,
+      },
+    ]);
+    mockedGetSocketConnections.mockReturnValue(mockConnections);
+    const req = httpMocks.createRequest({
+      params: { token: 'test-token' },
+      url: '/broker/test-token/some/path',
+    });
+    const res = httpMocks.createResponse();
+
+    const pending = overloadHttpRequestWithConnectionDetailsMiddleware(
+      req,
+      res,
+      next,
+    );
+    await jest.advanceTimersByTimeAsync(5000);
+    await pending;
+
+    expect(res.statusCode).toBe(404);
+    expect(res.getHeader('x-broker-failure')).toBe('no-connection');
+    expect(mockConnections.has('test-token')).toBe(false);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should prune an expired handshake while preserving a ready connection', async () => {
+    const mockConnections = new Map();
+    const readyConnection = {
+      socket: {},
+      socketVersion: '1.0',
+      metadata: { version: '1.2.3', capabilities: ['test'] },
+    };
+    mockConnections.set('test-token', [
+      {
+        socketVersion: '1.0',
+        handshakeStartTime: Date.now() - 31_000,
+      },
+      readyConnection,
+    ]);
+    mockedGetSocketConnections.mockReturnValue(mockConnections);
+    const req = httpMocks.createRequest({
+      params: { token: 'test-token' },
+      url: '/broker/test-token/some/path',
+    });
+    const res = httpMocks.createResponse();
+
+    await overloadHttpRequestWithConnectionDetailsMiddleware(req, res, next);
+
+    expect(res.statusCode).toBe(200);
+    expect(next).toHaveBeenCalled();
+    expect(mockConnections.get('test-token')).toEqual([readyConnection]);
+  });
+
+  it('should preserve an expired identified socket with incomplete metadata', async () => {
+    const mockConnections = new Map();
+    const identifiedConnection = {
+      socket: {},
+      socketVersion: '1.0',
+      metadata: { version: '1.2.3' },
+      handshakeStartTime: Date.now() - 31_000,
+    };
+    mockConnections.set('test-token', [identifiedConnection]);
+    mockedGetSocketConnections.mockReturnValue(mockConnections);
+    const req = httpMocks.createRequest({
+      params: { token: 'test-token' },
+      url: '/broker/test-token/some/path',
+    });
+    const res = httpMocks.createResponse();
+
+    await overloadHttpRequestWithConnectionDetailsMiddleware(req, res, next);
+
+    expect(res.statusCode).toBe(400);
+    expect(mockConnections.get('test-token')).toEqual([identifiedConnection]);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should preserve an incomplete legacy entry without a handshake timestamp', async () => {
+    const mockConnections = new Map();
+    mockConnections.set('test-token', [
+      {
+        socket: {},
+        socketVersion: '1.0',
+        metadata: { version: '1.2.3' },
+      },
+    ]);
+    mockedGetSocketConnections.mockReturnValue(mockConnections);
+    const req = httpMocks.createRequest({
+      params: { token: 'test-token' },
+      url: '/broker/test-token/some/path',
+    });
+    const res = httpMocks.createResponse();
+
+    await overloadHttpRequestWithConnectionDetailsMiddleware(req, res, next);
+
+    expect(res.statusCode).toBe(400);
+    expect(mockConnections.has('test-token')).toBe(true);
   });
 
   it('should return 400 if capabilities are missing from metadata', async () => {

--- a/test/unit/lib/hybrid-sdk/server/socket.test.ts
+++ b/test/unit/lib/hybrid-sdk/server/socket.test.ts
@@ -1,0 +1,194 @@
+import {
+  addAuthorizedHandshake,
+  ClientSocket,
+  findClientToRefreshCreds,
+  getSocketConnections,
+  removePendingHandshake,
+} from '../../../../../lib/hybrid-sdk/server/socket';
+import { HandshakeIdentity } from '../../../../../lib/hybrid-sdk/server/auth/authHelpers';
+import { Role } from '../../../../../lib/hybrid-sdk/client/types/client';
+
+const TOKEN = 'test-token';
+const BROKER_CLIENT_ID = 'client-1';
+const HANDSHAKE_ID = 'request-a';
+
+const pendingEntry = (overrides: Partial<ClientSocket> = {}): ClientSocket => ({
+  socketType: 'server',
+  socketVersion: 1,
+  brokerClientId: BROKER_CLIENT_ID,
+  brokerAppClientId: 'app-1',
+  role: Role.primary,
+  handshakeStartTime: Date.now(),
+  handshakeId: HANDSHAKE_ID,
+  ...overrides,
+});
+
+const identity = (
+  overrides: Partial<HandshakeIdentity> = {},
+): HandshakeIdentity => ({
+  brokerClientId: BROKER_CLIENT_ID,
+  role: Role.primary,
+  handshakeId: HANDSHAKE_ID,
+  ...overrides,
+});
+
+describe('findClientToRefreshCreds', () => {
+  const liveEntry = pendingEntry({
+    socket: { end: () => undefined },
+    metadata: { version: '1.2.3', capabilities: ['test'] },
+    handshakeId: 'request-a',
+  });
+  const pendingReconnect = pendingEntry({ handshakeId: 'request-b' });
+
+  it('prefers the live connection over a pending reconnect', () => {
+    expect(
+      findClientToRefreshCreds(
+        [pendingReconnect, liveEntry],
+        BROKER_CLIENT_ID,
+        Role.primary,
+      ),
+    ).toBe(liveEntry);
+  });
+
+  it('falls back to the only entry when no socket is attached yet', () => {
+    expect(
+      findClientToRefreshCreds(
+        [pendingReconnect],
+        BROKER_CLIENT_ID,
+        Role.primary,
+      ),
+    ).toBe(pendingReconnect);
+  });
+
+  it('ignores an entry with a different role', () => {
+    expect(
+      findClientToRefreshCreds([liveEntry], BROKER_CLIENT_ID, Role.secondary),
+    ).toBeUndefined();
+  });
+
+  it('ignores an entry with a different broker client id', () => {
+    expect(
+      findClientToRefreshCreds([liveEntry], 'other-client', Role.primary),
+    ).toBeUndefined();
+  });
+});
+
+describe('addAuthorizedHandshake', () => {
+  beforeEach(() => {
+    getSocketConnections().clear();
+  });
+  afterEach(() => {
+    getSocketConnections().clear();
+  });
+
+  it('keeps a reconnect separate from an identified connection', () => {
+    const identifiedSocket = { end: () => undefined };
+    const identifiedConnection = pendingEntry({
+      socket: identifiedSocket,
+      metadata: { version: '1.2.3', capabilities: ['test'] },
+      handshakeId: 'request-a',
+    });
+    const reconnect = pendingEntry({ handshakeId: 'request-b' });
+    getSocketConnections().set(TOKEN, [identifiedConnection]);
+
+    addAuthorizedHandshake(TOKEN, reconnect);
+
+    expect(getSocketConnections().get(TOKEN)).toEqual([
+      reconnect,
+      identifiedConnection,
+    ]);
+  });
+
+  it('replaces an existing pending attempt for the same client and role', () => {
+    const oldAttempt = pendingEntry({ handshakeId: 'request-a' });
+    const newAttempt = pendingEntry({ handshakeId: 'request-b' });
+    getSocketConnections().set(TOKEN, [oldAttempt]);
+
+    addAuthorizedHandshake(TOKEN, newAttempt);
+
+    expect(getSocketConnections().get(TOKEN)).toEqual([newAttempt]);
+  });
+});
+
+describe('removePendingHandshake', () => {
+  beforeEach(() => {
+    getSocketConnections().clear();
+  });
+  afterEach(() => {
+    getSocketConnections().clear();
+  });
+
+  it('removes the authorize-only entry for this handshake', () => {
+    getSocketConnections().set(TOKEN, [pendingEntry()]);
+
+    expect(removePendingHandshake(TOKEN, identity())).toBe(true);
+    // The pool is now empty, so the token itself is gone.
+    expect(getSocketConnections().has(TOKEN)).toBe(false);
+  });
+
+  it('keeps the other entries in the pool', () => {
+    const otherRole = pendingEntry({
+      role: Role.secondary,
+      handshakeId: 'request-b',
+    });
+    getSocketConnections().set(TOKEN, [pendingEntry(), otherRole]);
+
+    expect(removePendingHandshake(TOKEN, identity())).toBe(true);
+    expect(getSocketConnections().get(TOKEN)).toEqual([otherRole]);
+  });
+
+  // authorize() coalesces overlapping handshakes for the same client id and role
+  // into one entry, so the newer handshake owns it. Deleting it here would make
+  // identify() rebuild the entry without brokerAppClientId, role or
+  // credsValidationTime, which fails response auth and trips the stale-creds
+  // watchdog.
+  it('does not remove the entry once a newer handshake owns it', () => {
+    const newerHandshake = pendingEntry({ handshakeId: 'request-b' });
+    getSocketConnections().set(TOKEN, [newerHandshake]);
+
+    expect(
+      removePendingHandshake(TOKEN, identity({ handshakeId: 'request-a' })),
+    ).toBe(false);
+    expect(getSocketConnections().get(TOKEN)).toEqual([newerHandshake]);
+  });
+
+  // A reconnect can seat a second socket for the same client id and role. If
+  // that socket dies before identify, the entry still belongs to the live
+  // connection, and removing it would take a working client offline.
+  it('does not remove an entry that already holds a socket', () => {
+    const liveEntry = pendingEntry({
+      socket: { end: () => undefined },
+      metadata: { version: '1.2.3', capabilities: ['test'] },
+    });
+    getSocketConnections().set(TOKEN, [liveEntry]);
+
+    expect(removePendingHandshake(TOKEN, identity())).toBe(false);
+    expect(getSocketConnections().get(TOKEN)).toEqual([liveEntry]);
+  });
+
+  it('does nothing when the broker client id is missing', () => {
+    getSocketConnections().set(TOKEN, [pendingEntry()]);
+
+    expect(
+      removePendingHandshake(TOKEN, identity({ brokerClientId: undefined })),
+    ).toBe(false);
+    expect(getSocketConnections().get(TOKEN)).toHaveLength(1);
+  });
+
+  // No snyk-request-id means the handshake cannot be matched safely, so the
+  // entry is left to the handshake TTL sweep.
+  it('does nothing when the handshake id is missing', () => {
+    getSocketConnections().set(TOKEN, [
+      pendingEntry({ handshakeId: undefined }),
+    ]);
+
+    expect(
+      removePendingHandshake(TOKEN, identity({ handshakeId: undefined })),
+    ).toBe(false);
+    expect(getSocketConnections().get(TOKEN)).toHaveLength(1);
+  });
+
+  it('does nothing when the token has no pool', () => {
+    expect(removePendingHandshake(TOKEN, identity())).toBe(false);
+  });
+});

--- a/test/unit/lib/hybrid-sdk/server/socketHandlers/closeHandler.test.ts
+++ b/test/unit/lib/hybrid-sdk/server/socketHandlers/closeHandler.test.ts
@@ -1,0 +1,149 @@
+import { ISpark } from 'primus';
+
+jest.mock('../../../../../../lib/hybrid-sdk/server/infra/dispatcher', () => ({
+  clientDisconnected: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../../../../../../lib/hybrid-sdk/common/utils/metrics', () => ({
+  decrementSocketConnectionGauge: jest.fn(),
+}));
+jest.mock(
+  '../../../../../../lib/hybrid-sdk/server/socketHandlers/identifyHandler',
+  () => ({ rmClientIdFromTerminationMap: jest.fn() }),
+);
+
+import { handleConnectionCloseOnSocket } from '../../../../../../lib/hybrid-sdk/server/socketHandlers/closeHandler';
+import { clientDisconnected } from '../../../../../../lib/hybrid-sdk/server/infra/dispatcher';
+import {
+  ClientSocket,
+  getSocketConnections,
+} from '../../../../../../lib/hybrid-sdk/server/socket';
+import { Role } from '../../../../../../lib/hybrid-sdk/client/types/client';
+
+const TOKEN = 'test-token';
+const BROKER_CLIENT_ID = 'client-1';
+const HANDSHAKE_ID = 'request-a';
+
+const sparkWithHeaders = (headers: Record<string, string>): ISpark =>
+  ({ request: { headers } } as unknown as ISpark);
+
+const closingSpark = (overrides: Record<string, string> = {}): ISpark =>
+  sparkWithHeaders({
+    'x-snyk-broker-client-id': BROKER_CLIENT_ID,
+    'x-snyk-broker-client-role': Role.primary,
+    'snyk-request-id': HANDSHAKE_ID,
+    ...overrides,
+  });
+
+const pendingEntry = (overrides: Partial<ClientSocket> = {}): ClientSocket => ({
+  socketType: 'server',
+  socketVersion: 1,
+  brokerClientId: BROKER_CLIENT_ID,
+  brokerAppClientId: 'app-1',
+  role: Role.primary,
+  handshakeStartTime: Date.now(),
+  handshakeId: HANDSHAKE_ID,
+  ...overrides,
+});
+
+describe('handleConnectionCloseOnSocket', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getSocketConnections().clear();
+  });
+  afterEach(() => {
+    getSocketConnections().clear();
+  });
+
+  // Without this the authorize placeholder survives the disconnect and is only
+  // collected later, by the handshake TTL sweep on the next inbound request.
+  it('removes the authorize placeholder when the socket closes before identify', () => {
+    getSocketConnections().set(TOKEN, [pendingEntry()]);
+
+    handleConnectionCloseOnSocket('close', closingSpark(), TOKEN, '', false);
+
+    expect(getSocketConnections().has(TOKEN)).toBe(false);
+    expect(clientDisconnected).not.toHaveBeenCalled();
+  });
+
+  // Overlapping reconnects share one pool entry, and the newer handshake owns
+  // it. The older socket closing must not take the newer one's authorization
+  // state with it.
+  it('leaves the entry alone when a newer handshake has replaced it', () => {
+    const newerHandshake = pendingEntry({ handshakeId: 'request-b' });
+    getSocketConnections().set(TOKEN, [newerHandshake]);
+
+    handleConnectionCloseOnSocket(
+      'close',
+      closingSpark({ 'snyk-request-id': 'request-a' }),
+      TOKEN,
+      '',
+      false,
+    );
+
+    expect(getSocketConnections().get(TOKEN)).toEqual([newerHandshake]);
+  });
+
+  it('matches the role stored by authorize when the role header is absent', () => {
+    // authorize() stores '' when the client sends no role header.
+    getSocketConnections().set(TOKEN, [pendingEntry({ role: '' as Role })]);
+    const socket = sparkWithHeaders({
+      'x-snyk-broker-client-id': BROKER_CLIENT_ID,
+      'snyk-request-id': HANDSHAKE_ID,
+    });
+
+    handleConnectionCloseOnSocket('close', socket, TOKEN, '', false);
+
+    expect(getSocketConnections().has(TOKEN)).toBe(false);
+  });
+
+  it('leaves a live connection for the same client id in place', () => {
+    const liveEntry = pendingEntry({
+      socket: { end: () => undefined },
+      metadata: { version: '1.2.3', capabilities: ['test'] },
+    });
+    getSocketConnections().set(TOKEN, [liveEntry]);
+
+    handleConnectionCloseOnSocket('close', closingSpark(), TOKEN, '', false);
+
+    expect(getSocketConnections().get(TOKEN)).toEqual([liveEntry]);
+  });
+
+  it('preserves a pending reconnect when the old identified socket closes', () => {
+    const oldSocket = closingSpark({ 'snyk-request-id': 'request-a' });
+    const pendingReconnect = pendingEntry({
+      handshakeId: 'request-b',
+      handshakeStartTime: Date.now(),
+    });
+    const oldConnection = pendingEntry({
+      socket: oldSocket as unknown as { end() },
+      metadata: { version: '1.2.3', capabilities: ['test'] },
+      handshakeId: 'request-a',
+    });
+    getSocketConnections().set(TOKEN, [pendingReconnect, oldConnection]);
+
+    handleConnectionCloseOnSocket(
+      'close',
+      oldSocket,
+      TOKEN,
+      BROKER_CLIENT_ID,
+      true,
+    );
+
+    expect(getSocketConnections().get(TOKEN)).toEqual([pendingReconnect]);
+  });
+
+  it('removes the entry by socket identity when the client had identified', () => {
+    const identifiedSocket = closingSpark();
+    getSocketConnections().set(TOKEN, [
+      pendingEntry({
+        socket: identifiedSocket as unknown as { end() },
+        metadata: { version: '1.2.3', capabilities: ['test'] },
+      }),
+    ]);
+
+    handleConnectionCloseOnSocket('close', identifiedSocket, TOKEN, '', true);
+
+    expect(getSocketConnections().has(TOKEN)).toBe(false);
+    expect(clientDisconnected).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/lib/hybrid-sdk/server/socketHandlers/connectionHandler.test.ts
+++ b/test/unit/lib/hybrid-sdk/server/socketHandlers/connectionHandler.test.ts
@@ -1,0 +1,64 @@
+import { EventEmitter } from 'events';
+import { ISpark } from 'primus';
+
+jest.mock(
+  '../../../../../../lib/hybrid-sdk/server/socketHandlers/closeHandler',
+  () => ({ handleConnectionCloseOnSocket: jest.fn() }),
+);
+jest.mock(
+  '../../../../../../lib/hybrid-sdk/server/socketHandlers/identifyHandler',
+  () => ({ handleIdentifyOnSocket: jest.fn() }),
+);
+jest.mock('../../../../../../lib/hybrid-sdk/common/utils/metrics', () => ({
+  incrementSocketCloseReasonCount: jest.fn(),
+}));
+jest.mock(
+  '../../../../../../lib/hybrid-sdk/server/socketHandlers/terminateHandler',
+  () => ({ handleTerminationSignalOnSocket: jest.fn() }),
+);
+jest.mock(
+  '../../../../../../lib/hybrid-sdk/server/socketHandlers/errorHandler',
+  () => ({ handleSocketError: jest.fn() }),
+);
+
+import { incrementSocketCloseReasonCount } from '../../../../../../lib/hybrid-sdk/common/utils/metrics';
+import { handleSocketConnection } from '../../../../../../lib/hybrid-sdk/server/socketHandlers/connectionHandler';
+import { handleConnectionCloseOnSocket } from '../../../../../../lib/hybrid-sdk/server/socketHandlers/closeHandler';
+
+const TOKEN = 'test-token';
+
+const createSpark = (): ISpark => {
+  const socket = new EventEmitter() as EventEmitter & {
+    request: { uri: { pathname: string } };
+    send: jest.Mock;
+  };
+  socket.request = { uri: { pathname: `/primus/${TOKEN}/` } };
+  socket.send = jest.fn();
+  return socket as unknown as ISpark;
+};
+
+describe('handleSocketConnection terminal events', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('handles only the first terminal event for a socket', () => {
+    const socket = createSpark();
+    handleSocketConnection(socket);
+
+    (socket as unknown as EventEmitter).emit('close');
+    (socket as unknown as EventEmitter).emit('end');
+    (socket as unknown as EventEmitter).emit('timeout');
+
+    expect(incrementSocketCloseReasonCount).toHaveBeenCalledTimes(1);
+    expect(incrementSocketCloseReasonCount).toHaveBeenCalledWith('close');
+    expect(handleConnectionCloseOnSocket).toHaveBeenCalledTimes(1);
+    expect(handleConnectionCloseOnSocket).toHaveBeenCalledWith(
+      'close',
+      socket,
+      TOKEN,
+      null,
+      false,
+    );
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/main/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adds a 30 second prune timer for connections that initiate but never finish the handshake. Previously these incomplete connections would remain in memory indefinitely and return 503 errors unnecessarily. 

Also fixes a type error if a connection in the auth handler does not have metadata.
