### PR TITLE
fix: return retryable response during broker reconnect

### DIFF
--- a/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.ts
+++ b/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.ts
@@ -1,7 +1,11 @@
 import { NextFunction, Request, Response } from 'express';
 import { log as logger } from '../../../logs/logger';
 import { getDesensitizedToken } from '../utils/token';
-import { ClientSocket, getSocketConnections } from '../socket';
+import {
+  ClientSocket,
+  getSocketConnections,
+  wasRecentlyDisconnected,
+} from '../socket';
 import { incrementHttpRequestsTotal } from '../../common/utils/metrics';
 import { hostname } from 'node:os';
 import { URL, URLSearchParams } from 'node:url';
@@ -137,6 +141,15 @@ export const overloadHttpRequestWithConnectionDetailsMiddleware = async (
         return res.status(500).send('Error forwarding request to primary.');
       }
     } else {
+      if (wasRecentlyDisconnected(token)) {
+        logger.warn(
+          { desensitizedToken, requestId },
+          'No connection; client recently disconnected and may be reconnecting.',
+        );
+        res.setHeader('x-broker-failure', 'connection-not-ready');
+        res.setHeader('Retry-After', '1');
+        return res.status(503).json({ ok: false });
+      }
       logger.warn(
         { desensitizedToken, requestId },
         'No matching connection found.',

--- a/lib/hybrid-sdk/server/socket.ts
+++ b/lib/hybrid-sdk/server/socket.ts
@@ -33,9 +33,11 @@ const socketConnections = new Map<string, ClientSocket[]>();
 const RECONNECT_GRACE_MS = 60_000;
 const recentlyDisconnectedExpiryTimers = new Map<string, NodeJS.Timeout>();
 
-export const removeSocketConnection = (token: string) => {
-  socketConnections.delete(token);
-
+/**
+ * Starts or refreshes the reconnect grace period without changing the pool.
+ * A token can still have authorized handshakes even when it has no live socket.
+ */
+export const markRecentlyDisconnected = (token: string) => {
   const previousExpiryTimer = recentlyDisconnectedExpiryTimers.get(token);
   if (previousExpiryTimer) {
     clearTimeout(previousExpiryTimer);
@@ -48,6 +50,11 @@ export const removeSocketConnection = (token: string) => {
   }, RECONNECT_GRACE_MS);
   expiryTimer.unref();
   recentlyDisconnectedExpiryTimers.set(token, expiryTimer);
+};
+
+export const removeSocketConnection = (token: string) => {
+  socketConnections.delete(token);
+  markRecentlyDisconnected(token);
 };
 
 export const wasRecentlyDisconnected = (token: string): boolean =>

--- a/lib/hybrid-sdk/server/socket.ts
+++ b/lib/hybrid-sdk/server/socket.ts
@@ -30,6 +30,28 @@ export interface ClientSocket {
   handshakeId?: string;
 }
 const socketConnections = new Map<string, ClientSocket[]>();
+const RECONNECT_GRACE_MS = 60_000;
+const recentlyDisconnectedExpiryTimers = new Map<string, NodeJS.Timeout>();
+
+export const removeSocketConnection = (token: string) => {
+  socketConnections.delete(token);
+
+  const previousExpiryTimer = recentlyDisconnectedExpiryTimers.get(token);
+  if (previousExpiryTimer) {
+    clearTimeout(previousExpiryTimer);
+  }
+
+  const expiryTimer = setTimeout(() => {
+    if (recentlyDisconnectedExpiryTimers.get(token) === expiryTimer) {
+      recentlyDisconnectedExpiryTimers.delete(token);
+    }
+  }, RECONNECT_GRACE_MS);
+  expiryTimer.unref();
+  recentlyDisconnectedExpiryTimers.set(token, expiryTimer);
+};
+
+export const wasRecentlyDisconnected = (token: string): boolean =>
+  recentlyDisconnectedExpiryTimers.has(token);
 
 export const getSocketConnections = () => {
   return socketConnections;

--- a/lib/hybrid-sdk/server/socketHandlers/closeHandler.ts
+++ b/lib/hybrid-sdk/server/socketHandlers/closeHandler.ts
@@ -1,7 +1,11 @@
 import { decrementSocketConnectionGauge } from '../../common/utils/metrics';
 import { log as logger } from '../../../logs/logger';
 import { clientDisconnected } from '../infra/dispatcher';
-import { getSocketConnections, removePendingHandshake } from '../socket';
+import {
+  getSocketConnections,
+  removePendingHandshake,
+  removeSocketConnection,
+} from '../socket';
 import { getHandshakeIdentityFromHeaders } from '../auth/authHelpers';
 import { getDesensitizedToken } from '../utils/token';
 import { rmClientIdFromTerminationMap } from './identifyHandler';
@@ -36,7 +40,7 @@ export const handleConnectionCloseOnSocket = (
         connections.set(token, filteredClientPool);
       } else {
         logger.info({ maskedToken, hashedToken }, 'Removing client.');
-        connections.delete(token);
+        removeSocketConnection(token);
       }
       decrementSocketConnectionGauge();
       rmClientIdFromTerminationMap(token, clientId);

--- a/lib/hybrid-sdk/server/socketHandlers/closeHandler.ts
+++ b/lib/hybrid-sdk/server/socketHandlers/closeHandler.ts
@@ -3,6 +3,7 @@ import { log as logger } from '../../../logs/logger';
 import { clientDisconnected } from '../infra/dispatcher';
 import {
   getSocketConnections,
+  markRecentlyDisconnected,
   removePendingHandshake,
   removeSocketConnection,
 } from '../socket';
@@ -22,22 +23,22 @@ export const handleConnectionCloseOnSocket = (
     const { maskedToken, hashedToken } = getDesensitizedToken(token);
     if (identified) {
       const connections = getSocketConnections();
-      const clientPool = connections
-        .get(token)
-        ?.filter((_) => _.socket !== socket);
-      const filteredClientPool =
-        clientPool?.filter((_) => _.socket !== socket) || [];
+      const remainingConnections =
+        connections.get(token)?.filter((_) => _.socket !== socket) || [];
       logger.info(
         {
           closeReason,
           maskedToken,
           hashedToken,
-          remainingConnectionsCount: clientPool?.length || 0,
+          remainingConnectionsCount: remainingConnections.length,
         },
         'Client connection closed.',
       );
-      if (filteredClientPool?.length) {
-        connections.set(token, filteredClientPool);
+      if (remainingConnections.length) {
+        connections.set(token, remainingConnections);
+        if (!remainingConnections.some((connection) => connection.socket)) {
+          markRecentlyDisconnected(token);
+        }
       } else {
         logger.info({ maskedToken, hashedToken }, 'Removing client.');
         removeSocketConnection(token);

--- a/test/functional/server-reconnect.test.ts
+++ b/test/functional/server-reconnect.test.ts
@@ -1,0 +1,54 @@
+import path from 'path';
+import { axiosClient } from '../setup/axios-client';
+import {
+  BrokerClient,
+  closeBrokerClient,
+  createBrokerClient,
+} from '../setup/broker-client';
+import {
+  BrokerServer,
+  closeBrokerServer,
+  createBrokerServer,
+  waitForBrokerClientConnections,
+} from '../setup/broker-server';
+
+const fixtures = path.resolve(__dirname, '..', 'fixtures');
+const serverAccept = path.join(fixtures, 'server', 'filters.json');
+const clientAccept = path.join(fixtures, 'client', 'filters.json');
+
+describe('broker client reconnect window', () => {
+  let bs: BrokerServer;
+  let bc: BrokerClient;
+
+  beforeAll(async () => {
+    bs = await createBrokerServer({ filters: serverAccept });
+  });
+
+  afterAll(async () => {
+    await closeBrokerClient(bc);
+    await closeBrokerServer(bs);
+  });
+
+  it('returns a retryable response immediately after a client disconnected', async () => {
+    const brokerToken = 'recently-disconnected-token';
+    bc = await createBrokerClient({
+      brokerServerUrl: `http://localhost:${bs.port}`,
+      brokerToken,
+      filters: clientAccept,
+    });
+    await waitForBrokerClientConnections(bs, 2);
+    await closeBrokerClient(bc);
+
+    const response = await axiosClient.post(
+      `http://localhost:${bs.port}/broker/${brokerToken}/echo-body`,
+      {},
+    );
+
+    expect(response.status).toEqual(503);
+    expect(response.data).toStrictEqual({ ok: false });
+    expect(response.headers['x-broker-failure']).toEqual(
+      'connection-not-ready',
+    );
+    expect(response.headers['retry-after']).toEqual('1');
+  });
+});

--- a/test/unit/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.test.ts
+++ b/test/unit/lib/hybrid-sdk/server/routesHandlers/httpRequestHandler.test.ts
@@ -1,5 +1,8 @@
 import { overloadHttpRequestWithConnectionDetailsMiddleware } from '../../../../../../lib/hybrid-sdk/server/routesHandlers/httpRequestHandler';
-import { getSocketConnections } from '../../../../../../lib/hybrid-sdk/server/socket';
+import {
+  getSocketConnections,
+  wasRecentlyDisconnected,
+} from '../../../../../../lib/hybrid-sdk/server/socket';
 import { makeStreamingRequestToDownstream } from '../../../../../../lib/hybrid-sdk/http/request';
 import { hostname } from 'node:os';
 import { NextFunction } from 'express';
@@ -13,6 +16,7 @@ jest.mock('node:os', () => ({
 }));
 
 const mockedGetSocketConnections = getSocketConnections as jest.Mock;
+const mockedWasRecentlyDisconnected = wasRecentlyDisconnected as jest.Mock;
 const mockedMakeStreamingRequest =
   makeStreamingRequestToDownstream as jest.Mock;
 const mockedHostname = hostname as jest.Mock;
@@ -24,6 +28,7 @@ describe('overloadHttpRequestWithConnectionDetailsMiddleware', () => {
     jest.resetAllMocks();
     next = jest.fn();
     mockedHostname.mockReturnValue('broker-snyk-server-v2-0-0');
+    mockedWasRecentlyDisconnected.mockReturnValue(false);
     delete process.env.BROKER_SERVER_MANDATORY_AUTH_ENABLED;
   });
 
@@ -32,6 +37,7 @@ describe('overloadHttpRequestWithConnectionDetailsMiddleware', () => {
   });
 
   it('should return 404 if no connections are found for the token', async () => {
+    mockedWasRecentlyDisconnected.mockReturnValue(false);
     mockedGetSocketConnections.mockReturnValue(new Map());
     const req = httpMocks.createRequest({
       params: { token: 'test-token' },
@@ -44,6 +50,24 @@ describe('overloadHttpRequestWithConnectionDetailsMiddleware', () => {
     expect(res.statusCode).toBe(404);
     expect(res._getJSONData()).toEqual({ ok: false });
     expect(res.getHeader('x-broker-failure')).toBe('no-connection');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should return 503 when the token was recently disconnected', async () => {
+    mockedGetSocketConnections.mockReturnValue(new Map());
+    mockedWasRecentlyDisconnected.mockReturnValue(true);
+    const req = httpMocks.createRequest({
+      params: { token: 'test-token' },
+      url: '/broker/test-token/some/path',
+    });
+    const res = httpMocks.createResponse();
+
+    await overloadHttpRequestWithConnectionDetailsMiddleware(req, res, next);
+
+    expect(res.statusCode).toBe(503);
+    expect(res._getJSONData()).toEqual({ ok: false });
+    expect(res.getHeader('x-broker-failure')).toBe('connection-not-ready');
+    expect(res.getHeader('Retry-After')).toBe('1');
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -400,8 +424,9 @@ describe('overloadHttpRequestWithConnectionDetailsMiddleware', () => {
       expect(next).not.toHaveBeenCalled();
     });
 
-    it('should relay a successful response from primary (legacy token found)', async () => {
+    it('should still forward to primary when a secondary pod was recently disconnected', async () => {
       mockedHostname.mockReturnValue('broker-snyk-server-v2-5-1');
+      mockedWasRecentlyDisconnected.mockReturnValue(true);
       const mockPipe = jest.fn();
       mockedMakeStreamingRequest.mockResolvedValue({
         statusCode: 200,

--- a/test/unit/lib/hybrid-sdk/server/socket.test.ts
+++ b/test/unit/lib/hybrid-sdk/server/socket.test.ts
@@ -4,6 +4,8 @@ import {
   findClientToRefreshCreds,
   getSocketConnections,
   removePendingHandshake,
+  removeSocketConnection,
+  wasRecentlyDisconnected,
 } from '../../../../../lib/hybrid-sdk/server/socket';
 import { HandshakeIdentity } from '../../../../../lib/hybrid-sdk/server/auth/authHelpers';
 import { Role } from '../../../../../lib/hybrid-sdk/client/types/client';
@@ -190,5 +192,47 @@ describe('removePendingHandshake', () => {
 
   it('does nothing when the token has no pool', () => {
     expect(removePendingHandshake(TOKEN, identity())).toBe(false);
+  });
+});
+
+describe('recently disconnected socket connections', () => {
+  const token = 'test-token';
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    getSocketConnections().clear();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    getSocketConnections().clear();
+  });
+
+  it('removes the pool, marks the token, and expires the mark', () => {
+    getSocketConnections().set(token, []);
+
+    removeSocketConnection(token);
+
+    expect(getSocketConnections().has(token)).toBe(false);
+    expect(wasRecentlyDisconnected(token)).toBe(true);
+
+    jest.advanceTimersByTime(60_001);
+
+    expect(wasRecentlyDisconnected(token)).toBe(false);
+  });
+
+  it('refreshes the full grace period when a token disconnects again', () => {
+    removeSocketConnection(token);
+    jest.advanceTimersByTime(30_000);
+
+    removeSocketConnection(token);
+    jest.advanceTimersByTime(30_001);
+
+    expect(wasRecentlyDisconnected(token)).toBe(true);
+
+    jest.advanceTimersByTime(30_000);
+
+    expect(wasRecentlyDisconnected(token)).toBe(false);
   });
 });

--- a/test/unit/lib/hybrid-sdk/server/socket.test.ts
+++ b/test/unit/lib/hybrid-sdk/server/socket.test.ts
@@ -3,6 +3,7 @@ import {
   ClientSocket,
   findClientToRefreshCreds,
   getSocketConnections,
+  markRecentlyDisconnected,
   removePendingHandshake,
   removeSocketConnection,
   wasRecentlyDisconnected,
@@ -222,11 +223,21 @@ describe('recently disconnected socket connections', () => {
     expect(wasRecentlyDisconnected(token)).toBe(false);
   });
 
-  it('refreshes the full grace period when a token disconnects again', () => {
-    removeSocketConnection(token);
+  it('marks a token without removing its connection pool', () => {
+    const pendingReconnect = pendingEntry();
+    getSocketConnections().set(token, [pendingReconnect]);
+
+    markRecentlyDisconnected(token);
+
+    expect(getSocketConnections().get(token)).toEqual([pendingReconnect]);
+    expect(wasRecentlyDisconnected(token)).toBe(true);
+  });
+
+  it('refreshes the full grace period when a token is marked again', () => {
+    markRecentlyDisconnected(token);
     jest.advanceTimersByTime(30_000);
 
-    removeSocketConnection(token);
+    markRecentlyDisconnected(token);
     jest.advanceTimersByTime(30_001);
 
     expect(wasRecentlyDisconnected(token)).toBe(true);

--- a/test/unit/lib/hybrid-sdk/server/socketHandlers/closeHandler.test.ts
+++ b/test/unit/lib/hybrid-sdk/server/socketHandlers/closeHandler.test.ts
@@ -16,6 +16,7 @@ import { clientDisconnected } from '../../../../../../lib/hybrid-sdk/server/infr
 import {
   ClientSocket,
   getSocketConnections,
+  wasRecentlyDisconnected,
 } from '../../../../../../lib/hybrid-sdk/server/socket';
 import { Role } from '../../../../../../lib/hybrid-sdk/client/types/client';
 
@@ -47,10 +48,13 @@ const pendingEntry = (overrides: Partial<ClientSocket> = {}): ClientSocket => ({
 
 describe('handleConnectionCloseOnSocket', () => {
   beforeEach(() => {
+    jest.useFakeTimers();
     jest.clearAllMocks();
     getSocketConnections().clear();
   });
   afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
     getSocketConnections().clear();
   });
 
@@ -62,6 +66,7 @@ describe('handleConnectionCloseOnSocket', () => {
     handleConnectionCloseOnSocket('close', closingSpark(), TOKEN, '', false);
 
     expect(getSocketConnections().has(TOKEN)).toBe(false);
+    expect(wasRecentlyDisconnected(TOKEN)).toBe(false);
     expect(clientDisconnected).not.toHaveBeenCalled();
   });
 
@@ -108,8 +113,11 @@ describe('handleConnectionCloseOnSocket', () => {
     expect(getSocketConnections().get(TOKEN)).toEqual([liveEntry]);
   });
 
-  it('preserves a pending reconnect when the old identified socket closes', () => {
+  it('retains the disconnect marker when a pending reconnect also closes', () => {
     const oldSocket = closingSpark({ 'snyk-request-id': 'request-a' });
+    const reconnectingSocket = closingSpark({
+      'snyk-request-id': 'request-b',
+    });
     const pendingReconnect = pendingEntry({
       handshakeId: 'request-b',
       handshakeStartTime: Date.now(),
@@ -130,6 +138,47 @@ describe('handleConnectionCloseOnSocket', () => {
     );
 
     expect(getSocketConnections().get(TOKEN)).toEqual([pendingReconnect]);
+    expect(wasRecentlyDisconnected(TOKEN)).toBe(true);
+
+    handleConnectionCloseOnSocket(
+      'close',
+      reconnectingSocket,
+      TOKEN,
+      '',
+      false,
+    );
+
+    expect(getSocketConnections().has(TOKEN)).toBe(false);
+    expect(wasRecentlyDisconnected(TOKEN)).toBe(true);
+  });
+
+  it('does not mark the token when another live socket remains', () => {
+    const closingSocket = closingSpark({ 'snyk-request-id': 'request-a' });
+    const remainingSocket = closingSpark({
+      'snyk-request-id': 'request-b',
+    });
+    const closingConnection = pendingEntry({
+      socket: closingSocket as unknown as { end() },
+      metadata: { version: '1.2.3', capabilities: ['test'] },
+      handshakeId: 'request-a',
+    });
+    const remainingConnection = pendingEntry({
+      socket: remainingSocket as unknown as { end() },
+      metadata: { version: '1.2.3', capabilities: ['test'] },
+      handshakeId: 'request-b',
+    });
+    getSocketConnections().set(TOKEN, [closingConnection, remainingConnection]);
+
+    handleConnectionCloseOnSocket(
+      'close',
+      closingSocket,
+      TOKEN,
+      BROKER_CLIENT_ID,
+      true,
+    );
+
+    expect(getSocketConnections().get(TOKEN)).toEqual([remainingConnection]);
+    expect(wasRecentlyDisconnected(TOKEN)).toBe(false);
   });
 
   it('removes the entry by socket identity when the client had identified', () => {


### PR DESCRIPTION
## Summary

When a Broker client's last live websocket connection to a Broker server instance closes, routing can briefly continue sending requests to that instance while the client reconnects. Requests arriving during this window find no usable local connection and receive a `404`, incorrectly representing a temporary connection gap as a permanent failure.

This PR fixes this by returning a retryable `503` during this window, signalling that the failure is temporary. It also handles reconnects that are authorized but close before identifying by distinguishing pending handshakes from live websocket connections.

The overall flow is now this:

```
 Last live socket closes
     ↓
 Active socket is removed
     ↓
 Token is marked as recently disconnected for 60 seconds,
 even if a pending handshake remains
     ↓
 Request arrives without a usable connection
     ├─ Token was recently disconnected or is still reconnecting → Return 503 (safe to retry)
     └─ Token is unknown or the window expired → Return the existing 404
```

This distinction prevents a temporary reconnect window, including a reconnect that fails before identifying, from looking like a permanently unknown Broker token.

## Changes made

- Track recently disconnected Broker tokens for 60 seconds.
- Distinguish live websocket connections from authorized but unidentified pending handshakes.
- Retain the disconnect marker when the last live socket closes, even if a pending handshake remains.
- Return `503` with `Retry-After: 1` and `x-broker-failure: connection-not-ready` during the reconnect window.
- Preserve the existing `404 no-connection` response for unknown or long-disconnected tokens.
- Preserve secondary-to-primary request forwarding.
- Add unit and functional coverage for disconnect expiry, repeated disconnects, failed pending reconnects, surviving live sockets, forwarding, and the retryable response.
