### PR TITLE
fix: handle fragmented response metadata framing

### DIFF
--- a/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.ts
+++ b/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.ts
@@ -199,6 +199,23 @@ export const handlePostResponse = (req: Request, res: Response) => {
           'Incomplete metadata-length prefix at end of streaming HTTP response.',
         );
       }
+      if (
+        statusAndHeadersSize >= 0 &&
+        statusAndHeadersLength < statusAndHeadersSize
+      ) {
+        const error = new Error(
+          `Incomplete response metadata: received ${statusAndHeadersLength} of ${statusAndHeadersSize} bytes.`,
+        );
+        logger.error(
+          {
+            ...logContext,
+            receivedMetadataBytes: statusAndHeadersLength,
+            expectedMetadataBytes: statusAndHeadersSize,
+            error,
+          },
+          'Incomplete response metadata at end of streaming HTTP response.',
+        );
+      }
       logger.debug(logContext, 'Handling response-data request - end part.');
       streamHandler.finished();
       res.status(200).json({});

--- a/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.ts
+++ b/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.ts
@@ -67,6 +67,10 @@ export const handlePostResponse = (req: Request, res: Response) => {
   }
   let statusAndHeaders = '';
   let statusAndHeadersSize = -1;
+  const statusAndHeadersSizeBuffer = Buffer.alloc(4);
+  let statusAndHeadersSizeBytesRead = 0;
+  const statusAndHeadersBuffers: Buffer[] = [];
+  let statusAndHeadersLength = 0;
   req
     .on('data', function (data) {
       try {
@@ -76,18 +80,30 @@ export const handlePostResponse = (req: Request, res: Response) => {
         );
         let bytesRead = 0;
         if (statusAndHeadersSize === -1) {
-          bytesRead += 4;
-          statusAndHeadersSize = data.readUInt32LE();
+          const bytesToRead = Math.min(
+            statusAndHeadersSizeBuffer.length - statusAndHeadersSizeBytesRead,
+            data.length,
+          );
+          data.copy(
+            statusAndHeadersSizeBuffer,
+            statusAndHeadersSizeBytesRead,
+            bytesRead,
+            bytesRead + bytesToRead,
+          );
+          statusAndHeadersSizeBytesRead += bytesToRead;
+          bytesRead += bytesToRead;
+          if (
+            statusAndHeadersSizeBytesRead < statusAndHeadersSizeBuffer.length
+          ) {
+            return;
+          }
+          statusAndHeadersSize = statusAndHeadersSizeBuffer.readUInt32LE();
           logger.debug(
             { ...logContext, statusAndHeadersSize },
             'Request metadata size read from stream.',
           );
         }
 
-        let statusAndHeadersLength = Buffer.byteLength(
-          statusAndHeaders,
-          'utf8',
-        );
         if (
           statusAndHeadersSize > 0 &&
           statusAndHeadersLength < statusAndHeadersSize
@@ -100,10 +116,16 @@ export const handlePostResponse = (req: Request, res: Response) => {
             { ...logContext, bytesRead, endPosition },
             'Reading ioJson.',
           );
-          statusAndHeaders += data.toString('utf8', bytesRead, endPosition);
+          const statusAndHeadersChunk = data.subarray(bytesRead, endPosition);
+          statusAndHeadersBuffers.push(statusAndHeadersChunk);
+          statusAndHeadersLength += statusAndHeadersChunk.length;
           bytesRead = endPosition;
-          statusAndHeadersLength = Buffer.byteLength(statusAndHeaders, 'utf8');
           if (statusAndHeadersLength === statusAndHeadersSize) {
+            statusAndHeaders = Buffer.concat(
+              statusAndHeadersBuffers,
+              statusAndHeadersSize,
+            ).toString('utf8');
+            statusAndHeadersBuffers.length = 0;
             logger.trace(
               { ...logContext, statusAndHeaders },
               'Converting to json.',
@@ -160,6 +182,23 @@ export const handlePostResponse = (req: Request, res: Response) => {
       }
     })
     .on('end', function () {
+      if (
+        statusAndHeadersSizeBytesRead > 0 &&
+        statusAndHeadersSizeBytesRead < statusAndHeadersSizeBuffer.length
+      ) {
+        const error = new Error(
+          `Incomplete metadata-length prefix: received ${statusAndHeadersSizeBytesRead} of ${statusAndHeadersSizeBuffer.length} bytes.`,
+        );
+        logger.error(
+          {
+            ...logContext,
+            receivedPrefixBytes: statusAndHeadersSizeBytesRead,
+            expectedPrefixBytes: statusAndHeadersSizeBuffer.length,
+            error,
+          },
+          'Incomplete metadata-length prefix at end of streaming HTTP response.',
+        );
+      }
       logger.debug(logContext, 'Handling response-data request - end part.');
       streamHandler.finished();
       res.status(200).json({});

--- a/test/unit/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.test.ts
+++ b/test/unit/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.test.ts
@@ -1,4 +1,7 @@
 import { EventEmitter } from 'events';
+import express from 'express';
+import http from 'http';
+import { AddressInfo } from 'net';
 import { log } from '../../../../../../lib/logs/logger';
 import { handlePostResponse } from '../../../../../../lib/hybrid-sdk/server/routesHandlers/postResponseHandler';
 
@@ -13,14 +16,16 @@ jest.mock('../../../../../../lib/logs/logger', () => ({
 }));
 
 const mockWriteStatusAndHeaders = jest.fn();
+const mockWriteChunk = jest.fn();
+const mockFinished = jest.fn();
 jest.mock(
   '../../../../../../lib/hybrid-sdk/http/server-post-stream-handler',
   () => ({
     StreamResponseHandler: {
       create: jest.fn(() => ({
         writeStatusAndHeaders: mockWriteStatusAndHeaders,
-        writeChunk: jest.fn(),
-        finished: jest.fn(),
+        writeChunk: mockWriteChunk,
+        finished: mockFinished,
         destroy: jest.fn(),
         streamResponse: {},
       })),
@@ -49,6 +54,19 @@ const frameIoData = (obj: Record<string, unknown>): Buffer => {
   const prefix = Buffer.alloc(4);
   prefix.writeUInt32LE(length);
   return Buffer.concat([prefix, Buffer.from(json, 'utf8')]);
+};
+
+const validResponseFrame = () => {
+  const metadata = Buffer.from(
+    JSON.stringify({
+      status: 200,
+      headers: { 'content-type': 'text/plain' },
+    }),
+    'utf8',
+  );
+  const prefix = Buffer.alloc(4);
+  prefix.writeUInt32LE(metadata.length);
+  return { prefix, metadata, body: Buffer.from('valid response body') };
 };
 
 const createReqRes = () => {
@@ -155,5 +173,168 @@ describe('handlePostResponse — errorType logging', () => {
       expect.objectContaining({ responseStatus: 200, errorType: undefined }),
       'Handling response-data request - io bits',
     );
+  });
+});
+
+describe('handlePostResponse — four-byte prefix fragmentation evidence', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const driveFrame = (prefixFragmentSizes: number[]) => {
+    const { req, res } = createReqRes();
+    const { prefix, metadata, body } = validResponseFrame();
+    handlePostResponse(req, res);
+
+    let offset = 0;
+    for (const size of prefixFragmentSizes) {
+      req.emit('data', prefix.subarray(offset, offset + size));
+      offset += size;
+    }
+    expect(offset).toBe(prefix.length);
+    req.emit('data', metadata);
+    req.emit('data', body);
+    req.emit('end');
+
+    return { res, metadata, body };
+  };
+
+  it('accepts a valid frame when all four prefix bytes are in one data event', () => {
+    const { res, body } = driveFrame([4]);
+
+    expect(log.error).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'Caught error handling data event for streaming HTTP response.',
+    );
+    expect(mockWriteStatusAndHeaders).toHaveBeenCalledWith({
+      status: 200,
+      headers: { 'content-type': 'text/plain' },
+    });
+    expect(mockWriteChunk).toHaveBeenCalledWith(body, expect.any(Function));
+    expect(mockFinished).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it.each([
+    ['1+3', [1, 3]],
+    ['2+2', [2, 2]],
+    ['3+1', [3, 1]],
+    ['1+1+1+1', [1, 1, 1, 1]],
+    ['1+1+2', [1, 1, 2]],
+    ['2+1+1', [2, 1, 1]],
+  ])(
+    'logs ERR_BUFFER_OUT_OF_BOUNDS and loses a valid frame for %s prefix delivery',
+    (_label, fragmentSizes) => {
+      const { res } = driveFrame(fragmentSizes as number[]);
+      const parserErrors = (log.error as jest.Mock).mock.calls.filter(
+        ([, message]) =>
+          message ===
+          'Caught error handling data event for streaming HTTP response.',
+      );
+
+      expect(parserErrors).toHaveLength(fragmentSizes.length);
+      for (const [context] of parserErrors) {
+        expect(context).toMatchObject({
+          statusAndHeaders: '',
+          statusAndHeadersSize: -1,
+          error: { code: 'ERR_BUFFER_OUT_OF_BOUNDS' },
+        });
+        expect(context.error.name).toBe('RangeError');
+        expect(context.error.message).toBe(
+          'Attempt to access memory outside buffer bounds',
+        );
+      }
+      expect(mockWriteStatusAndHeaders).not.toHaveBeenCalled();
+      expect(mockWriteChunk).not.toHaveBeenCalled();
+
+      // The data-event exception is swallowed. The normal end handler still
+      // closes the caller's body stream and acknowledges the POST.
+      expect(mockFinished).toHaveBeenCalledTimes(1);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({});
+    },
+  );
+
+  it('reinterprets the next four metadata bytes as a replacement prefix', () => {
+    const { metadata } = driveFrame([1, 3]);
+    const replacementSize = metadata.readUInt32LE(0);
+
+    expect(log.debug).toHaveBeenCalledWith(
+      expect.objectContaining({ statusAndHeadersSize: replacementSize }),
+      'Request metadata size read from stream.',
+    );
+    expect(replacementSize).not.toBe(metadata.length);
+    expect(mockWriteStatusAndHeaders).not.toHaveBeenCalled();
+  });
+
+  it('reproduces 1+3 prefix delivery through a real chunked HTTP request', async () => {
+    const app = express();
+    let transferEncoding: string | undefined;
+    app.use((req, _res, next) => {
+      transferEncoding = req.headers['transfer-encoding'];
+      next();
+    });
+    app.post('/response-data/:brokerToken/:streamingId', handlePostResponse);
+    const server = http.createServer(app);
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => {
+        server.off('error', reject);
+        resolve();
+      });
+    });
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const { prefix, metadata, body } = validResponseFrame();
+      const responseStatus = new Promise<number | undefined>(
+        (resolve, reject) => {
+          const request = http.request(
+            {
+              host: '127.0.0.1',
+              port,
+              method: 'POST',
+              path: '/response-data/token/stream-1',
+              headers: {
+                'content-type': 'application/vnd.broker.stream+octet-stream',
+              },
+            },
+            (response) => {
+              response.resume();
+              response.on('end', () => resolve(response.statusCode));
+            },
+          );
+          request.on('error', reject);
+          request.write(prefix.subarray(0, 1));
+          request.write(prefix.subarray(1));
+          request.write(metadata);
+          request.end(body);
+        },
+      );
+
+      await expect(responseStatus).resolves.toBe(200);
+      expect(transferEncoding).toBe('chunked');
+
+      const receivedLengths = (log.trace as jest.Mock).mock.calls
+        .filter(([, message]) => message === 'Received data event.')
+        .map(([context]) => context.dataLength);
+      expect(receivedLengths).toEqual([1, 3, metadata.length, body.length]);
+      const parserErrors = (log.error as jest.Mock).mock.calls.filter(
+        ([, message]) =>
+          message ===
+          'Caught error handling data event for streaming HTTP response.',
+      );
+      expect(parserErrors).toHaveLength(2);
+      expect(parserErrors[0][0]).toMatchObject({
+        statusAndHeaders: '',
+        statusAndHeadersSize: -1,
+        error: { code: 'ERR_BUFFER_OUT_OF_BOUNDS' },
+      });
+      expect(mockWriteStatusAndHeaders).not.toHaveBeenCalled();
+      expect(mockWriteChunk).not.toHaveBeenCalled();
+      expect(mockFinished).toHaveBeenCalledTimes(1);
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
   });
 });

--- a/test/unit/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.test.ts
+++ b/test/unit/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.test.ts
@@ -219,50 +219,213 @@ describe('handlePostResponse — four-byte prefix fragmentation evidence', () =>
     ['3+1', [3, 1]],
     ['1+1+1+1', [1, 1, 1, 1]],
     ['1+1+2', [1, 1, 2]],
+    ['1+2+1', [1, 2, 1]],
     ['2+1+1', [2, 1, 1]],
   ])(
-    'logs ERR_BUFFER_OUT_OF_BOUNDS and loses a valid frame for %s prefix delivery',
+    'accepts a valid frame for %s prefix delivery',
     (_label, fragmentSizes) => {
-      const { res } = driveFrame(fragmentSizes as number[]);
-      const parserErrors = (log.error as jest.Mock).mock.calls.filter(
-        ([, message]) =>
-          message ===
-          'Caught error handling data event for streaming HTTP response.',
-      );
+      const { res, body } = driveFrame(fragmentSizes as number[]);
 
-      expect(parserErrors).toHaveLength(fragmentSizes.length);
-      for (const [context] of parserErrors) {
-        expect(context).toMatchObject({
-          statusAndHeaders: '',
-          statusAndHeadersSize: -1,
-          error: { code: 'ERR_BUFFER_OUT_OF_BOUNDS' },
-        });
-        expect(context.error.name).toBe('RangeError');
-        expect(context.error.message).toBe(
-          'Attempt to access memory outside buffer bounds',
-        );
-      }
-      expect(mockWriteStatusAndHeaders).not.toHaveBeenCalled();
-      expect(mockWriteChunk).not.toHaveBeenCalled();
-
-      // The data-event exception is swallowed. The normal end handler still
-      // closes the caller's body stream and acknowledges the POST.
+      expect(log.error).not.toHaveBeenCalled();
+      expect(mockWriteStatusAndHeaders).toHaveBeenCalledWith({
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
+      });
+      expect(mockWriteChunk).toHaveBeenCalledWith(body, expect.any(Function));
       expect(mockFinished).toHaveBeenCalledTimes(1);
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({});
     },
   );
 
-  it('reinterprets the next four metadata bytes as a replacement prefix', () => {
+  it('reads the declared metadata size after a fragmented prefix', () => {
     const { metadata } = driveFrame([1, 3]);
-    const replacementSize = metadata.readUInt32LE(0);
 
     expect(log.debug).toHaveBeenCalledWith(
-      expect.objectContaining({ statusAndHeadersSize: replacementSize }),
+      expect.objectContaining({ statusAndHeadersSize: metadata.length }),
       'Request metadata size read from stream.',
     );
-    expect(replacementSize).not.toBe(metadata.length);
+    expect(mockWriteStatusAndHeaders).toHaveBeenCalledWith({
+      status: 200,
+      headers: { 'content-type': 'text/plain' },
+    });
+  });
+
+  it.each([1, 2, 3])(
+    'logs an incomplete metadata-length prefix when the request ends after %d byte(s)',
+    (receivedPrefixBytes) => {
+      const { req, res } = createReqRes();
+      const { prefix } = validResponseFrame();
+      handlePostResponse(req, res);
+
+      req.emit('data', prefix.subarray(0, receivedPrefixBytes));
+      req.emit('end');
+
+      const framingErrors = (log.error as jest.Mock).mock.calls.filter(
+        ([, message]) =>
+          message ===
+          'Incomplete metadata-length prefix at end of streaming HTTP response.',
+      );
+      expect(log.error).toHaveBeenCalledTimes(1);
+      expect(framingErrors).toHaveLength(1);
+      expect(framingErrors[0][0]).toMatchObject({
+        hashedToken: 'hashed',
+        maskedToken: 'masked',
+        streamingID: 'stream-1',
+        requestId: 'req-1',
+        receivedPrefixBytes,
+        expectedPrefixBytes: 4,
+        error: {
+          message: `Incomplete metadata-length prefix: received ${receivedPrefixBytes} of 4 bytes.`,
+        },
+      });
+      expect(mockWriteStatusAndHeaders).not.toHaveBeenCalled();
+      expect(mockWriteChunk).not.toHaveBeenCalled();
+      expect(mockFinished).toHaveBeenCalledTimes(1);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({});
+    },
+  );
+
+  it('does not classify a zero-byte request as a truncated prefix', () => {
+    const { req, res } = createReqRes();
+    handlePostResponse(req, res);
+
+    req.emit('end');
+
+    expect(log.error).not.toHaveBeenCalled();
     expect(mockWriteStatusAndHeaders).not.toHaveBeenCalled();
+    expect(mockWriteChunk).not.toHaveBeenCalled();
+    expect(mockFinished).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({});
+  });
+
+  it('parses a complete prefix, metadata, and body from one data event', () => {
+    const { req, res } = createReqRes();
+    const { prefix, metadata, body } = validResponseFrame();
+    handlePostResponse(req, res);
+
+    req.emit('data', Buffer.concat([prefix, metadata, body]));
+    req.emit('end');
+
+    expect(log.error).not.toHaveBeenCalled();
+    expect(mockWriteStatusAndHeaders).toHaveBeenCalledWith({
+      status: 200,
+      headers: { 'content-type': 'text/plain' },
+    });
+    expect(mockWriteChunk).toHaveBeenCalledTimes(1);
+    expect(mockWriteChunk).toHaveBeenCalledWith(body, expect.any(Function));
+    expect(mockFinished).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({});
+  });
+
+  it('parses metadata fragmented inside a multibyte UTF-8 value', () => {
+    const { req, res } = createReqRes();
+    const headers = {
+      'content-type': 'text/plain; charset=utf-8',
+      'x-response-label': '日本語',
+    };
+    const metadata = Buffer.from(JSON.stringify({ status: 206, headers }));
+    const prefix = Buffer.alloc(4);
+    prefix.writeUInt32LE(metadata.length);
+    const body = Buffer.from('exact UTF-8 response body');
+    const multibyteValue = Buffer.from('日');
+    const codePointStart = metadata.indexOf(multibyteValue);
+    expect(codePointStart).toBeGreaterThan(-1);
+    const splitPosition = codePointStart + 1;
+    handlePostResponse(req, res);
+
+    req.emit(
+      'data',
+      Buffer.concat([prefix, metadata.subarray(0, splitPosition)]),
+    );
+    req.emit('data', Buffer.concat([metadata.subarray(splitPosition), body]));
+    req.emit('end');
+
+    expect(log.error).not.toHaveBeenCalled();
+    expect(mockWriteStatusAndHeaders).toHaveBeenCalledWith({
+      status: 206,
+      headers,
+    });
+    const forwardedBody = Buffer.concat(
+      mockWriteChunk.mock.calls.map(([chunk]) => chunk),
+    );
+    expect(forwardedBody).toEqual(body);
+    expect(mockFinished).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({});
+  });
+
+  it('continues into metadata when the prefix-completing event contains both', () => {
+    const { req, res } = createReqRes();
+    const { prefix, metadata, body } = validResponseFrame();
+    handlePostResponse(req, res);
+
+    req.emit('data', prefix.subarray(0, 2));
+    req.emit(
+      'data',
+      Buffer.concat([prefix.subarray(2), metadata.subarray(0, 7)]),
+    );
+    req.emit('data', metadata.subarray(7));
+    req.emit('data', body);
+    req.emit('end');
+
+    expect(log.error).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'Caught error handling data event for streaming HTTP response.',
+    );
+    expect(mockWriteStatusAndHeaders).toHaveBeenCalledWith({
+      status: 200,
+      headers: { 'content-type': 'text/plain' },
+    });
+    expect(mockWriteChunk).toHaveBeenCalledWith(body, expect.any(Function));
+    expect(mockFinished).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('forwards body bytes from the event that completes metadata', () => {
+    const { req, res } = createReqRes();
+    const { prefix, metadata, body } = validResponseFrame();
+    const metadataTailLength = 3;
+    const firstBodyLength = 5;
+    handlePostResponse(req, res);
+
+    req.emit(
+      'data',
+      Buffer.concat([
+        prefix,
+        metadata.subarray(0, metadata.length - metadataTailLength),
+      ]),
+    );
+    req.emit(
+      'data',
+      Buffer.concat([
+        metadata.subarray(metadata.length - metadataTailLength),
+        body.subarray(0, firstBodyLength),
+      ]),
+    );
+    req.emit('data', body.subarray(firstBodyLength));
+    req.emit('end');
+
+    expect(log.error).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'Caught error handling data event for streaming HTTP response.',
+    );
+    expect(mockWriteStatusAndHeaders).toHaveBeenCalledWith({
+      status: 200,
+      headers: { 'content-type': 'text/plain' },
+    });
+    const forwardedBody = Buffer.concat(
+      mockWriteChunk.mock.calls.map(([chunk]) => chunk),
+    );
+    expect(forwardedBody).toEqual(body);
+    expect(mockWriteChunk.mock.calls[0][0]).toEqual(
+      body.subarray(0, firstBodyLength),
+    );
+    expect(mockFinished).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
   });
 
   it('reproduces 1+3 prefix delivery through a real chunked HTTP request', async () => {
@@ -317,19 +480,15 @@ describe('handlePostResponse — four-byte prefix fragmentation evidence', () =>
         .filter(([, message]) => message === 'Received data event.')
         .map(([context]) => context.dataLength);
       expect(receivedLengths).toEqual([1, 3, metadata.length, body.length]);
-      const parserErrors = (log.error as jest.Mock).mock.calls.filter(
-        ([, message]) =>
-          message ===
-          'Caught error handling data event for streaming HTTP response.',
-      );
-      expect(parserErrors).toHaveLength(2);
-      expect(parserErrors[0][0]).toMatchObject({
-        statusAndHeaders: '',
-        statusAndHeadersSize: -1,
-        error: { code: 'ERR_BUFFER_OUT_OF_BOUNDS' },
+      expect(log.error).not.toHaveBeenCalled();
+      expect(mockWriteStatusAndHeaders).toHaveBeenCalledWith({
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
       });
-      expect(mockWriteStatusAndHeaders).not.toHaveBeenCalled();
-      expect(mockWriteChunk).not.toHaveBeenCalled();
+      const forwardedBody = Buffer.concat(
+        mockWriteChunk.mock.calls.map(([chunk]) => chunk),
+      );
+      expect(forwardedBody).toEqual(body);
       expect(mockFinished).toHaveBeenCalledTimes(1);
     } finally {
       await new Promise<void>((resolve, reject) =>

--- a/test/unit/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.test.ts
+++ b/test/unit/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.test.ts
@@ -287,6 +287,43 @@ describe('handlePostResponse — four-byte prefix fragmentation evidence', () =>
     },
   );
 
+  it('logs incomplete response metadata when the request ends before the declared metadata size', () => {
+    const { req, res } = createReqRes();
+    const expectedMetadataBytes = 100;
+    const receivedMetadataBytes = 50;
+    const prefix = Buffer.alloc(4);
+    prefix.writeUInt32LE(expectedMetadataBytes);
+    handlePostResponse(req, res);
+
+    req.emit('data', prefix);
+    req.emit('data', Buffer.alloc(receivedMetadataBytes));
+    req.emit('end');
+
+    const framingErrors = (log.error as jest.Mock).mock.calls.filter(
+      ([, message]) =>
+        message ===
+        'Incomplete response metadata at end of streaming HTTP response.',
+    );
+    expect(log.error).toHaveBeenCalledTimes(1);
+    expect(framingErrors).toHaveLength(1);
+    expect(framingErrors[0][0]).toMatchObject({
+      hashedToken: 'hashed',
+      maskedToken: 'masked',
+      streamingID: 'stream-1',
+      requestId: 'req-1',
+      receivedMetadataBytes,
+      expectedMetadataBytes,
+      error: {
+        message: `Incomplete response metadata: received ${receivedMetadataBytes} of ${expectedMetadataBytes} bytes.`,
+      },
+    });
+    expect(mockWriteStatusAndHeaders).not.toHaveBeenCalled();
+    expect(mockWriteChunk).not.toHaveBeenCalled();
+    expect(mockFinished).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({});
+  });
+
   it('does not classify a zero-byte request as a truncated prefix', () => {
     const { req, res } = createReqRes();
     handlePostResponse(req, res);


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/main/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR fixes and handles correctly fragmented response metadata

  - handle response metadata framing across arbitrary stream event boundaries
  - preserve existing streaming and acknowledgement behavior
  - restore error logging when a metadata-length prefix is incomplete at stream end
  - add focused coverage for fragmented prefixes, UTF-8 metadata, single-event frames, and exact body forwarding

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core streaming parse logic on the broker response-data path; mis-parsing could drop or corrupt proxied responses, though behavior is heavily regression-tested.
> 
> **Overview**
> **Fixes broker streaming response parsing** when the 4-byte metadata-length prefix or JSON metadata arrives split across multiple `data` events (e.g. chunked HTTP with a 1+3 byte prefix).
> 
> `handlePostResponse` now **incrementally buffers** the length prefix and metadata as raw `Buffer` chunks (via `Buffer.concat`) instead of assuming the first chunk contains a full `readUInt32LE` and appending metadata with string concatenation. **On stream end**, it logs structured errors for a truncated prefix or metadata shorter than the declared size, without treating an empty body as a framing failure. Successful paths still call `writeStatusAndHeaders`, forward body chunks, finish the stream, and return HTTP 200.
> 
> **Tests** add broad coverage: many prefix split patterns, UTF-8 metadata split mid-codepoint, metadata/body overlap in one event, incomplete-frame logging, and a local Express/HTTP integration that reproduces 1+3 prefix delivery over chunked transfer-encoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d5cc18fdd1587408566ca62cfce77b9f80d1d7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->