### PR TITLE
feat: bgd primary registration [ACC-3572]

### DIFF
--- a/lib/hybrid-sdk/server/infra/dispatcher.ts
+++ b/lib/hybrid-sdk/server/infra/dispatcher.ts
@@ -168,61 +168,24 @@ export let serverStopping;
 const config = getConfig();
 
 if (config.dispatcherUrl) {
-  const serverId = config.hostname?.substring(
-    config.hostname?.lastIndexOf('-') + 1,
-  );
-
-  const kc = new DispatcherClient(
+  const useGatewayDispatcher = config.useGatewayDispatcher === 'true';
+  const serverId = useGatewayDispatcher
+    ? config.hostname
+    : config.hostname?.substring(config.hostname?.lastIndexOf('-') + 1);
+  const dispatcherClient = new DispatcherClient(
     config.dispatcherUrl,
     config.hostname,
     serverId,
     config.dispatcherVersion,
-    'node-dispatcher',
+    useGatewayDispatcher ? 'envoy-dispatcher' : 'node-dispatcher',
   );
 
-  // Optional dual-write to the broker-gateway (Go) dispatcher. When
-  // GATEWAY_DISPATCHER_URL is set, each lifecycle event is mirrored so the new
-  // dispatcher's Redis state is populated ahead of a read-path cutover. Unlike
-  // the node dispatcher (which registers the truncated pod ordinal), the gateway
-  // registers the FULL pod name (config.hostname) as its server id, so the envoy
-  // sidecar can resolve the exact pod FQDN from Redis alone — no token-hash
-  // sharding, any pod count. The version defaults to the primary's and only needs
-  // overriding if the two dispatchers' API versions ever diverge.
-  const gatewayClient = config.gatewayDispatcherUrl
-    ? new DispatcherClient(
-        config.gatewayDispatcherUrl,
-        config.hostname,
-        config.hostname,
-        config.gatewayDispatcherVersion || config.dispatcherVersion,
-        'envoy-dispatcher',
-      )
-    : undefined;
-
-  // The mirror is fire-and-forget: we never await it on the primary path, so a
-  // slow or unhealthy gateway cannot add latency to (or fail) the primary write.
-  // DispatcherClient already swallows its own errors, so the promise resolves
-  // even on failure; the guard catch is belt-and-braces against a synchronous
-  // throw (e.g. URL construction) becoming an unhandledRejection.
-  const mirror = (write?: Promise<void>) => {
-    void write?.catch(() => {});
-  };
-
   clientConnected = async function (token, clientId, clientVersion) {
-    mirror(gatewayClient?.clientConnected(token, clientId, clientVersion));
-    await kc.clientConnected(token, clientId, clientVersion);
+    await dispatcherClient.clientConnected(token, clientId, clientVersion);
   };
 
   clientPinged = async function (token, clientId, clientVersion, time) {
-    mirror(
-      gatewayClient?.clientConnected(
-        token,
-        clientId,
-        clientVersion,
-        'client-pinged',
-        time,
-      ),
-    );
-    await kc.clientConnected(
+    await dispatcherClient.clientConnected(
       token,
       clientId,
       clientVersion,
@@ -232,20 +195,15 @@ if (config.dispatcherUrl) {
   };
 
   clientDisconnected = async function (token, clientId) {
-    mirror(gatewayClient?.clientDisconnected(token, clientId));
-    await kc.clientDisconnected(token, clientId);
+    await dispatcherClient.clientDisconnected(token, clientId);
   };
 
   serverStarting = async function () {
-    mirror(gatewayClient?.serverStarting());
-    await kc.serverStarting();
+    await dispatcherClient.serverStarting();
   };
 
   serverStopping = async function (cb) {
-    // Primary owns the shutdown callback; mirror with a no-op so the gateway
-    // write cannot influence shutdown.
-    mirror(gatewayClient?.serverStopping(() => {}));
-    await kc.serverStopping(cb);
+    await dispatcherClient.serverStopping(cb);
   };
 } else {
   logger.error(

--- a/lib/hybrid-sdk/server/infra/dispatcher.ts
+++ b/lib/hybrid-sdk/server/infra/dispatcher.ts
@@ -168,24 +168,61 @@ export let serverStopping;
 const config = getConfig();
 
 if (config.dispatcherUrl) {
-  const useGatewayDispatcher = config.useGatewayDispatcher === 'true';
-  const serverId = useGatewayDispatcher
-    ? config.hostname
-    : config.hostname?.substring(config.hostname?.lastIndexOf('-') + 1);
-  const dispatcherClient = new DispatcherClient(
+  const serverId = config.hostname?.substring(
+    config.hostname?.lastIndexOf('-') + 1,
+  );
+
+  const kc = new DispatcherClient(
     config.dispatcherUrl,
     config.hostname,
     serverId,
     config.dispatcherVersion,
-    useGatewayDispatcher ? 'envoy-dispatcher' : 'node-dispatcher',
+    'node-dispatcher',
   );
 
+  // Optional dual-write to the broker-gateway (Go) dispatcher. When
+  // GATEWAY_DISPATCHER_URL is set, each lifecycle event is mirrored so the new
+  // dispatcher's Redis state is populated ahead of a read-path cutover. Unlike
+  // the node dispatcher (which registers the truncated pod ordinal), the gateway
+  // registers the FULL pod name (config.hostname) as its server id, so the envoy
+  // sidecar can resolve the exact pod FQDN from Redis alone — no token-hash
+  // sharding, any pod count. The version defaults to the primary's and only needs
+  // overriding if the two dispatchers' API versions ever diverge.
+  const gatewayClient = config.gatewayDispatcherUrl
+    ? new DispatcherClient(
+        config.gatewayDispatcherUrl,
+        config.hostname,
+        config.hostname,
+        config.gatewayDispatcherVersion || config.dispatcherVersion,
+        'envoy-dispatcher',
+      )
+    : undefined;
+
+  // When BGD is configured it is the awaited primary write path. The legacy
+  // dispatcher remains a fire-and-forget mirror during the migration.
+  const mirror = (write?: Promise<void>) => {
+    void write?.catch(() => {});
+  };
+
+  const primaryClient = gatewayClient || kc;
+  const mirrorClient = gatewayClient ? kc : undefined;
+
   clientConnected = async function (token, clientId, clientVersion) {
-    await dispatcherClient.clientConnected(token, clientId, clientVersion);
+    mirror(mirrorClient?.clientConnected(token, clientId, clientVersion));
+    await primaryClient.clientConnected(token, clientId, clientVersion);
   };
 
   clientPinged = async function (token, clientId, clientVersion, time) {
-    await dispatcherClient.clientConnected(
+    mirror(
+      mirrorClient?.clientConnected(
+        token,
+        clientId,
+        clientVersion,
+        'client-pinged',
+        time,
+      ),
+    );
+    await primaryClient.clientConnected(
       token,
       clientId,
       clientVersion,
@@ -195,15 +232,18 @@ if (config.dispatcherUrl) {
   };
 
   clientDisconnected = async function (token, clientId) {
-    await dispatcherClient.clientDisconnected(token, clientId);
+    mirror(mirrorClient?.clientDisconnected(token, clientId));
+    await primaryClient.clientDisconnected(token, clientId);
   };
 
   serverStarting = async function () {
-    await dispatcherClient.serverStarting();
+    mirror(mirrorClient?.serverStarting());
+    await primaryClient.serverStarting();
   };
 
   serverStopping = async function (cb) {
-    await dispatcherClient.serverStopping(cb);
+    mirror(mirrorClient?.serverStopping(() => {}));
+    await primaryClient.serverStopping(cb);
   };
 } else {
   logger.error(

--- a/test/functional/dispatcher-server-api.test.ts
+++ b/test/functional/dispatcher-server-api.test.ts
@@ -184,15 +184,28 @@ describe('Broker Server Dispatcher API interaction', () => {
   });
 });
 
-describe('Broker Server selectable dispatcher', () => {
-  const dispatcherUrl = 'http://configured-dispatcher';
-  const token = 'token';
+describe('Broker Server Dispatcher dual-write to gateway', () => {
+  const apiVersion = '2022-12-02%7Eexperimental';
+  const token = 'broker-test-token';
   const hashedToken = hashToken(token);
-  const clientId = 'client-id';
-  const clientVersion = '1.2.3';
-  const apiVersion = '2022-12-02~experimental';
-  const podName = 'broker-server-3-0';
+  const clientId = '00000000-0000-0000-0000-000000000001';
+  const clientVersion = '4.144.1';
+  const primaryUrl = 'http://broker-server-dispatcher';
+  const gatewayUrl = 'http://broker-gateway-dispatcher';
 
+  const expectedBody = {
+    data: {
+      attributes: {
+        broker_client_version: clientVersion,
+        health_check_link: 'http://0/healthcheck',
+      },
+    },
+  };
+
+  const connectionPath = `/internal/brokerservers/0/connections/${hashedToken}?broker_client_id=${clientId}&request_type=client-connected&version=${apiVersion}`;
+
+  // Each test re-requires config + dispatcher from a fresh module graph so the
+  // module-level `if (config.dispatcherUrl)` wiring picks up that test's env.
   const loadDispatcher = async () => {
     jest.resetModules();
     const {
@@ -204,37 +217,166 @@ describe('Broker Server selectable dispatcher', () => {
 
   beforeEach(() => {
     nock.cleanAll();
-    process.env.hostname = podName;
-    process.env.DISPATCHER_URL = dispatcherUrl;
+    process.env.hostname = '0';
   });
 
   afterEach(() => {
     nock.cleanAll();
     delete process.env.DISPATCHER_URL;
-    delete process.env.USE_GATEWAY_DISPATCHER;
     delete process.env.GATEWAY_DISPATCHER_URL;
-    delete process.env.hostname;
   });
 
-  it('uses the full pod name when gateway dispatcher is selected', async () => {
-    process.env.USE_GATEWAY_DISPATCHER = 'true';
+  it('writes clientConnected to the primary gateway and legacy mirror', async () => {
+    const spyPrimary = jest.fn();
+    const spyGateway = jest.fn();
+    // The legacy mirror is fire-and-forget; await this to deterministically
+    // observe both writes landing.
+    let resolveGatewayWritten;
+    const gatewayWritten = new Promise<void>((resolve) => {
+      resolveGatewayWritten = resolve;
+    });
+
+    nock(primaryUrl)
+      .post(connectionPath)
+      .reply((_uri, body) => {
+        spyPrimary(JSON.parse(body as string));
+        return [200, 'OK'];
+      });
+    nock(gatewayUrl)
+      .post(connectionPath)
+      .reply((_uri, body) => {
+        spyGateway(JSON.parse(body as string));
+        resolveGatewayWritten();
+        return [201, 'Created'];
+      });
+
+    process.env.DISPATCHER_URL = primaryUrl;
+    process.env.GATEWAY_DISPATCHER_URL = gatewayUrl;
+    const dispatcher = await loadDispatcher();
+
+    await expect(
+      dispatcher.clientConnected(token, clientId, clientVersion),
+    ).resolves.not.toThrowError();
+    await gatewayWritten;
+
+    expect(spyPrimary).toBeCalledWith(expectedBody);
+    expect(spyGateway).toBeCalledWith(expectedBody);
+  });
+
+  it('does not write to the gateway when GATEWAY_DISPATCHER_URL is unset', async () => {
+    const spyPrimary = jest.fn();
+
+    nock(primaryUrl)
+      .post(connectionPath)
+      .reply((_uri, body) => {
+        spyPrimary(JSON.parse(body as string));
+        return [200, 'OK'];
+      });
+    // Any contact with the gateway host would consume this interceptor.
+    const gatewayScope = nock(gatewayUrl).post(/.*/).reply(200);
+
+    process.env.DISPATCHER_URL = primaryUrl;
+    delete process.env.GATEWAY_DISPATCHER_URL;
+    const dispatcher = await loadDispatcher();
+
+    await expect(
+      dispatcher.clientConnected(token, clientId, clientVersion),
+    ).resolves.not.toThrowError();
+
+    expect(spyPrimary).toBeCalledTimes(1);
+    expect(gatewayScope.isDone()).toBe(false);
+  });
+
+  it('isolates the primary gateway path from an unhealthy legacy mirror', async () => {
+    const spyPrimary = jest.fn();
+    let gatewayAttempts = 0;
+    let resolveFirstAttempt;
+    const firstGatewayAttempt = new Promise<void>((resolve) => {
+      resolveFirstAttempt = resolve;
+    });
+
+    nock(gatewayUrl)
+      .post(connectionPath)
+      .reply((_uri, body) => {
+        spyPrimary(JSON.parse(body as string));
+        return [200, 'OK'];
+      });
+    // Unhealthy legacy mirror: every attempt (and axios-retry's retries) 500s.
+    // persist() keeps the failures inside nock so the background retry budget
+    // (~1.4s for 5xx, up to ~11s if it were black-holing) never touches the
+    // real network.
+    nock(primaryUrl)
+      .persist()
+      .post(connectionPath)
+      .reply(() => {
+        gatewayAttempts += 1;
+        resolveFirstAttempt();
+        return [500, 'Internal Server Error'];
+      });
+
+    process.env.DISPATCHER_URL = primaryUrl;
+    process.env.GATEWAY_DISPATCHER_URL = gatewayUrl;
+    const dispatcher = await loadDispatcher();
+
+    const start = Date.now();
+    await expect(
+      dispatcher.clientConnected(token, clientId, clientVersion),
+    ).resolves.not.toThrowError();
+    const elapsed = Date.now() - start;
+
+    // Gateway write landed exactly once and was unaffected by the failing mirror.
+    expect(spyPrimary).toBeCalledTimes(1);
+    expect(spyPrimary).toBeCalledWith(expectedBody);
+    // The call returned on the gateway alone, without waiting on the legacy
+    // retry budget — this is the latency isolation fire-and-forget guarantees.
+    expect(elapsed).toBeLessThan(500);
+
+    // The mirror was genuinely attempted (fire-and-forget) and is harmless on
+    // failure. Drain the background retries inside nock before teardown.
+    await firstGatewayAttempt;
+    expect(gatewayAttempts).toBeGreaterThan(0);
+    await new Promise((resolve) => setTimeout(resolve, 1600));
+  });
+
+  it('registers the full pod name with the gateway while the node dispatcher keeps the ordinal', async () => {
+    const podName = 'broker-server-3-0';
+    // Node keeps the truncated ordinal ("0"); the gateway must get the full pod
+    // name so the envoy sidecar can resolve the exact pod FQDN from Redis.
+    const nodePath = `/internal/brokerservers/0/connections/${hashedToken}?broker_client_id=${clientId}&request_type=client-connected&version=${apiVersion}`;
     const gatewayPath = `/internal/brokerservers/${podName}/connections/${hashedToken}?broker_client_id=${clientId}&request_type=client-connected&version=${apiVersion}`;
-    const gatewayScope = nock(dispatcherUrl).post(gatewayPath).reply(201);
 
+    const spyNode = jest.fn();
+    const spyGateway = jest.fn();
+    let resolveGatewayWritten;
+    const gatewayWritten = new Promise<void>((resolve) => {
+      resolveGatewayWritten = resolve;
+    });
+
+    nock(primaryUrl)
+      .post(nodePath)
+      .reply(() => {
+        spyNode();
+        return [200, 'OK'];
+      });
+    nock(gatewayUrl)
+      .post(gatewayPath)
+      .reply(() => {
+        spyGateway();
+        resolveGatewayWritten();
+        return [201, 'Created'];
+      });
+
+    process.env.DISPATCHER_URL = primaryUrl;
+    process.env.GATEWAY_DISPATCHER_URL = gatewayUrl;
+    process.env.hostname = podName;
     const dispatcher = await loadDispatcher();
+
     await dispatcher.clientConnected(token, clientId, clientVersion);
+    await gatewayWritten;
 
-    expect(gatewayScope.isDone()).toBe(true);
-  });
-
-  it('uses the pod ordinal when legacy dispatcher is selected', async () => {
-    process.env.USE_GATEWAY_DISPATCHER = 'false';
-    const legacyPath = `/internal/brokerservers/0/connections/${hashedToken}?broker_client_id=${clientId}&request_type=client-connected&version=${apiVersion}`;
-    const legacyScope = nock(dispatcherUrl).post(legacyPath).reply(200);
-
-    const dispatcher = await loadDispatcher();
-    await dispatcher.clientConnected(token, clientId, clientVersion);
-
-    expect(legacyScope.isDone()).toBe(true);
+    // Each interceptor only matches its own path, so these passing proves the
+    // node used the ordinal and the gateway used the full pod name.
+    expect(spyNode).toBeCalledTimes(1);
+    expect(spyGateway).toBeCalledTimes(1);
   });
 });

--- a/test/functional/dispatcher-server-api.test.ts
+++ b/test/functional/dispatcher-server-api.test.ts
@@ -184,28 +184,15 @@ describe('Broker Server Dispatcher API interaction', () => {
   });
 });
 
-describe('Broker Server Dispatcher dual-write to gateway', () => {
-  const apiVersion = '2022-12-02%7Eexperimental';
-  const token = 'broker-test-token';
+describe('Broker Server selectable dispatcher', () => {
+  const dispatcherUrl = 'http://configured-dispatcher';
+  const token = 'token';
   const hashedToken = hashToken(token);
-  const clientId = '00000000-0000-0000-0000-000000000001';
-  const clientVersion = '4.144.1';
-  const primaryUrl = 'http://broker-server-dispatcher';
-  const gatewayUrl = 'http://broker-gateway-dispatcher';
+  const clientId = 'client-id';
+  const clientVersion = '1.2.3';
+  const apiVersion = '2022-12-02~experimental';
+  const podName = 'broker-server-3-0';
 
-  const expectedBody = {
-    data: {
-      attributes: {
-        broker_client_version: clientVersion,
-        health_check_link: 'http://0/healthcheck',
-      },
-    },
-  };
-
-  const connectionPath = `/internal/brokerservers/0/connections/${hashedToken}?broker_client_id=${clientId}&request_type=client-connected&version=${apiVersion}`;
-
-  // Each test re-requires config + dispatcher from a fresh module graph so the
-  // module-level `if (config.dispatcherUrl)` wiring picks up that test's env.
   const loadDispatcher = async () => {
     jest.resetModules();
     const {
@@ -217,166 +204,37 @@ describe('Broker Server Dispatcher dual-write to gateway', () => {
 
   beforeEach(() => {
     nock.cleanAll();
-    process.env.hostname = '0';
+    process.env.hostname = podName;
+    process.env.DISPATCHER_URL = dispatcherUrl;
   });
 
   afterEach(() => {
     nock.cleanAll();
     delete process.env.DISPATCHER_URL;
+    delete process.env.USE_GATEWAY_DISPATCHER;
     delete process.env.GATEWAY_DISPATCHER_URL;
+    delete process.env.hostname;
   });
 
-  it('mirrors clientConnected to both the primary and the gateway dispatcher', async () => {
-    const spyPrimary = jest.fn();
-    const spyGateway = jest.fn();
-    // The mirror is fire-and-forget, so clientConnected resolves on the primary
-    // alone. Await this to deterministically observe the gateway write landing.
-    let resolveGatewayWritten;
-    const gatewayWritten = new Promise<void>((resolve) => {
-      resolveGatewayWritten = resolve;
-    });
-
-    nock(primaryUrl)
-      .post(connectionPath)
-      .reply((_uri, body) => {
-        spyPrimary(JSON.parse(body as string));
-        return [200, 'OK'];
-      });
-    nock(gatewayUrl)
-      .post(connectionPath)
-      .reply((_uri, body) => {
-        spyGateway(JSON.parse(body as string));
-        resolveGatewayWritten();
-        return [201, 'Created'];
-      });
-
-    process.env.DISPATCHER_URL = primaryUrl;
-    process.env.GATEWAY_DISPATCHER_URL = gatewayUrl;
-    const dispatcher = await loadDispatcher();
-
-    await expect(
-      dispatcher.clientConnected(token, clientId, clientVersion),
-    ).resolves.not.toThrowError();
-    await gatewayWritten;
-
-    expect(spyPrimary).toBeCalledWith(expectedBody);
-    expect(spyGateway).toBeCalledWith(expectedBody);
-  });
-
-  it('does not write to the gateway when GATEWAY_DISPATCHER_URL is unset', async () => {
-    const spyPrimary = jest.fn();
-
-    nock(primaryUrl)
-      .post(connectionPath)
-      .reply((_uri, body) => {
-        spyPrimary(JSON.parse(body as string));
-        return [200, 'OK'];
-      });
-    // Any contact with the gateway host would consume this interceptor.
-    const gatewayScope = nock(gatewayUrl).post(/.*/).reply(200);
-
-    process.env.DISPATCHER_URL = primaryUrl;
-    delete process.env.GATEWAY_DISPATCHER_URL;
-    const dispatcher = await loadDispatcher();
-
-    await expect(
-      dispatcher.clientConnected(token, clientId, clientVersion),
-    ).resolves.not.toThrowError();
-
-    expect(spyPrimary).toBeCalledTimes(1);
-    expect(gatewayScope.isDone()).toBe(false);
-  });
-
-  it('isolates the primary write path from an unhealthy gateway', async () => {
-    const spyPrimary = jest.fn();
-    let gatewayAttempts = 0;
-    let resolveFirstAttempt;
-    const firstGatewayAttempt = new Promise<void>((resolve) => {
-      resolveFirstAttempt = resolve;
-    });
-
-    nock(primaryUrl)
-      .post(connectionPath)
-      .reply((_uri, body) => {
-        spyPrimary(JSON.parse(body as string));
-        return [200, 'OK'];
-      });
-    // Unhealthy gateway: every attempt (and axios-retry's retries) 500s.
-    // persist() keeps the failures inside nock so the background retry budget
-    // (~1.4s for 5xx, up to ~11s if it were black-holing) never touches the
-    // real network.
-    nock(gatewayUrl)
-      .persist()
-      .post(connectionPath)
-      .reply(() => {
-        gatewayAttempts += 1;
-        resolveFirstAttempt();
-        return [500, 'Internal Server Error'];
-      });
-
-    process.env.DISPATCHER_URL = primaryUrl;
-    process.env.GATEWAY_DISPATCHER_URL = gatewayUrl;
-    const dispatcher = await loadDispatcher();
-
-    const start = Date.now();
-    await expect(
-      dispatcher.clientConnected(token, clientId, clientVersion),
-    ).resolves.not.toThrowError();
-    const elapsed = Date.now() - start;
-
-    // Primary write landed exactly once and was unaffected by the failing mirror.
-    expect(spyPrimary).toBeCalledTimes(1);
-    expect(spyPrimary).toBeCalledWith(expectedBody);
-    // The call returned on the primary alone, without waiting on the gateway's
-    // retry budget — this is the latency isolation fire-and-forget guarantees.
-    expect(elapsed).toBeLessThan(500);
-
-    // The mirror was genuinely attempted (fire-and-forget) and is harmless on
-    // failure. Drain the background retries inside nock before teardown.
-    await firstGatewayAttempt;
-    expect(gatewayAttempts).toBeGreaterThan(0);
-    await new Promise((resolve) => setTimeout(resolve, 1600));
-  });
-
-  it('registers the full pod name with the gateway while the node dispatcher keeps the ordinal', async () => {
-    const podName = 'broker-server-3-0';
-    // Node keeps the truncated ordinal ("0"); the gateway must get the full pod
-    // name so the envoy sidecar can resolve the exact pod FQDN from Redis.
-    const nodePath = `/internal/brokerservers/0/connections/${hashedToken}?broker_client_id=${clientId}&request_type=client-connected&version=${apiVersion}`;
+  it('uses the full pod name when gateway dispatcher is selected', async () => {
+    process.env.USE_GATEWAY_DISPATCHER = 'true';
     const gatewayPath = `/internal/brokerservers/${podName}/connections/${hashedToken}?broker_client_id=${clientId}&request_type=client-connected&version=${apiVersion}`;
+    const gatewayScope = nock(dispatcherUrl).post(gatewayPath).reply(201);
 
-    const spyNode = jest.fn();
-    const spyGateway = jest.fn();
-    let resolveGatewayWritten;
-    const gatewayWritten = new Promise<void>((resolve) => {
-      resolveGatewayWritten = resolve;
-    });
-
-    nock(primaryUrl)
-      .post(nodePath)
-      .reply(() => {
-        spyNode();
-        return [200, 'OK'];
-      });
-    nock(gatewayUrl)
-      .post(gatewayPath)
-      .reply(() => {
-        spyGateway();
-        resolveGatewayWritten();
-        return [201, 'Created'];
-      });
-
-    process.env.DISPATCHER_URL = primaryUrl;
-    process.env.GATEWAY_DISPATCHER_URL = gatewayUrl;
-    process.env.hostname = podName;
     const dispatcher = await loadDispatcher();
-
     await dispatcher.clientConnected(token, clientId, clientVersion);
-    await gatewayWritten;
 
-    // Each interceptor only matches its own path, so these passing proves the
-    // node used the ordinal and the gateway used the full pod name.
-    expect(spyNode).toBeCalledTimes(1);
-    expect(spyGateway).toBeCalledTimes(1);
+    expect(gatewayScope.isDone()).toBe(true);
+  });
+
+  it('uses the pod ordinal when legacy dispatcher is selected', async () => {
+    process.env.USE_GATEWAY_DISPATCHER = 'false';
+    const legacyPath = `/internal/brokerservers/0/connections/${hashedToken}?broker_client_id=${clientId}&request_type=client-connected&version=${apiVersion}`;
+    const legacyScope = nock(dispatcherUrl).post(legacyPath).reply(200);
+
+    const dispatcher = await loadDispatcher();
+    await dispatcher.clientConnected(token, clientId, clientVersion);
+
+    expect(legacyScope.isDone()).toBe(true);
   });
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/main/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Enables making the Broker Gateway Dispatcher the primary write path for dual server registration. 

We now have the following states:

 | `DISPATCHER_URL` | `GATEWAY_DISPATCHER_URL` | Behavior |
 |---|---|---|
 | Set | Set | Dual write: BGD is the awaited primary; legacy dispatcher is fire-and-forget. |
 | Set | Unset | Legacy only: legacy dispatcher is primary; no BGD write. |
 | Unset | Set or unset | No writes: lifecycle methods become no-ops. |