### PR TITLE
fix: remove content-encoding header [OSM-3847]

### DIFF
--- a/lib/broker-workload/prepareRequest.ts
+++ b/lib/broker-workload/prepareRequest.ts
@@ -85,6 +85,7 @@ export const prepareRequest = async (
     'x-forwarded-for',
     'x-forwarded-proto',
     'content-length',
+    'content-encoding',
     'host',
     'x-forwarded-host',
     'x-forwarded-port',

--- a/test/functional/client-server.test.ts
+++ b/test/functional/client-server.test.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import zlib from 'zlib';
 import { axiosClient } from '../setup/axios-client';
 import {
   BrokerClient,
@@ -112,6 +113,52 @@ describe('proxy requests originating from behind the broker client', () => {
 
     expect(response.status).toEqual(200);
     expect(response.data).toEqual('xyz');
+  });
+
+  describe('request bodies sent with content-encoding: gzip', () => {
+    const plaintextBody = JSON.stringify({
+      some: { example: 'a'.repeat(2000) },
+    });
+    const gzippedBody = zlib.gzipSync(Buffer.from(plaintextBody));
+
+    it('does not relay content-encoding to the downstream', async () => {
+      const response = await axiosClient.post(
+        `http://localhost:${bc.port}/echo-headers`,
+        gzippedBody,
+        {
+          headers: {
+            'Content-Encoding': 'gzip',
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+
+      expect(response.status).toEqual(200);
+      expect(response.data).not.toHaveProperty('content-encoding');
+      expect(response.data['content-length']).toEqual(
+        String(Buffer.byteLength(plaintextBody)),
+      );
+    });
+
+    it('delivers the inflated body to the downstream intact', async () => {
+      const response = await axiosClient.post(
+        `http://localhost:${bc.port}/echo-body`,
+        gzippedBody,
+        {
+          headers: {
+            'Content-Encoding': 'gzip',
+            'Content-Type': 'application/json',
+            // This leg corrupts any compressed response over ~1kb, which is a
+            // separate defect from the request header under test. Opt out of
+            // response compression so this test fails only on the request side.
+            'Accept-Encoding': 'identity',
+          },
+        },
+      );
+
+      expect(response.status).toEqual(200);
+      expect(response.data).toEqual(JSON.parse(plaintextBody));
+    });
   });
 
   it('block request for non-whitelisted url', async () => {

--- a/test/functional/server-client.test.ts
+++ b/test/functional/server-client.test.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import zlib from 'zlib';
 import version from '../../lib/hybrid-sdk/common/utils/version';
 import { axiosClient } from '../setup/axios-client';
 import {
@@ -520,6 +521,48 @@ describe('proxy requests originating from behind the broker server', () => {
 
     expect(response.status).toEqual(200);
     expect(response.data).toEqual(paramRequiringCompression);
+  });
+
+  describe('request bodies sent with content-encoding: gzip', () => {
+    const plaintextBody = JSON.stringify({
+      want: 'a'.repeat(2000), // over git's 1024-byte gzip threshold
+    });
+    const gzippedBody = zlib.gzipSync(Buffer.from(plaintextBody));
+
+    it('does not relay content-encoding to the downstream', async () => {
+      const response = await axiosClient.post(
+        `http://localhost:${bs.port}/broker/${brokerToken}/echo-headers`,
+        gzippedBody,
+        {
+          headers: {
+            'Content-Encoding': 'gzip',
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+
+      expect(response.status).toEqual(200);
+      expect(response.data).not.toHaveProperty('content-encoding');
+      expect(response.data['content-length']).toEqual(
+        String(Buffer.byteLength(plaintextBody)),
+      );
+    });
+
+    it('delivers the inflated body to the downstream intact', async () => {
+      const response = await axiosClient.post(
+        `http://localhost:${bs.port}/broker/${brokerToken}/echo-body`,
+        gzippedBody,
+        {
+          headers: {
+            'Content-Encoding': 'gzip',
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+
+      expect(response.status).toEqual(200);
+      expect(response.data).toEqual(JSON.parse(plaintextBody));
+    });
   });
 
   it('successfully stream data', async () => {

--- a/test/unit/lib/broker-workload/prepareRequest.test.ts
+++ b/test/unit/lib/broker-workload/prepareRequest.test.ts
@@ -131,6 +131,132 @@ describe('prepareRequest — downstream x-request-id mirror', () => {
   });
 });
 
+describe('prepareRequest — request content-encoding', () => {
+  const baseResult = { url: 'https://example.com/path' } as any;
+  const baseOptions = {
+    config: { removeXForwardedHeaders: 'false', universalBrokerEnabled: false },
+  } as any;
+  const logContext: any = {};
+
+  // The broker server inflates a gzipped request body but leaves
+  // content-encoding in place, so by the time we relay it the header is a lie.
+  // Forwarding it makes the downstream SCM gunzip plaintext and fail with
+  // "fatal: zlib error inflating request, result -3".
+  const packBody = '0032want deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n0000';
+
+  it('removes content-encoding from a relayed request body', async () => {
+    const payload = {
+      method: 'POST',
+      url: '/repo.git/git-upload-pack',
+      headers: {
+        'content-encoding': 'gzip',
+        'content-type': 'application/x-git-upload-pack-request',
+      },
+      body: packBody,
+    };
+
+    const { req } = await prepareRequest(
+      { ...baseResult },
+      payload,
+      logContext,
+      baseOptions,
+      'tok',
+      'client',
+    );
+
+    expect(req.headers['content-encoding']).toBeUndefined();
+  });
+
+  it('removes content-encoding regardless of header casing', async () => {
+    const payload = {
+      method: 'POST',
+      url: '/repo.git/git-upload-pack',
+      headers: { 'Content-Encoding': 'GZIP' },
+      body: packBody,
+    };
+
+    const { req } = await prepareRequest(
+      { ...baseResult },
+      payload,
+      logContext,
+      baseOptions,
+      'tok',
+      'client',
+    );
+
+    expect(req.headers['Content-Encoding']).toBeUndefined();
+    expect(req.headers['content-encoding']).toBeUndefined();
+  });
+
+  it('sets content-length to the inflated body size once content-encoding is gone', async () => {
+    const payload = {
+      method: 'POST',
+      url: '/repo.git/git-upload-pack',
+      headers: { 'content-encoding': 'gzip', 'content-length': '39' },
+      body: packBody,
+    };
+
+    const { req } = await prepareRequest(
+      { ...baseResult },
+      payload,
+      logContext,
+      baseOptions,
+      'tok',
+      'client',
+    );
+
+    expect(req.headers['content-encoding']).toBeUndefined();
+    expect(req.headers['Content-Length']).toBe(Buffer.byteLength(packBody));
+  });
+
+  it.each(['client', 'server'])(
+    'removes content-encoding on the %s leg',
+    async (socketType) => {
+      const payload = {
+        method: 'POST',
+        url: '/repo.git/git-upload-pack',
+        headers: { 'content-encoding': 'gzip' },
+        body: packBody,
+      };
+
+      const { req } = await prepareRequest(
+        { ...baseResult },
+        payload,
+        logContext,
+        baseOptions,
+        'tok',
+        socketType,
+      );
+
+      expect(req.headers['content-encoding']).toBeUndefined();
+    },
+  );
+
+  it('keeps accept-encoding so downstream responses can still be compressed', async () => {
+    const payload = {
+      method: 'POST',
+      url: '/repo.git/git-upload-pack',
+      headers: {
+        'accept-encoding': 'gzip, deflate',
+        'content-encoding': 'gzip',
+      },
+      body: packBody,
+    };
+
+    const { req } = await prepareRequest(
+      { ...baseResult },
+      payload,
+      logContext,
+      baseOptions,
+      'tok',
+      'client',
+    );
+
+    expect(req.headers['accept-encoding']).toBe('gzip, deflate');
+    expect(req.headers['content-encoding']).toBeUndefined();
+  });
+});
+
 describe('prepareRequest — GitHub create tree validation', () => {
   const baseResult = {
     url: 'https://api.github.com/repos/owner/repo/git/trees',


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/main/.github/CONTRIBUTING.md) rules

#### What does this PR do?
In some situations the broker server may inflate a compressed request body but leave the `content-encoding` header in the request leading the broker client to receive a malformed POST. This affects all POST bodies over 1024B which are auto-inflated by default. See Jira ticket for more details.
