### PR TITLE
fix: gitlab universal systemcheck auth header [ACC-3491]

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -372,16 +372,16 @@
     "gitlab": {
       "validations": [
         {
-          "url": "https://$GITLAB/api/v3/user",
+          "url": "https://$GITLAB/api/v4/user",
           "auth": {
             "type": "header",
-            "name": "private_token",
+            "name": "private-token",
             "value": "$GITLAB_TOKEN"
           }
         }
       ],
       "default": {
-        "BROKER_CLIENT_VALIDATION_URL": "https://$GITLAB/api/v3/user?private_token=$GITLAB_TOKEN",
+        "BROKER_CLIENT_VALIDATION_URL": "https://$GITLAB/api/v4/user?private_token=$GITLAB_TOKEN",
         "GIT_URL": "$GITLAB",
         "GIT_USERNAME": "oauth2",
         "GIT_PASSWORD": "$GITLAB_TOKEN",

--- a/config.default.jsontest
+++ b/config.default.jsontest
@@ -345,16 +345,16 @@
     "gitlab": {
       "validations": [
         {
-          "url": "https://$GITLAB/api/v3/user",
+          "url": "https://$GITLAB/api/v4/user",
           "auth": {
             "type": "header",
-            "name": "private_token",
+            "name": "private-token",
             "value": "$GITLAB_TOKEN"
           }
         }
       ],
       "default": {
-        "BROKER_CLIENT_VALIDATION_URL": "https://$GITLAB/api/v3/user?private_token=$GITLAB_TOKEN",
+        "BROKER_CLIENT_VALIDATION_URL": "https://$GITLAB/api/v4/user?private_token=$GITLAB_TOKEN",
         "GIT_URL": "$GITLAB",
         "GIT_USERNAME": "oauth2",
         "GIT_PASSWORD": "$GITLAB_TOKEN",

--- a/lib/hybrid-sdk/client/types/config.ts
+++ b/lib/hybrid-sdk/client/types/config.ts
@@ -51,6 +51,7 @@ export interface ConnectionValidation {
 
 export interface ConnectionHeaderAuth {
   type: 'header';
+  name?: string;
   value: string;
 }
 

--- a/lib/hybrid-sdk/client/utils/connectionValidation.ts
+++ b/lib/hybrid-sdk/client/utils/connectionValidation.ts
@@ -24,7 +24,7 @@ export const validateConnection = async (config: ConnectionConfig) => {
         ).toString('base64')}`;
         break;
       case 'header':
-        headers['Authorization'] = `${auth.value}`;
+        headers[auth.name ?? 'Authorization'] = `${auth.value}`;
         break;
       default: {
         const parsed = parse(url);

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepare:templates": "rm -rf ./dist/client-templates && cp -Rf ./client-templates ./dist",
     "start": "node .",
     "dev": "tsc-watch --project tsconfig.json --onSuccess 'node .' | ./node_modules/.bin/bunyan",
-    "dev:client": "LOG_LEVEL=debug NODE_ENV=development tsc-watch --project tsconfig.json --onSuccess 'node dist/cli/index.js client' | ./node_modules/.bin/bunyan",
+    "dev:client": "NODE_ENV=development tsc-watch --project tsconfig.json --onSuccess 'node --env-file-if-exists=.env dist/cli/index.js client' | ./node_modules/.bin/bunyan",
     "dev:client-to-local-server": "BROKER_SERVER_URL=http://localhost:9000 USE_LOCAL_BACKEND='true' LOG_LEVEL=debug PORT=9001 NODE_ENV=development tsc-watch --project tsconfig.json --onSuccess 'node dist/cli/index.js client' | ./node_modules/.bin/bunyan",
     "dev:client2-to-local-server": "BROKER_SERVER_URL=http://localhost:9000 USE_LOCAL_BACKEND='true' LOG_LEVEL=debug PORT=9002 NODE_ENV=development tsc-watch --project tsconfig.json --onSuccess 'node dist/cli/index.js client' | ./node_modules/.bin/bunyan",
     "dev:server": "LOG_LEVEL=debug PORT=9000 ACCEPT=accept-server.local.json NODE_ENV=development tsc-watch --project tsconfig.json --onSuccess 'node dist/cli/index.js server' | ./node_modules/.bin/bunyan",

--- a/test/unit/connectionValidation.test.ts
+++ b/test/unit/connectionValidation.test.ts
@@ -1,43 +1,101 @@
+import nock from 'nock';
 import { validateConnection } from '../../lib/hybrid-sdk/client/utils/connectionValidation';
 import { ConnectionConfig } from '../../lib/hybrid-sdk/client/types/config';
 
-const nock = require('nock');
-
-describe('validateConnection (credentials-in-url)', () => {
+describe('client/utils/connectionValidation.ts', () => {
   afterEach(() => {
     nock.cleanAll();
   });
 
-  it('does not mutate the connection config and keeps sending credentials across repeated calls', async () => {
-    const originalUrl =
-      'https://user:name@nexus.local/service/rest/v1/status/check';
-    const expectedAuth = `Basic ${Buffer.from('user:name').toString('base64')}`;
-    nock('https://nexus.local')
-      .persist()
-      .matchHeader('authorization', expectedAuth)
-      .get('/service/rest/v1/status/check')
-      .reply(() => [200, 'nexus - ok']);
-    nock('https://nexus.local')
-      .persist()
-      .get('/service/rest/v1/status/check')
-      .reply(() => [401, 'nexus - missing credentials']);
+  describe('validateConnection()', () => {
+    it('should not mutate the connection config and should keep sending credentials across repeated calls', async () => {
+      const originalUrl =
+        'https://user:name@nexus.local/service/rest/v1/status/check';
+      const expectedAuth = `Basic ${Buffer.from('user:name').toString(
+        'base64',
+      )}`;
+      const scope = nock('https://nexus.local')
+        .matchHeader('authorization', expectedAuth)
+        .get('/service/rest/v1/status/check')
+        .twice()
+        .reply(() => [200, 'nexus - ok']);
 
-    const config = {
-      validations: [{ url: originalUrl }],
-    } as unknown as ConnectionConfig;
+      const config = {
+        validations: [{ url: originalUrl }],
+      } as unknown as ConnectionConfig;
 
-    const first = await validateConnection(config);
-    const second = await validateConnection(config);
+      const first = await validateConnection(config);
+      const second = await validateConnection(config);
+      scope.done();
 
-    // The shared config's url must be left untouched — this is the mutation
-    // the fix prevents.
-    expect(config.validations[0].url).toBe(originalUrl);
+      // The shared config's url must be left untouched — this is the mutation
+      // the fix prevents.
+      expect(config.validations[0].url).toBe(originalUrl);
 
-    // Both calls authenticate (200 requires the matchHeader interceptor).
-    // Before the fix, the second call would be 401 -> passing false.
-    expect(first.passing).toBe(true);
-    expect(second.passing).toBe(true);
-    expect((first.data[0] as any).statusCode).toBe(200);
-    expect((second.data[0] as any).statusCode).toBe(200);
+      // Both calls authenticate (200 requires the matchHeader interceptor).
+      // Before the fix, the second call would be 401 -> passing false.
+      expect(first.passing).toBe(true);
+      expect(second.passing).toBe(true);
+      expect((first.data[0] as any).statusCode).toBe(200);
+      expect((second.data[0] as any).statusCode).toBe(200);
+    });
+
+    it('should use the configured header name', async () => {
+      let receivedHeaders: Record<string, string> | undefined;
+      const scope = nock('https://gitlab.local')
+        .get('/api/v4/user')
+        .reply(function (this: any) {
+          receivedHeaders = this.req.headers;
+          return [200, 'gitlab - ok'];
+        });
+
+      const config = {
+        validations: [
+          {
+            url: 'https://gitlab.local/api/v4/user',
+            auth: {
+              type: 'header',
+              name: 'private-token',
+              value: 'gitlab-token',
+            },
+          },
+        ],
+      } as ConnectionConfig;
+
+      const result = await validateConnection(config);
+      scope.done();
+
+      expect(result.passing).toBe(true);
+      expect(receivedHeaders?.['private-token']).toBe('gitlab-token');
+      expect(receivedHeaders?.authorization).toBeUndefined();
+    });
+
+    it('should default to the Authorization header when no name is configured', async () => {
+      let receivedHeaders: Record<string, string> | undefined;
+      const scope = nock('https://github.local')
+        .get('/user')
+        .reply(function (this: any) {
+          receivedHeaders = this.req.headers;
+          return [200, 'github - ok'];
+        });
+
+      const config = {
+        validations: [
+          {
+            url: 'https://github.local/user',
+            auth: {
+              type: 'header',
+              value: 'token github-token',
+            },
+          },
+        ],
+      } as ConnectionConfig;
+
+      const result = await validateConnection(config);
+      scope.done();
+
+      expect(result.passing).toBe(true);
+      expect(receivedHeaders?.authorization).toBe('token github-token');
+    });
   });
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/main/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR fixs GitLab Universal Broker systemchecks returning `401 Unauthorized`.

Universal connection validation supports header-based authentication, including a configurable header name. However, `validateConnection()` ignored that name and always sent the configured value through the `Authorization` header.

The GitLab validation configuration provides a personal access token using the `private-token` header. The systemcheck therefore sent:

```
Authorization: <gitlab-token>

instead of:

private-token: <gitlab-token>
```

Additionally:

  - the validation configuration also used the removed GitLab API v3 endpoint, while the default GitLab filters use /api/v4/user.
  - replace the CommonJS Nock require with a typed ES import.
  - replace the persistent repeated-request mock with an exact `.twice()` expectation ([nock docs](https://github.com/nock/nock#expectations))
