### PR TITLE
fix: unify bearer auth for universal PAT system checks [ACC-3491]

### DIFF
--- a/lib/hybrid-sdk/common/config/universal.ts
+++ b/lib/hybrid-sdk/common/config/universal.ts
@@ -38,43 +38,16 @@ export const getConfigForConnectionsFromConfig = (config) => {
 };
 
 export const getConfigForConnection = (key, config): ConnectionConfig => {
-  const connectionConfig: ConnectionConfig = {
-    ...getConfigForType(config.connections[key].type),
-    ...config.connections[key],
+  const connection = config.connections[key];
+  return {
+    ...getConfigForType(connection.type),
+    ...connection,
     ...getValidationConfigForType(
-      determineFilterType(config.connections[key].type, config),
+      determineFilterType(connection.type, connection),
     ),
   };
-
-  // If it's a Bitbucket Server connection and a PAT is provided,
-  // override the validation auth to use Bearer token.
-  // This ensures system checks use the PAT instead of defaulting to basic auth.
-  if (
-    connectionConfig.type === 'bitbucket-server' &&
-    connectionConfig.BITBUCKET_PAT &&
-    connectionConfig.validations &&
-    Array.isArray(connectionConfig.validations)
-  ) {
-    logger.debug(
-      { connectionName: key },
-      'Bitbucket Server connection with PAT found. Modifying validation auth to use Bearer token.',
-    );
-    connectionConfig.validations = connectionConfig.validations.map(
-      (validation) => {
-        // Preserve other validation properties, override auth
-        return {
-          ...validation,
-          auth: {
-            type: 'header',
-            value: `Bearer ${connectionConfig.BITBUCKET_PAT}`,
-          },
-        };
-      },
-    );
-  }
-
-  return connectionConfig;
 };
+
 export const getValidationConfigForType = (type) => {
   const config = getConfig();
   return {

--- a/test/unit/lib/hybrid-sdk/common/config/universal.test.ts
+++ b/test/unit/lib/hybrid-sdk/common/config/universal.test.ts
@@ -1,0 +1,69 @@
+import { loadBrokerConfig } from '../../../../../../lib/hybrid-sdk/common/config/config';
+import { getConfigForConnection } from '../../../../../../lib/hybrid-sdk/common/config/universal';
+
+describe('common/config/universal.ts', () => {
+  beforeAll(async () => {
+    await loadBrokerConfig();
+  });
+
+  describe('getConfigForConnection()', () => {
+    const getValidationAuth = (
+      type: string,
+      credentials: Record<string, string>,
+    ) => {
+      const config = {
+        connections: {
+          connection: { type, ...credentials },
+        },
+      };
+
+      return getConfigForConnection('connection', config).validations?.[0].auth;
+    };
+
+    it('should use basic auth for a Jira connection without a PAT', () => {
+      expect(
+        getValidationAuth('jira', {
+          JIRA_USERNAME: 'jira-user',
+          JIRA_PASSWORD: 'jira-password',
+        }),
+      ).toEqual({
+        type: 'basic',
+        username: '$JIRA_USERNAME',
+        password: '$JIRA_PASSWORD',
+      });
+    });
+
+    it('should use bearer auth for a Jira connection with a PAT', () => {
+      expect(getValidationAuth('jira', { JIRA_PAT: 'jira-pat' })).toEqual({
+        type: 'header',
+        name: 'Authorization',
+        value: 'Bearer $JIRA_PAT',
+      });
+    });
+
+    it('should use basic auth for a Bitbucket Server connection without a PAT', () => {
+      expect(
+        getValidationAuth('bitbucket-server', {
+          BITBUCKET_USERNAME: 'bitbucket-user',
+          BITBUCKET_PASSWORD: 'bitbucket-password',
+        }),
+      ).toEqual({
+        type: 'basic',
+        username: '$BITBUCKET_USERNAME',
+        password: '$BITBUCKET_PASSWORD',
+      });
+    });
+
+    it('should use bearer auth for a Bitbucket Server connection with a PAT', () => {
+      expect(
+        getValidationAuth('bitbucket-server', {
+          BITBUCKET_PAT: 'bitbucket-pat',
+        }),
+      ).toEqual({
+        type: 'header',
+        name: 'Authorization',
+        value: 'Bearer $BITBUCKET_PAT',
+      });
+    });
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/main/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR unify PAT system checks for UB and fixes Jira PAT system check.

Universal connection validation passed the top-level configuration to `determineFilterType()`. As a result, it could not detect `JIRA_PAT` on the individual connection and selected Jira's basic-auth validation, causing the system check to return 401.

Bitbucket Server PAT validation worked only because of a separate, Bitbucket-specific auth override.

Fixes:

  - pass the individual connection configuration to `determineFilterType()`.
  - select the existing bearer-auth validation definitions for Jira and Bitbucket Server PAT connections.
  - remove the Bitbucket-specific validation override.
  - preserve Basic-auth validation for connections without a PAT.
  - ddd regression coverage for Jira and Bitbucket Server with both Basic and PAT authentication.