### PR TITLE
refactor: modernize pending POST stream response delivery

### DIFF
--- a/lib/hybrid-sdk/LegacyStreamResponseHandler.ts
+++ b/lib/hybrid-sdk/LegacyStreamResponseHandler.ts
@@ -1,45 +1,118 @@
-import {
-  streamsStore,
-  StreamResponse,
-} from './http/server-post-stream-handler';
+import { PassThrough } from 'stream';
+import { pipeline } from 'stream/promises';
+
 import { log as logger } from '../logs/logger';
-import { observeResponseSize } from './common/utils/metrics';
+import {
+  PendingResponse,
+  PendingResponseRegistry,
+  pendingResponseRegistry,
+} from './http/server-post-stream-handler';
+import { ResponseMetadata } from './http/response-frame-decoder';
+import { getDesensitizedToken } from './server/utils/token';
+
+type LegacyChunk = Buffer | string | undefined;
 
 /**
- * @deprecated Deprecated in favour of {@link StreamResponseHandler} */
-export const legacyStreamResponseHandler = (token) => {
-  return (streamingID, chunk, finished, ioResponse) => {
-    const streamFromId = streamsStore.get(streamingID) as StreamResponse;
+ * Adapts the callback-based websocket chunk protocol to a claimed response.
+ *
+ * The PassThrough is a source owned only by this legacy delivery. The actual
+ * HTTP response remains in pipeline(), so its backpressure, errors and final
+ * completion are included in the delivery lifecycle.
+ */
+class LegacyResponseDelivery {
+  private readonly source = new PassThrough({ highWaterMark: 1024 * 1024 });
+  private bodyBytes = 0;
+  private ended = false;
 
-    if (streamFromId) {
-      const { streamBuffer, response } = streamFromId;
-      let { streamSize } = streamFromId;
+  constructor(
+    private readonly pending: PendingResponse,
+    private readonly logContext: Record<string, unknown>,
+    onSettled: () => void,
+  ) {
+    void pipeline(this.source, pending.destination)
+      .then(() => pending.complete(this.bodyBytes))
+      .catch((error: Error) => {
+        pending.cancel(error);
+        logger.error(
+          { ...this.logContext, error },
+          'Failed forwarding legacy websocket response stream.',
+        );
+      })
+      .finally(onSettled);
+  }
 
-      if (streamBuffer) {
-        if (ioResponse) {
-          response.status(ioResponse.status).set(ioResponse.headers);
-        }
-        if (chunk) {
-          streamSize += chunk.length;
-          streamBuffer.write(chunk);
-          streamsStore.set(streamingID, { streamSize, streamBuffer, response });
-        }
-        if (finished) {
-          streamBuffer.end();
-          streamsStore.del(streamingID);
-          observeResponseSize({
-            bytes: streamSize,
-            isStreaming: true,
-          });
-        }
-      } else {
-        logger.warn({ streamingID, token }, 'Discarding binary chunk.');
-      }
-    } else {
-      logger.warn(
-        { streamingID, token },
-        'Trying to write into a closed stream.',
-      );
+  write(
+    chunk: LegacyChunk,
+    finished: boolean,
+    metadata?: ResponseMetadata,
+  ): void {
+    if (this.ended) {
+      return;
     }
+
+    try {
+      if (metadata) {
+        this.pending.applyMetadata(metadata);
+      }
+      if (chunk) {
+        // Preserve the legacy receiver metric semantics for string chunks.
+        this.bodyBytes += chunk.length;
+        // The legacy event contract has no acknowledgement with which to
+        // propagate drain. PassThrough preserves its buffering boundary while
+        // pipeline coordinates the readable side and the real destination.
+        this.source.write(chunk);
+      }
+      if (finished) {
+        this.ended = true;
+        this.source.end();
+      }
+    } catch (error) {
+      this.ended = true;
+      this.source.destroy(error as Error);
+    }
+  }
+}
+
+export const legacyStreamResponseHandler = (
+  token: string,
+  registry: PendingResponseRegistry = pendingResponseRegistry,
+) => {
+  const deliveries = new Map<string, LegacyResponseDelivery>();
+
+  return (
+    streamingID: string,
+    chunk: LegacyChunk,
+    finished: boolean,
+    metadata?: ResponseMetadata,
+  ): void => {
+    let delivery = deliveries.get(streamingID);
+    if (!delivery) {
+      const claim = registry.claim(streamingID, {
+        legacyConnectionIdentifier: token,
+        enforceLegacyOwnership: true,
+      });
+      if (claim.status !== 'claimed') {
+        const { maskedToken, hashedToken } = getDesensitizedToken(token);
+        logger.warn(
+          {
+            streamingID,
+            claimStatus: claim.status,
+            maskedToken,
+            hashedToken,
+          },
+          'Trying to write into a closed or claimed stream.',
+        );
+        return;
+      }
+
+      delivery = new LegacyResponseDelivery(
+        claim.pending,
+        { streamingID },
+        () => deliveries.delete(streamingID),
+      );
+      deliveries.set(streamingID, delivery);
+    }
+
+    delivery.write(chunk, finished, metadata);
   };
 };

--- a/lib/hybrid-sdk/clientRequestHelpers.ts
+++ b/lib/hybrid-sdk/clientRequestHelpers.ts
@@ -10,8 +10,7 @@ import {
 import undefsafe from 'undefsafe';
 import { ExtendedLogContext } from './common/types/log';
 import { uuidv4 } from './common/utils/uuid';
-import stream from 'stream';
-import { streamsStore } from './http/server-post-stream-handler';
+import { pendingResponseRegistry } from './http/server-post-stream-handler';
 import { maskToken } from './common/utils/token';
 import { makeRequestToDownstream } from './http/request';
 
@@ -58,33 +57,29 @@ export class HybridClientRequestHandler {
 
   private makeWebsocketRequestWithStreamingResponse() {
     const streamingID = uuidv4();
-    const streamBuffer = new stream.PassThrough({ highWaterMark: 1048576 });
-    streamBuffer.on('error', (error) => {
-      // This may be a duplicate error, as the most likely cause of this is the POST handler calling destroy.
-      logger.error(
-        {
-          ...this.logContext,
-          error,
-          stackTrace: new Error('stacktrace generator').stack,
-        },
-        '[HTTP Flow][Relay] Error piping POST response stream through to HTTP response',
-      );
-      this.res.destroy(error);
-    });
     this.logContext.streamingID = streamingID;
     logger.debug(
       this.logContext,
       '[HTTP Flow][Relay] Sending request over websocket connection expecting POST stream response',
     );
 
-    streamsStore.set(streamingID, {
+    const registration = pendingResponseRegistry.register(streamingID, {
       response: this.res,
-      streamBuffer,
-      streamSize: 0,
       brokerAppClientId: this.res.locals.brokerAppClientId ?? null,
+      legacyConnectionIdentifier:
+        this.req.params?.token ??
+        (this.options.universalBrokerEnabled
+          ? this.res.locals.websocket.identifier
+          : this.options.brokerToken),
     });
+    if (registration.status === 'destination-unavailable') {
+      logger.debug(
+        this.logContext,
+        '[HTTP Flow][Relay] Requester disconnected before POST stream registration.',
+      );
+      return;
+    }
     this.res.setHeader('snyk-request-id', this.req.requestId);
-    streamBuffer.pipe(this.res);
     const simplifiedContextWithStreamingID = this.simplifiedContext;
     simplifiedContextWithStreamingID['streamingID'] = streamingID;
     logger.debug(

--- a/lib/hybrid-sdk/http/response-frame-decoder.ts
+++ b/lib/hybrid-sdk/http/response-frame-decoder.ts
@@ -1,0 +1,179 @@
+import { Transform, TransformCallback } from 'stream';
+
+export interface ResponseMetadata {
+  status: number;
+  headers?: Record<string, string | string[] | number | undefined>;
+  errorType?: string;
+}
+
+export interface ResponseFrameDecoderOptions {
+  maxMetadataBytes?: number;
+  onMetadata?: (metadata: ResponseMetadata) => void;
+}
+
+const PREFIX_BYTES = 4;
+// Defensive implementation bound only. Choosing a protocol-level limit needs
+// a separate compatibility decision across deployed Broker versions.
+// TODO: replace this with an explicitly versioned protocol limit.
+const DEFAULT_MAX_METADATA_BYTES = 1024 * 1024;
+
+/**
+ * Decodes one Broker POST response frame:
+ *
+ *   4-byte little-endian metadata byte length | JSON metadata | body bytes
+ *
+ * Only body bytes are emitted from the readable side. Metadata is delivered
+ * synchronously before the first body byte through the callback/event.
+ */
+export class ResponseFrameDecoder extends Transform {
+  readonly maxMetadataBytes: number;
+  bodyBytes = 0;
+
+  private readonly prefix = Buffer.alloc(PREFIX_BYTES);
+  private prefixBytes = 0;
+  private metadataBytesExpected: number | null = null;
+  private metadataBytes = 0;
+  private readonly metadataChunks: Buffer[] = [];
+  private metadataDecoded = false;
+  private readonly onMetadata?: (metadata: ResponseMetadata) => void;
+
+  constructor(options: ResponseFrameDecoderOptions = {}) {
+    super();
+    this.maxMetadataBytes =
+      options.maxMetadataBytes ?? DEFAULT_MAX_METADATA_BYTES;
+    this.onMetadata = options.onMetadata;
+  }
+
+  _transform(
+    chunk: Buffer | string,
+    encoding: BufferEncoding,
+    callback: TransformCallback,
+  ): void {
+    try {
+      const data = Buffer.isBuffer(chunk)
+        ? chunk
+        : Buffer.from(chunk, encoding);
+      let offset = 0;
+
+      if (this.metadataBytesExpected === null) {
+        const prefixBytesToCopy = Math.min(
+          PREFIX_BYTES - this.prefixBytes,
+          data.length,
+        );
+        data.copy(
+          this.prefix,
+          this.prefixBytes,
+          offset,
+          offset + prefixBytesToCopy,
+        );
+        this.prefixBytes += prefixBytesToCopy;
+        offset += prefixBytesToCopy;
+
+        if (this.prefixBytes < PREFIX_BYTES) {
+          callback();
+          return;
+        }
+
+        this.metadataBytesExpected = this.prefix.readUInt32LE(0);
+        if (this.metadataBytesExpected === 0) {
+          throw new Error('Response metadata must not be empty.');
+        }
+        if (this.metadataBytesExpected > this.maxMetadataBytes) {
+          throw new Error(
+            `Response metadata length ${this.metadataBytesExpected} exceeds the ${this.maxMetadataBytes}-byte limit.`,
+          );
+        }
+      }
+
+      if (!this.metadataDecoded && offset < data.length) {
+        const metadataBytesToCopy = Math.min(
+          this.metadataBytesExpected - this.metadataBytes,
+          data.length - offset,
+        );
+        if (metadataBytesToCopy > 0) {
+          this.metadataChunks.push(
+            data.subarray(offset, offset + metadataBytesToCopy),
+          );
+          this.metadataBytes += metadataBytesToCopy;
+          offset += metadataBytesToCopy;
+        }
+
+        if (this.metadataBytes === this.metadataBytesExpected) {
+          const metadata = this.decodeMetadata();
+          this.metadataDecoded = true;
+          this.onMetadata?.(metadata);
+          this.emit('metadata', metadata);
+        }
+      }
+
+      if (this.metadataDecoded && offset < data.length) {
+        const body = data.subarray(offset);
+        this.bodyBytes += body.length;
+        this.push(body);
+      }
+      callback();
+    } catch (error) {
+      callback(error as Error);
+    }
+  }
+
+  _flush(callback: TransformCallback): void {
+    if (this.prefixBytes < PREFIX_BYTES) {
+      callback(
+        new Error(
+          `Incomplete metadata-length prefix: received ${this.prefixBytes} of ${PREFIX_BYTES} bytes.`,
+        ),
+      );
+      return;
+    }
+    if (!this.metadataDecoded) {
+      callback(
+        new Error(
+          `Incomplete response metadata: received ${this.metadataBytes} of ${this.metadataBytesExpected} bytes.`,
+        ),
+      );
+      return;
+    }
+    callback();
+  }
+
+  private decodeMetadata(): ResponseMetadata {
+    const encoded = Buffer.concat(
+      this.metadataChunks,
+      this.metadataBytesExpected!,
+    ).toString('utf8');
+    let value: unknown;
+    try {
+      value = JSON.parse(encoded);
+    } catch (error) {
+      throw new Error('Malformed response metadata JSON.', { cause: error });
+    }
+
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      throw new Error('Response metadata must be a JSON object.');
+    }
+    const metadata = value as Partial<ResponseMetadata>;
+    if (
+      !Number.isInteger(metadata.status) ||
+      metadata.status! < 100 ||
+      metadata.status! > 999
+    ) {
+      throw new Error('Response metadata must contain a valid status.');
+    }
+    if (
+      metadata.headers !== undefined &&
+      (typeof metadata.headers !== 'object' ||
+        metadata.headers === null ||
+        Array.isArray(metadata.headers))
+    ) {
+      throw new Error('Response metadata headers must be an object.');
+    }
+    if (
+      metadata.errorType !== undefined &&
+      typeof metadata.errorType !== 'string'
+    ) {
+      throw new Error('Response metadata errorType must be a string.');
+    }
+    return metadata as ResponseMetadata;
+  }
+}

--- a/lib/hybrid-sdk/http/response-frame-decoder.ts
+++ b/lib/hybrid-sdk/http/response-frame-decoder.ts
@@ -1,4 +1,4 @@
-import { Transform, TransformCallback } from 'stream';
+import { Transform, TransformCallback } from 'node:stream';
 
 export interface ResponseMetadata {
   status: number;
@@ -9,6 +9,33 @@ export interface ResponseMetadata {
 export interface ResponseFrameDecoderOptions {
   maxMetadataBytes?: number;
   onMetadata?: (metadata: ResponseMetadata) => void;
+}
+
+export type ResponseFrameFailureDiagnostics =
+  | {
+      failureReason: 'incomplete-prefix';
+      receivedPrefixBytes: number;
+      expectedPrefixBytes: number;
+    }
+  | {
+      failureReason: 'incomplete-metadata';
+      receivedMetadataBytes: number;
+      expectedMetadataBytes: number;
+    }
+  | { failureReason: 'malformed-metadata' }
+  | { failureReason: 'invalid-metadata' }
+  | { failureReason: 'metadata-too-large' };
+
+/** A decoder-owned failure with safe context suitable for structured logs. */
+export class ResponseFrameError extends Error {
+  constructor(
+    message: string,
+    readonly diagnostics: ResponseFrameFailureDiagnostics,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'ResponseFrameError';
+  }
 }
 
 const PREFIX_BYTES = 4;
@@ -76,11 +103,14 @@ export class ResponseFrameDecoder extends Transform {
 
         this.metadataBytesExpected = this.prefix.readUInt32LE(0);
         if (this.metadataBytesExpected === 0) {
-          throw new Error('Response metadata must not be empty.');
+          throw new ResponseFrameError('Response metadata must not be empty.', {
+            failureReason: 'invalid-metadata',
+          });
         }
         if (this.metadataBytesExpected > this.maxMetadataBytes) {
-          throw new Error(
+          throw new ResponseFrameError(
             `Response metadata length ${this.metadataBytesExpected} exceeds the ${this.maxMetadataBytes}-byte limit.`,
+            { failureReason: 'metadata-too-large' },
           );
         }
       }
@@ -120,16 +150,26 @@ export class ResponseFrameDecoder extends Transform {
   _flush(callback: TransformCallback): void {
     if (this.prefixBytes < PREFIX_BYTES) {
       callback(
-        new Error(
+        new ResponseFrameError(
           `Incomplete metadata-length prefix: received ${this.prefixBytes} of ${PREFIX_BYTES} bytes.`,
+          {
+            failureReason: 'incomplete-prefix',
+            receivedPrefixBytes: this.prefixBytes,
+            expectedPrefixBytes: PREFIX_BYTES,
+          },
         ),
       );
       return;
     }
     if (!this.metadataDecoded) {
       callback(
-        new Error(
+        new ResponseFrameError(
           `Incomplete response metadata: received ${this.metadataBytes} of ${this.metadataBytesExpected} bytes.`,
+          {
+            failureReason: 'incomplete-metadata',
+            receivedMetadataBytes: this.metadataBytes,
+            expectedMetadataBytes: this.metadataBytesExpected!,
+          },
         ),
       );
       return;
@@ -146,11 +186,17 @@ export class ResponseFrameDecoder extends Transform {
     try {
       value = JSON.parse(encoded);
     } catch (error) {
-      throw new Error('Malformed response metadata JSON.', { cause: error });
+      throw new ResponseFrameError(
+        'Malformed response metadata JSON.',
+        { failureReason: 'malformed-metadata' },
+        { cause: error },
+      );
     }
 
     if (!value || typeof value !== 'object' || Array.isArray(value)) {
-      throw new Error('Response metadata must be a JSON object.');
+      throw new ResponseFrameError('Response metadata must be a JSON object.', {
+        failureReason: 'invalid-metadata',
+      });
     }
     const metadata = value as Partial<ResponseMetadata>;
     if (
@@ -158,7 +204,10 @@ export class ResponseFrameDecoder extends Transform {
       metadata.status! < 100 ||
       metadata.status! > 999
     ) {
-      throw new Error('Response metadata must contain a valid status.');
+      throw new ResponseFrameError(
+        'Response metadata must contain a valid status.',
+        { failureReason: 'invalid-metadata' },
+      );
     }
     if (
       metadata.headers !== undefined &&
@@ -166,13 +215,19 @@ export class ResponseFrameDecoder extends Transform {
         metadata.headers === null ||
         Array.isArray(metadata.headers))
     ) {
-      throw new Error('Response metadata headers must be an object.');
+      throw new ResponseFrameError(
+        'Response metadata headers must be an object.',
+        { failureReason: 'invalid-metadata' },
+      );
     }
     if (
       metadata.errorType !== undefined &&
       typeof metadata.errorType !== 'string'
     ) {
-      throw new Error('Response metadata errorType must be a string.');
+      throw new ResponseFrameError(
+        'Response metadata errorType must be a string.',
+        { failureReason: 'invalid-metadata' },
+      );
     }
     return metadata as ResponseMetadata;
   }

--- a/lib/hybrid-sdk/http/server-post-stream-handler.ts
+++ b/lib/hybrid-sdk/http/server-post-stream-handler.ts
@@ -1,79 +1,289 @@
-import stream from 'stream';
-
+import { Writable } from 'node:stream';
 import { Response } from 'express';
 import NodeCache from 'node-cache';
 import { getConfig } from '../common/config/config';
 import { observeResponseSize } from '../common/utils/metrics';
+import { ResponseMetadata } from './response-frame-decoder';
 
-export const streamsStore = new NodeCache({
-  stdTTL: parseInt(getConfig().cacheExpiry) || 3600, // 1 hour
-  checkperiod: parseInt(getConfig().cacheCheckPeriod) || 60, // 1 min
-  useClones: false,
-});
+export interface PendingResponseRegistration {
+  readonly response: Response;
+  readonly brokerAppClientId: string | null;
+  readonly legacyConnectionIdentifier?: string;
+}
 
-export interface StreamResponse {
-  streamBuffer: stream.PassThrough;
+export interface ClaimOptions {
+  brokerAppClientId?: string;
+  enforceBrokerOwnership?: boolean;
+  legacyConnectionIdentifier?: string;
+  enforceLegacyOwnership?: boolean;
+}
+
+export type RegistrationResult =
+  | { status: 'registered' }
+  | { status: 'destination-unavailable' };
+
+export type ClaimResult =
+  | { status: 'claimed'; pending: PendingResponse }
+  | { status: 'not-found' | 'already-claimed' | 'owner-mismatch' };
+
+type Settlement =
+  | { type: 'complete'; bodyBytes: number }
+  | { type: 'cancel'; error?: Error };
+
+/** A one-shot capability returned by PendingResponseRegistry.claim(). */
+export class PendingResponse {
+  readonly destination: Writable;
+
+  constructor(
+    readonly streamingID: string,
+    private readonly response: Response,
+    private readonly settle: (
+      pending: PendingResponse,
+      settlement: Settlement,
+    ) => boolean,
+  ) {
+    // The original response is deliberately the destination. In particular,
+    // POST delivery must not terminate at an intermediate buffer.
+    this.destination = response;
+  }
+
+  applyMetadata(metadata: ResponseMetadata): void {
+    if (isResponseUnavailable(this.response)) {
+      throw new Error(
+        `Pending response ${this.streamingID} cannot accept response metadata.`,
+      );
+    }
+    this.response.status(metadata.status);
+    if (metadata.headers) {
+      this.response.set(metadata.headers);
+    }
+  }
+
+  complete(bodyBytes: number): boolean {
+    return this.settle(this, { type: 'complete', bodyBytes });
+  }
+
+  cancel(error?: Error): boolean {
+    return this.settle(this, { type: 'cancel', error });
+  }
+}
+
+interface ResponseWatchers {
   response: Response;
-  streamSize?: number;
-  brokerAppClientId: string | null;
+  onClose: () => void;
+  onError: (error: Error) => void;
 }
 
-export class StreamResponseHandler {
-  streamingID: string;
-  streamResponse: StreamResponse;
-  // streamBuffer;
-  // response;
-  // streamSize = 0;
+/**
+ * Owns pending-response registration, broker ownership checks, one-shot claims,
+ * cancellation and expiry. Cache records never escape this class.
+ */
+export class PendingResponseRegistry {
+  private readonly activeClaims = new Map<string, PendingResponse>();
+  private readonly responseWatchers = new Map<string, ResponseWatchers>();
+  private readonly onExpired = (
+    streamingID: string,
+    registration: PendingResponseRegistration,
+  ) => {
+    this.expireRegistration(streamingID, registration);
+  };
 
-  static create(streamingID) {
-    const stream = streamsStore.get(streamingID);
-    if (!stream) {
-      return null;
+  private readonly expireRegistration = (
+    streamingID: string,
+    registration: PendingResponseRegistration,
+  ) => {
+    this.detachResponseWatchers(streamingID);
+    if (!registration.response.destroyed) {
+      registration.response.destroy();
     }
-    const streamResponse = stream as StreamResponse;
+  };
 
-    return new StreamResponseHandler(
-      streamingID,
-      streamResponse.streamBuffer,
-      streamResponse.response,
-      streamResponse.brokerAppClientId ?? null,
-    );
+  constructor(
+    private readonly store: NodeCache = new NodeCache({
+      stdTTL: parseInt(getConfig().cacheExpiry) || 3600, // 1 hour
+      checkperiod: parseInt(getConfig().cacheCheckPeriod) || 60, // 1 min
+      useClones: false,
+    }),
+  ) {
+    this.store.on('expired', this.onExpired);
   }
 
-  constructor(streamingID, streamBuffer, response, brokerAppClientId) {
-    this.streamingID = streamingID;
-    this.streamResponse = {
-      streamBuffer,
-      response,
-      streamSize: 0,
-      brokerAppClientId,
+  register(
+    streamingID: string,
+    registration: PendingResponseRegistration,
+    ttlSeconds?: number,
+  ): RegistrationResult {
+    if (this.activeClaims.has(streamingID) || this.store.has(streamingID)) {
+      throw new Error(`Pending response ${streamingID} is already registered.`);
+    }
+    if (isResponseUnavailable(registration.response)) {
+      return { status: 'destination-unavailable' };
+    }
+
+    const storedRegistration = { ...registration };
+    if (ttlSeconds === undefined) {
+      this.store.set(streamingID, storedRegistration);
+    } else {
+      this.store.set(streamingID, storedRegistration, ttlSeconds);
+    }
+
+    const onClose = () => {
+      if (storedRegistration.response.writableFinished) {
+        if (!this.activeClaims.has(streamingID)) {
+          this.store.del(streamingID);
+        }
+        this.detachResponseWatchers(streamingID);
+        return;
+      }
+      this.cancelFromDestination(
+        streamingID,
+        new Error(`Original response ${streamingID} closed prematurely.`),
+      );
     };
+    const onError = (error: Error) =>
+      this.cancelFromDestination(streamingID, error);
+    storedRegistration.response.once('close', onClose);
+    storedRegistration.response.once('error', onError);
+    this.responseWatchers.set(streamingID, {
+      response: storedRegistration.response,
+      onClose,
+      onError,
+    });
+    return { status: 'registered' };
   }
 
-  writeStatusAndHeaders = (statusAndHeaders) => {
-    this.streamResponse.response
-      .status(statusAndHeaders.status)
-      .set(statusAndHeaders.headers);
-  };
-
-  writeChunk = (chunk, waitForDrainCb) => {
-    this.streamResponse.streamSize += chunk.length;
-    if (!this.streamResponse.streamBuffer.write(chunk) && waitForDrainCb) {
-      waitForDrainCb(this.streamResponse.streamBuffer);
+  claim(streamingID: string, options: ClaimOptions = {}): ClaimResult {
+    const registration =
+      this.store.get<PendingResponseRegistration>(streamingID);
+    if (!registration) {
+      return {
+        status: this.activeClaims.has(streamingID)
+          ? 'already-claimed'
+          : 'not-found',
+      };
     }
-  };
 
-  finished = () => {
-    this.streamResponse.streamBuffer.end();
-    streamsStore.del(this.streamingID);
-    observeResponseSize({
-      bytes: this.streamResponse.streamSize,
-      isStreaming: true,
-    });
-  };
+    if (
+      (options.enforceBrokerOwnership &&
+        (!options.brokerAppClientId ||
+          !registration.brokerAppClientId ||
+          options.brokerAppClientId !== registration.brokerAppClientId)) ||
+      (options.enforceLegacyOwnership &&
+        (!options.legacyConnectionIdentifier ||
+          !registration.legacyConnectionIdentifier ||
+          options.legacyConnectionIdentifier !==
+            registration.legacyConnectionIdentifier))
+    ) {
+      return { status: 'owner-mismatch' };
+    }
 
-  destroy = (error) => {
-    this.streamResponse.streamBuffer.destroy(error);
-    streamsStore.del(this.streamingID);
-  };
+    // NodeCache revalidates expiry in take(). Treat that result as the
+    // ownership boundary: a value observed by get() must not escape if it
+    // expires before the cache can remove it.
+    const claimedRegistration =
+      this.store.take<PendingResponseRegistration>(streamingID);
+    if (!claimedRegistration) {
+      return {
+        status: this.activeClaims.has(streamingID)
+          ? 'already-claimed'
+          : 'not-found',
+      };
+    }
+    const pending = new PendingResponse(
+      streamingID,
+      claimedRegistration.response,
+      (settledPending, settlement) => this.settle(settledPending, settlement),
+    );
+    this.activeClaims.set(streamingID, pending);
+
+    return { status: 'claimed', pending };
+  }
+
+  cancel(streamingID: string, error?: Error): boolean {
+    const active = this.activeClaims.get(streamingID);
+    if (active) {
+      return active.cancel(error);
+    }
+
+    const registration =
+      this.store.get<PendingResponseRegistration>(streamingID);
+    if (!registration) {
+      this.detachResponseWatchers(streamingID);
+      return false;
+    }
+    this.store.del(streamingID);
+    this.detachResponseWatchers(streamingID);
+    if (!registration.response.destroyed) {
+      registration.response.destroy(error);
+    }
+    return true;
+  }
+
+  dispose(): void {
+    this.store.off('expired', this.onExpired);
+    for (const streamingID of this.responseWatchers.keys()) {
+      this.detachResponseWatchers(streamingID);
+    }
+  }
+
+  private settle(
+    pending: PendingResponse,
+    settlement: Settlement,
+    destroyDestination = true,
+  ): boolean {
+    if (this.activeClaims.get(pending.streamingID) !== pending) {
+      return false;
+    }
+
+    this.activeClaims.delete(pending.streamingID);
+    this.detachResponseWatchers(pending.streamingID);
+
+    if (settlement.type === 'complete') {
+      observeResponseSize({
+        bytes: settlement.bodyBytes,
+        isStreaming: true,
+      });
+    } else if (destroyDestination && !pending.destination.destroyed) {
+      pending.destination.destroy(settlement.error);
+    }
+    return true;
+  }
+
+  private cancelFromDestination(streamingID: string, error: Error): void {
+    const active = this.activeClaims.get(streamingID);
+    if (active) {
+      // The destination has already failed or closed. Release registry state;
+      // pipeline owns propagation and destruction from this point.
+      this.settle(active, { type: 'cancel', error }, false);
+      return;
+    }
+
+    const registration =
+      this.store.get<PendingResponseRegistration>(streamingID);
+    if (registration) {
+      this.store.del(streamingID);
+    }
+    this.detachResponseWatchers(streamingID);
+    if (registration && !registration.response.destroyed) {
+      registration.response.destroy();
+    }
+  }
+
+  private detachResponseWatchers(streamingID: string): void {
+    const watchers = this.responseWatchers.get(streamingID);
+    if (!watchers) {
+      return;
+    }
+    watchers.response.off('close', watchers.onClose);
+    watchers.response.off('error', watchers.onError);
+    this.responseWatchers.delete(streamingID);
+  }
 }
+
+const isResponseUnavailable = (response: Response): boolean =>
+  response.destroyed ||
+  response.writableEnded ||
+  response.writableFinished ||
+  response.headersSent;
+
+export const pendingResponseRegistry = new PendingResponseRegistry();

--- a/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.ts
+++ b/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.ts
@@ -1,13 +1,24 @@
 import { Request, Response } from 'express';
-
-import { log as logger } from '../../../logs/logger';
-import { getDesensitizedToken } from '../utils/token';
-import { incrementHttpRequestsTotal } from '../../common/utils/metrics';
-import { getConfig } from '../../common/config/config';
 import { decode } from 'jsonwebtoken';
-import { StreamResponseHandler } from '../../http/server-post-stream-handler';
+import { pipeline } from 'node:stream/promises';
+import { log as logger } from '../../../logs/logger';
+import { getConfig } from '../../common/config/config';
+import { incrementHttpRequestsTotal } from '../../common/utils/metrics';
+import {
+  PendingResponse,
+  pendingResponseRegistry,
+} from '../../http/server-post-stream-handler';
+import {
+  ResponseFrameDecoder,
+  ResponseFrameError,
+  ResponseMetadata,
+} from '../../http/response-frame-decoder';
+import { getDesensitizedToken } from '../utils/token';
 
-export const handlePostResponse = (req: Request, res: Response) => {
+export const handlePostResponse = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
   incrementHttpRequestsTotal(false, 'data-response');
   const token = req.params.brokerToken;
   const streamingID = req.params.streamingId;
@@ -27,17 +38,12 @@ export const handlePostResponse = (req: Request, res: Response) => {
   req['maskedToken'] = desensitizedToken.maskedToken;
   req['hashedToken'] = desensitizedToken.hashedToken;
 
-  const streamHandler = StreamResponseHandler.create(streamingID);
-  if (!streamHandler) {
-    logger.error(logContext, 'Unable to find request matching streaming id.');
-    res
-      .status(500)
-      .json({ message: 'Unable to find request matching streaming id.' });
-    return;
-  }
-  if (getConfig().BROKER_SERVER_MANDATORY_AUTH_ENABLED) {
+  let pending: PendingResponse | undefined;
+  try {
+    const enforceBrokerOwnership =
+      getConfig().BROKER_SERVER_MANDATORY_AUTH_ENABLED;
     const credentials = req.headers.authorization;
-    if (!credentials) {
+    if (enforceBrokerOwnership && !credentials) {
       logger.error(
         logContext,
         'Invalid Broker client credentials on response data.',
@@ -45,18 +51,20 @@ export const handlePostResponse = (req: Request, res: Response) => {
       res.status(401).json({ message: 'Invalid Broker client credentials.' });
       return;
     }
-    const decodedJwt = credentials
-      ? decode(credentials!.replace(/bearer /i, ''), {
-          complete: true,
-        })
-      : null;
 
-    const brokerAppClientId = decodedJwt ? decodedJwt?.payload['azp'] : '';
-    if (
-      !brokerAppClientId ||
-      !streamHandler.streamResponse.brokerAppClientId ||
-      brokerAppClientId != streamHandler.streamResponse.brokerAppClientId
-    ) {
+    const decodedJwt =
+      enforceBrokerOwnership && credentials
+        ? decode(credentials.replace(/bearer /i, ''), { complete: true })
+        : null;
+    const brokerAppClientId = decodedJwt
+      ? (decodedJwt.payload['azp'] as string)
+      : undefined;
+    const claim = pendingResponseRegistry.claim(streamingID, {
+      brokerAppClientId,
+      enforceBrokerOwnership,
+    });
+
+    if (claim.status === 'owner-mismatch') {
       logger.error(
         logContext,
         'Invalid Broker client credentials for stream on response data.',
@@ -64,168 +72,61 @@ export const handlePostResponse = (req: Request, res: Response) => {
       res.status(401).json({ message: 'Invalid Broker client credentials.' });
       return;
     }
-  }
-  let statusAndHeaders = '';
-  let statusAndHeadersSize = -1;
-  const statusAndHeadersSizeBuffer = Buffer.alloc(4);
-  let statusAndHeadersSizeBytesRead = 0;
-  const statusAndHeadersBuffers: Buffer[] = [];
-  let statusAndHeadersLength = 0;
-  req
-    .on('data', function (data) {
-      try {
-        logger.trace(
-          { ...logContext, dataLength: Buffer.byteLength(data, 'utf8') },
-          'Received data event.',
-        );
-        let bytesRead = 0;
-        if (statusAndHeadersSize === -1) {
-          const bytesToRead = Math.min(
-            statusAndHeadersSizeBuffer.length - statusAndHeadersSizeBytesRead,
-            data.length,
-          );
-          data.copy(
-            statusAndHeadersSizeBuffer,
-            statusAndHeadersSizeBytesRead,
-            bytesRead,
-            bytesRead + bytesToRead,
-          );
-          statusAndHeadersSizeBytesRead += bytesToRead;
-          bytesRead += bytesToRead;
-          if (
-            statusAndHeadersSizeBytesRead < statusAndHeadersSizeBuffer.length
-          ) {
-            return;
-          }
-          statusAndHeadersSize = statusAndHeadersSizeBuffer.readUInt32LE();
-          logger.debug(
-            { ...logContext, statusAndHeadersSize },
-            'Request metadata size read from stream.',
-          );
-        }
-
-        if (
-          statusAndHeadersSize > 0 &&
-          statusAndHeadersLength < statusAndHeadersSize
-        ) {
-          const endPosition = Math.min(
-            bytesRead + statusAndHeadersSize - statusAndHeadersLength,
-            data.length,
-          );
-          logger.trace(
-            { ...logContext, bytesRead, endPosition },
-            'Reading ioJson.',
-          );
-          const statusAndHeadersChunk = data.subarray(bytesRead, endPosition);
-          statusAndHeadersBuffers.push(statusAndHeadersChunk);
-          statusAndHeadersLength += statusAndHeadersChunk.length;
-          bytesRead = endPosition;
-          if (statusAndHeadersLength === statusAndHeadersSize) {
-            statusAndHeaders = Buffer.concat(
-              statusAndHeadersBuffers,
-              statusAndHeadersSize,
-            ).toString('utf8');
-            statusAndHeadersBuffers.length = 0;
-            logger.trace(
-              { ...logContext, statusAndHeaders },
-              'Converting to json.',
-            );
-            const statusAndHeadersJson = JSON.parse(statusAndHeaders);
-            const logData = {
-              ...logContext,
-              responseStatus: statusAndHeadersJson.status,
-              errorType: statusAndHeadersJson.errorType,
-            };
-            const logMessage = 'Handling response-data request - io bits';
-            if (
-              statusAndHeadersJson.status > 299 &&
-              statusAndHeadersJson.status !== 404
-            ) {
-              logger.info(logData, logMessage);
-            } else {
-              logger.debug(logData, logMessage);
-            }
-            streamHandler.writeStatusAndHeaders(statusAndHeadersJson);
-          } else {
-            logger.trace(
-              {
-                ...logContext,
-                currentSize: statusAndHeadersLength,
-                expectedSize: statusAndHeadersSize,
-              },
-              'Was unable to fit all information into a single data object.',
-            );
-          }
-        }
-        if (bytesRead < data.length) {
-          logger.trace(
-            logContext,
-            'Handling response-data request - data part.',
-          );
-          streamHandler.writeChunk(
-            data.subarray(bytesRead, data.length),
-            (streamBuffer) => {
-              logger.trace(logContext, 'Pausing request stream.');
-              req.pause();
-              streamBuffer.once('drain', () => {
-                logger.trace(logContext, 'Resuming request stream.');
-                req.resume();
-              });
-            },
-          );
-        }
-      } catch (e) {
-        logger.error(
-          { ...logContext, statusAndHeaders, statusAndHeadersSize, error: e },
-          'Caught error handling data event for streaming HTTP response.',
-        );
-      }
-    })
-    .on('end', function () {
-      if (
-        statusAndHeadersSizeBytesRead > 0 &&
-        statusAndHeadersSizeBytesRead < statusAndHeadersSizeBuffer.length
-      ) {
-        const error = new Error(
-          `Incomplete metadata-length prefix: received ${statusAndHeadersSizeBytesRead} of ${statusAndHeadersSizeBuffer.length} bytes.`,
-        );
-        logger.error(
-          {
-            ...logContext,
-            receivedPrefixBytes: statusAndHeadersSizeBytesRead,
-            expectedPrefixBytes: statusAndHeadersSizeBuffer.length,
-            error,
-          },
-          'Incomplete metadata-length prefix at end of streaming HTTP response.',
-        );
-      }
-      if (
-        statusAndHeadersSize >= 0 &&
-        statusAndHeadersLength < statusAndHeadersSize
-      ) {
-        const error = new Error(
-          `Incomplete response metadata: received ${statusAndHeadersLength} of ${statusAndHeadersSize} bytes.`,
-        );
-        logger.error(
-          {
-            ...logContext,
-            receivedMetadataBytes: statusAndHeadersLength,
-            expectedMetadataBytes: statusAndHeadersSize,
-            error,
-          },
-          'Incomplete response metadata at end of streaming HTTP response.',
-        );
-      }
-      logger.debug(logContext, 'Handling response-data request - end part.');
-      streamHandler.finished();
-      res.status(200).json({});
-    })
-    .on('error', (err) => {
+    if (claim.status !== 'claimed') {
       logger.error(
-        { ...logContext, error: err },
-        'Received error handling POST from client.',
+        { ...logContext, claimStatus: claim.status },
+        'Unable to claim request matching streaming id.',
       );
-      streamHandler.destroy(err);
-      res.status(500).json({ err });
+      res
+        .status(500)
+        .json({ message: 'Unable to find request matching streaming id.' });
+      return;
+    }
+    pending = claim.pending;
+
+    const decoder = new ResponseFrameDecoder({
+      onMetadata: (metadata) => {
+        logMetadata(logContext, metadata);
+        pending!.applyMetadata(metadata);
+      },
     });
+
+    await pipeline(req, decoder, pending.destination);
+    pending.complete(decoder.bodyBytes);
+    res.status(200).json({});
+  } catch (error) {
+    const streamError = error as Error;
+    pending?.cancel(streamError);
+    const framingDiagnostics =
+      streamError instanceof ResponseFrameError
+        ? streamError.diagnostics
+        : undefined;
+    logger.error(
+      { ...logContext, ...framingDiagnostics, error: streamError },
+      'Failed handling POST response stream pipeline.',
+    );
+    // This slice intentionally has one generic framing/delivery failure status.
+    // A protocol-hardening slice can split malformed, oversized and server
+    // failures without making 500 the long-term wire contract here.
+    if (!res.headersSent && !res.destroyed) {
+      res.status(500).json({ message: 'Failed to handle response stream.' });
+    }
+  }
+};
+
+const logMetadata = (
+  logContext: Record<string, unknown>,
+  metadata: ResponseMetadata,
+): void => {
+  const logData = {
+    ...logContext,
+    responseStatus: metadata.status,
+    errorType: metadata.errorType,
+  };
+  const logMessage = 'Handling response-data request - io bits';
+  if (metadata.status > 299 && metadata.status !== 404) {
+    logger.info(logData, logMessage);
+  } else {
+    logger.debug(logData, logMessage);
+  }
 };

--- a/test/unit/lib/hybrid-sdk/LegacyStreamResponseHandler.test.ts
+++ b/test/unit/lib/hybrid-sdk/LegacyStreamResponseHandler.test.ts
@@ -1,0 +1,154 @@
+import { PassThrough } from 'node:stream';
+import NodeCache from 'node-cache';
+import { legacyStreamResponseHandler } from '../../../../lib/hybrid-sdk/LegacyStreamResponseHandler';
+import { PendingResponseRegistry } from '../../../../lib/hybrid-sdk/http/server-post-stream-handler';
+import { getDesensitizedToken } from '../../../../lib/hybrid-sdk/server/utils/token';
+import { log as logger } from '../../../../lib/logs/logger';
+
+jest.mock('../../../../lib/logs/logger', () => ({
+  log: {
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+const createResponse = () => {
+  const body: Buffer[] = [];
+  const response = Object.assign(new PassThrough(), {
+    status: jest.fn().mockReturnThis(),
+    set: jest.fn().mockReturnThis(),
+  });
+  response.on('data', (chunk) => body.push(chunk));
+  return { response, body };
+};
+
+const expectSafeFailedClaimLog = (
+  token: string,
+  streamingID: string,
+  claimStatus: 'owner-mismatch' | 'not-found' | 'already-claimed',
+) => {
+  const [logRecord, message] = (logger.warn as jest.Mock).mock.calls.at(-1);
+
+  expect(logRecord).toEqual({
+    streamingID,
+    claimStatus,
+    ...getDesensitizedToken(token),
+  });
+  expect(logRecord).not.toHaveProperty('token');
+  expect(JSON.stringify(logRecord)).not.toContain(token);
+  expect(message).toBe('Trying to write into a closed or claimed stream.');
+};
+
+describe('hybrid-sdk', () => {
+  describe('legacyStreamResponseHandler()', () => {
+    let cache: NodeCache;
+    let registry: PendingResponseRegistry;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      cache = new NodeCache({ useClones: false, checkperiod: 0 });
+      registry = new PendingResponseRegistry(cache);
+    });
+
+    afterEach(() => {
+      registry.dispose();
+      cache.close();
+    });
+
+    it('claims a pending response once and forwards WebSocket chunks', async () => {
+      const { response, body } = createResponse();
+      registry.register('stream-1', {
+        response: response as any,
+        brokerAppClientId: null,
+        legacyConnectionIdentifier: 'token',
+      });
+      const handleChunk = legacyStreamResponseHandler('token', registry);
+      const finished = new Promise<void>((resolve) =>
+        response.once('finish', resolve),
+      );
+
+      handleChunk('stream-1', Buffer.from('first'), false, {
+        status: 206,
+        headers: { 'content-type': 'text/plain' },
+      });
+      expect(registry.claim('stream-1')).toEqual({
+        status: 'already-claimed',
+      });
+      handleChunk('stream-1', Buffer.from('-second'), true);
+      await finished;
+
+      expect(response.status).toHaveBeenCalledWith(206);
+      expect(response.set).toHaveBeenCalledWith({
+        'content-type': 'text/plain',
+      });
+      expect(Buffer.concat(body).toString()).toBe('first-second');
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(registry.claim('stream-1')).toEqual({ status: 'not-found' });
+    });
+
+    it('safely logs when POST delivery claimed the response first', async () => {
+      const { response, body } = createResponse();
+      const token = 'already-claimed-owner-token';
+      registry.register('stream-1', {
+        response: response as any,
+        brokerAppClientId: null,
+        legacyConnectionIdentifier: token,
+      });
+      expect(registry.claim('stream-1').status).toBe('claimed');
+
+      legacyStreamResponseHandler(token, registry)(
+        'stream-1',
+        Buffer.from('must-not-be-written'),
+        true,
+        { status: 200 },
+      );
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(response.status).not.toHaveBeenCalled();
+      expect(body).toEqual([]);
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expectSafeFailedClaimLog(token, 'stream-1', 'already-claimed');
+    });
+
+    it('safely logs and preserves the claim when ownership does not match', () => {
+      const { response } = createResponse();
+      const token = 'wrong-owner-token-that-must-not-be-logged';
+      registry.register('stream-1', {
+        response: response as any,
+        brokerAppClientId: null,
+        legacyConnectionIdentifier: 'right-token',
+      });
+
+      legacyStreamResponseHandler(token, registry)(
+        'stream-1',
+        Buffer.from('must-not-be-written'),
+        true,
+        { status: 200 },
+      );
+
+      expect(response.status).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expectSafeFailedClaimLog(token, 'stream-1', 'owner-mismatch');
+      expect(
+        registry.claim('stream-1', {
+          enforceLegacyOwnership: true,
+          legacyConnectionIdentifier: 'right-token',
+        }).status,
+      ).toBe('claimed');
+    });
+
+    it('safely logs when the pending response is not found', () => {
+      const token = 'not-found-owner-token';
+
+      legacyStreamResponseHandler(token, registry)(
+        'missing-stream',
+        Buffer.from('must-not-be-written'),
+        true,
+        { status: 200 },
+      );
+
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expectSafeFailedClaimLog(token, 'missing-stream', 'not-found');
+    });
+  });
+});

--- a/test/unit/lib/hybrid-sdk/clientRequestHelpers.test.ts
+++ b/test/unit/lib/hybrid-sdk/clientRequestHelpers.test.ts
@@ -1,7 +1,9 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 import { log as logger } from '../../../../lib/logs/logger';
 import { makeRequestToDownstream } from '../../../../lib/hybrid-sdk/http/request';
 import { HybridClientRequestHandler } from '../../../../lib/hybrid-sdk/clientRequestHelpers';
+import { pendingResponseRegistry } from '../../../../lib/hybrid-sdk/http/server-post-stream-handler';
+import { getConfig } from '../../../../lib/hybrid-sdk/common/config/config';
 
 jest.mock('../../../../lib/logs/logger');
 jest.mock('../../../../lib/hybrid-sdk/common/config/config', () => ({
@@ -11,7 +13,9 @@ jest.mock('../../../../lib/hybrid-sdk/common/config/config', () => ({
 // Silence the side-effecting transitive imports (NodeCache init + axios) —
 // they have nothing to do with the log-level under test.
 jest.mock('../../../../lib/hybrid-sdk/http/server-post-stream-handler', () => ({
-  streamsStore: { set: jest.fn(), get: jest.fn(), del: jest.fn() },
+  pendingResponseRegistry: {
+    register: jest.fn(() => ({ status: 'registered' })),
+  },
 }));
 jest.mock('../../../../lib/hybrid-sdk/http/request', () => ({
   makeRequestToDownstream: jest.fn(),
@@ -283,6 +287,122 @@ describe('HybridClientRequestHandler — response carries snyk-request-id on WS 
 
     expect(res.setHeader).toHaveBeenCalledWith('snyk-request-id', BROKER_UUID);
   });
+
+  it('does not send a WebSocket request when the response destination is unavailable', async () => {
+    const wsSend = jest.fn();
+    const res: any = Object.assign(new EventEmitter(), {
+      destroyed: true,
+      locals: {
+        websocket: { send: wsSend, identifier: 'id' },
+        capabilities: ['post-streams'],
+      },
+      setHeader: jest.fn(),
+    });
+    (pendingResponseRegistry.register as jest.Mock).mockReturnValueOnce({
+      status: 'destination-unavailable',
+    });
+    const unhandledRejection = jest.fn();
+    process.once('unhandledRejection', unhandledRejection);
+
+    try {
+      const handler = new HybridClientRequestHandler(makeMockReq() as any, res);
+      expect(() =>
+        handler.makeRequest({ url: '/some/path' } as any),
+      ).not.toThrow();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(wsSend).not.toHaveBeenCalled();
+      expect(res.setHeader).not.toHaveBeenCalled();
+      expect(unhandledRejection).not.toHaveBeenCalled();
+    } finally {
+      process.off('unhandledRejection', unhandledRejection);
+    }
+  });
+});
+
+describe('hybrid-sdk/client HybridClientRequestHandler makeRequest()', () => {
+  const makeMockReq = (params: Record<string, string> = {}) => ({
+    url: '/some/path',
+    method: 'GET',
+    body: '{}',
+    headers: {},
+    params,
+  });
+
+  const makeMockRes = (identifier: string) => ({
+    locals: {
+      websocket: { send: jest.fn(), identifier },
+      capabilities: ['post-streams'],
+    },
+    setHeader: jest.fn(),
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('registers the route token as the legacy owner', () => {
+    (getConfig as jest.Mock).mockReturnValue({
+      universalBrokerEnabled: true,
+      brokerToken: 'classic-fallback',
+    });
+    const req: any = makeMockReq({ token: 'route-owner' });
+    const res: any = makeMockRes('universal-fallback');
+
+    const handler = new HybridClientRequestHandler(req, res);
+    handler.makeRequest({ url: '/some/path' } as any);
+
+    expect(pendingResponseRegistry.register).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        response: res,
+        brokerAppClientId: null,
+        legacyConnectionIdentifier: 'route-owner',
+      },
+    );
+  });
+
+  it('registers the broker token as the classic client-local legacy owner', () => {
+    (getConfig as jest.Mock).mockReturnValue({
+      universalBrokerEnabled: false,
+      brokerToken: 'classic-owner',
+    });
+    const req: any = makeMockReq();
+    const res: any = makeMockRes('universal-fallback');
+
+    const handler = new HybridClientRequestHandler(req, res);
+    handler.makeRequest({ url: '/some/path' } as any);
+
+    expect(pendingResponseRegistry.register).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        response: res,
+        brokerAppClientId: null,
+        legacyConnectionIdentifier: 'classic-owner',
+      },
+    );
+  });
+
+  it('registers the websocket identifier as the Universal client-local legacy owner', () => {
+    (getConfig as jest.Mock).mockReturnValue({
+      universalBrokerEnabled: true,
+      brokerToken: 'classic-fallback',
+    });
+    const req: any = makeMockReq();
+    const res: any = makeMockRes('universal-owner');
+
+    const handler = new HybridClientRequestHandler(req, res);
+    handler.makeRequest({ url: '/some/path' } as any);
+
+    expect(pendingResponseRegistry.register).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        response: res,
+        brokerAppClientId: null,
+        legacyConnectionIdentifier: 'universal-owner',
+      },
+    );
+  });
 });
 
 describe('HybridClientRequestHandler — WS paths include snyk-request-id in payload', () => {
@@ -324,8 +444,8 @@ describe('HybridClientRequestHandler — WS paths include snyk-request-id in pay
 
   it('includes snyk-request-id in WS payload (streaming response path)', () => {
     const wsSend = jest.fn();
-    // The streaming path calls streamBuffer.pipe(this.res), so res must be
-    // an EventEmitter-compatible writable to avoid a synchronous throw.
+    // Registration watches response lifecycle events, so this response mock
+    // remains EventEmitter-compatible.
     const res: any = Object.assign(new EventEmitter(), {
       locals: {
         websocket: { send: wsSend, identifier: 'test-identifier' },

--- a/test/unit/lib/hybrid-sdk/http/pending-response-registry.test.ts
+++ b/test/unit/lib/hybrid-sdk/http/pending-response-registry.test.ts
@@ -1,0 +1,306 @@
+import { PassThrough } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import NodeCache from 'node-cache';
+import { observeResponseSize } from '../../../../../lib/hybrid-sdk/common/utils/metrics';
+import { PendingResponseRegistry } from '../../../../../lib/hybrid-sdk/http/server-post-stream-handler';
+
+jest.mock('../../../../../lib/hybrid-sdk/common/utils/metrics', () => ({
+  observeResponseSize: jest.fn(),
+}));
+
+const createRegistration = (brokerAppClientId = 'broker-a') => {
+  const response = Object.assign(new PassThrough(), {
+    status: jest.fn().mockReturnThis(),
+    set: jest.fn().mockReturnThis(),
+  });
+  const errors: Error[] = [];
+  response.on('error', (error) => errors.push(error));
+  response.resume();
+  return {
+    registration: {
+      response: response as any,
+      brokerAppClientId,
+      legacyConnectionIdentifier: 'legacy-a',
+    },
+    response,
+    errors,
+  };
+};
+
+describe('hybrid-sdk/http', () => {
+  describe('PendingResponseRegistry', () => {
+    let cache: NodeCache;
+    let registry: PendingResponseRegistry;
+
+    beforeEach(() => {
+      cache = new NodeCache({ useClones: false, checkperiod: 0 });
+      registry = new PendingResponseRegistry(cache);
+      jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+      registry.dispose();
+      cache.close();
+      jest.useRealTimers();
+    });
+
+    it('grants a one-shot claim when the response is pending', () => {
+      const { registration, response } = createRegistration();
+      registry.register('stream-1', registration);
+
+      const first = registry.claim('stream-1');
+      const duplicate = registry.claim('stream-1');
+
+      expect(first.status).toBe('claimed');
+      expect(duplicate).toEqual({ status: 'already-claimed' });
+      if (first.status === 'claimed') {
+        expect(first.pending.destination).toBe(response);
+      }
+    });
+
+    it('preserves the claim when broker ownership differs', () => {
+      const { registration } = createRegistration();
+      registry.register('stream-1', registration);
+
+      expect(
+        registry.claim('stream-1', {
+          enforceBrokerOwnership: true,
+          brokerAppClientId: 'broker-b',
+        }),
+      ).toEqual({ status: 'owner-mismatch' });
+      expect(
+        registry.claim('stream-1', {
+          enforceBrokerOwnership: true,
+          brokerAppClientId: 'broker-a',
+        }).status,
+      ).toBe('claimed');
+    });
+
+    it('preserves the claim when legacy connection ownership differs', () => {
+      const { registration } = createRegistration();
+      registry.register('stream-1', registration);
+
+      expect(
+        registry.claim('stream-1', {
+          enforceLegacyOwnership: true,
+          legacyConnectionIdentifier: 'legacy-b',
+        }),
+      ).toEqual({ status: 'owner-mismatch' });
+      expect(
+        registry.claim('stream-1', {
+          enforceLegacyOwnership: true,
+          legacyConnectionIdentifier: 'legacy-a',
+        }).status,
+      ).toBe('claimed');
+    });
+
+    it('rejects registration when the streaming ID is already pending or claimed', () => {
+      const first = createRegistration();
+      const replacement = createRegistration();
+      registry.register('stream-1', first.registration);
+
+      expect(() =>
+        registry.register('stream-1', replacement.registration),
+      ).toThrow('Pending response stream-1 is already registered.');
+      expect(registry.claim('stream-1').status).toBe('claimed');
+      expect(() =>
+        registry.register('stream-1', replacement.registration),
+      ).toThrow('Pending response stream-1 is already registered.');
+      expect(replacement.response.listenerCount('close')).toBe(0);
+    });
+
+    it('returns destination-unavailable when the response is already destroyed', () => {
+      const { registration, response } = createRegistration();
+      response.destroy();
+
+      expect(registry.register('stream-1', registration)).toEqual({
+        status: 'destination-unavailable',
+      });
+
+      expect(registry.claim('stream-1')).toEqual({ status: 'not-found' });
+      expect(response.listenerCount('close')).toBe(0);
+      expect(response.listenerCount('error')).toBe(1);
+    });
+
+    it('destroys the response when it is canceled before being claimed', async () => {
+      const { registration, response, errors } = createRegistration();
+      registry.register('stream-1', registration);
+      const cancellation = new Error('requester disconnected');
+
+      expect(registry.cancel('stream-1', cancellation)).toBe(true);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(response.destroyed).toBe(true);
+      expect(errors).toEqual([cancellation]);
+      expect(registry.claim('stream-1')).toEqual({ status: 'not-found' });
+    });
+
+    it('releases an active claim when the requester disconnects', () => {
+      const { registration, response } = createRegistration();
+      registry.register('stream-1', registration);
+      const claim = registry.claim('stream-1');
+      if (claim.status !== 'claimed') {
+        throw new Error('expected claim');
+      }
+
+      response.emit('close');
+
+      expect(claim.pending.complete(1)).toBe(false);
+      expect(registry.claim('stream-1')).toEqual({ status: 'not-found' });
+    });
+
+    it('removes an unclaimed response when it finishes independently', async () => {
+      const { registration, response } = createRegistration();
+      registry.register('stream-1', registration);
+
+      const closed = new Promise((resolve) => response.once('close', resolve));
+      response.end();
+      await closed;
+
+      expect(registry.claim('stream-1')).toEqual({ status: 'not-found' });
+    });
+
+    it('destroys an unclaimed response when its registration expires', () => {
+      jest.useFakeTimers();
+      const { registration, response } = createRegistration();
+      registry.register('stream-1', registration, 0.01);
+
+      jest.advanceTimersByTime(20);
+
+      expect(registry.claim('stream-1')).toEqual({ status: 'not-found' });
+      expect(response.destroyed).toBe(true);
+    });
+
+    it('returns not-found when the registration expires during acquisition', () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(1_000);
+      const { registration, response } = createRegistration();
+      registry.register('stream-1', registration, 0.01);
+      const expiresAt = cache.getTtl('stream-1');
+      if (!expiresAt) {
+        throw new Error('expected cache expiry');
+      }
+      jest.setSystemTime(expiresAt);
+      const take = jest.spyOn(cache, 'take').mockImplementation((key) => {
+        jest.setSystemTime(expiresAt + 1);
+        return NodeCache.prototype.take.call(cache, key);
+      });
+
+      const claim = registry.claim('stream-1');
+
+      expect(take).toHaveReturnedWith(undefined);
+      expect(claim).toEqual({ status: 'not-found' });
+      expect(response.destroyed).toBe(true);
+      expect(cache.has('stream-1')).toBe(false);
+    });
+
+    it('keeps a claim active when its registration deadline passes', () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(1_000);
+      const { registration, response } = createRegistration();
+      registry.register('stream-1', registration, 0.01);
+      jest.advanceTimersByTime(9);
+      const claim = registry.claim('stream-1');
+      if (claim.status !== 'claimed') {
+        throw new Error('expected claim');
+      }
+
+      jest.advanceTimersByTime(2);
+
+      expect(response.destroyed).toBe(false);
+      expect(claim.pending.complete(1)).toBe(true);
+      expect(registry.claim('stream-1')).toEqual({ status: 'not-found' });
+    });
+
+    it('allows claimed delivery to finish after its registration deadline', async () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(1_000);
+      const { registration, response } = createRegistration();
+      const received: Buffer[] = [];
+      response.on('data', (chunk) => received.push(chunk));
+      registry.register('stream-1', registration, 0.01);
+      jest.advanceTimersByTime(9);
+      const claim = registry.claim('stream-1');
+      if (claim.status !== 'claimed') {
+        throw new Error('expected claim');
+      }
+      const source = new PassThrough();
+      const transfer = pipeline(source, claim.pending.destination);
+
+      source.write(Buffer.from('before-'));
+      jest.advanceTimersByTime(2);
+      source.end(Buffer.from('after'));
+      await transfer;
+
+      expect(Buffer.concat(received).toString()).toBe('before-after');
+      expect(response.destroyed).toBe(true);
+      expect(response.errored).toBeNull();
+      expect(claim.pending.complete(12)).toBe(true);
+      expect(observeResponseSize).toHaveBeenCalledWith({
+        bytes: 12,
+        isStreaming: true,
+      });
+    });
+
+    it('settles only once when completion and cancellation are repeated', () => {
+      const { registration, response } = createRegistration();
+      registry.register('stream-1', registration);
+      const claim = registry.claim('stream-1');
+      if (claim.status !== 'claimed') {
+        throw new Error('expected claim');
+      }
+
+      expect(claim.pending.complete(42)).toBe(true);
+      expect(claim.pending.complete(42)).toBe(false);
+      expect(claim.pending.cancel(new Error('late cancel'))).toBe(false);
+      response.emit('close');
+
+      expect(response.destroyed).toBe(false);
+      expect(observeResponseSize).toHaveBeenCalledTimes(1);
+      expect(observeResponseSize).toHaveBeenCalledWith({
+        bytes: 42,
+        isStreaming: true,
+      });
+      expect(response.listenerCount('close')).toBe(0);
+      expect(response.listenerCount('error')).toBe(1);
+      expect(registry.claim('stream-1')).toEqual({ status: 'not-found' });
+    });
+
+    it('rejects metadata when response headers are already committed', () => {
+      const { registration, response } = createRegistration();
+      registry.register('stream-1', registration);
+      const claim = registry.claim('stream-1');
+      if (claim.status !== 'claimed') {
+        throw new Error('expected claim');
+      }
+      Object.assign(response, { headersSent: true });
+
+      expect(() => claim.pending.applyMetadata({ status: 500 })).toThrow(
+        'Pending response stream-1 cannot accept response metadata.',
+      );
+      expect(response.status).not.toHaveBeenCalled();
+      expect(response.set).not.toHaveBeenCalled();
+      expect(claim.pending.cancel()).toBe(true);
+      expect(response.listenerCount('close')).toBe(0);
+      expect(response.listenerCount('error')).toBe(1);
+    });
+
+    it('destroys the destination once when an active claim is canceled repeatedly', async () => {
+      const { registration, response, errors } = createRegistration();
+      registry.register('stream-1', registration);
+      const claim = registry.claim('stream-1');
+      if (claim.status !== 'claimed') {
+        throw new Error('expected claim');
+      }
+      const error = new Error('delivery failed');
+
+      expect(claim.pending.cancel(error)).toBe(true);
+      expect(claim.pending.cancel(error)).toBe(false);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(response.destroyed).toBe(true);
+      expect(errors).toEqual([error]);
+      expect(observeResponseSize).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/test/unit/lib/hybrid-sdk/http/response-frame-decoder.test.ts
+++ b/test/unit/lib/hybrid-sdk/http/response-frame-decoder.test.ts
@@ -1,0 +1,251 @@
+import { Readable, Writable } from 'stream';
+import { pipeline } from 'stream/promises';
+import { ResponseFrameDecoder } from '../../../../../lib/hybrid-sdk/http/response-frame-decoder';
+
+const createFrame = (
+  body = Buffer.from('response body'),
+  metadata: Record<string, unknown> = {
+    status: 200,
+    headers: { 'content-type': 'text/plain' },
+  },
+) => {
+  const encodedMetadata = Buffer.from(JSON.stringify(metadata), 'utf8');
+  const prefix = Buffer.alloc(4);
+  prefix.writeUInt32LE(encodedMetadata.length);
+  return { prefix, metadata: encodedMetadata, body };
+};
+
+const decode = async (chunks: Buffer[]) => {
+  const body: Buffer[] = [];
+  const metadata = jest.fn();
+  const decoder = new ResponseFrameDecoder({ onMetadata: metadata });
+  await pipeline(
+    Readable.from(chunks),
+    decoder,
+    new Writable({
+      write(chunk, _encoding, callback) {
+        body.push(chunk);
+        callback();
+      },
+    }),
+  );
+  return { body: Buffer.concat(body), metadata, decoder };
+};
+
+describe('ResponseFrameDecoder', () => {
+  it.each([
+    ['1+3', [1, 3]],
+    ['2+2', [2, 2]],
+    ['3+1', [3, 1]],
+    ['1+1+1+1', [1, 1, 1, 1]],
+  ])('decodes a prefix fragmented as %s', async (_label, sizes) => {
+    const framed = createFrame();
+    let offset = 0;
+    const chunks = sizes.map((size) => {
+      const chunk = framed.prefix.subarray(offset, offset + size);
+      offset += size;
+      return chunk;
+    });
+    chunks.push(framed.metadata, framed.body);
+
+    const result = await decode(chunks);
+
+    expect(result.metadata).toHaveBeenCalledWith({
+      status: 200,
+      headers: { 'content-type': 'text/plain' },
+    });
+    expect(result.body).toEqual(framed.body);
+  });
+
+  it('decodes metadata fragmented through a UTF-8 code point', async () => {
+    const framed = createFrame(Buffer.from('body'), {
+      status: 206,
+      headers: { 'x-label': '日本語' },
+    });
+    const split = framed.metadata.indexOf(Buffer.from('日')) + 1;
+
+    const result = await decode([
+      Buffer.concat([framed.prefix, framed.metadata.subarray(0, split)]),
+      framed.metadata.subarray(split),
+      framed.body,
+    ]);
+
+    expect(result.metadata).toHaveBeenCalledWith({
+      status: 206,
+      headers: { 'x-label': '日本語' },
+    });
+    expect(result.body).toEqual(framed.body);
+  });
+
+  it('emits body bytes in the same chunk that completes metadata', async () => {
+    const framed = createFrame();
+    const split = framed.metadata.length - 3;
+    const firstBodyBytes = framed.body.subarray(0, 5);
+
+    const result = await decode([
+      Buffer.concat([framed.prefix, framed.metadata.subarray(0, split)]),
+      Buffer.concat([framed.metadata.subarray(split), firstBodyBytes]),
+      framed.body.subarray(5),
+    ]);
+
+    expect(result.body).toEqual(framed.body);
+  });
+
+  it('emits no body bytes when metadata application fails', async () => {
+    const framed = createFrame(Buffer.from('must-not-be-written'));
+    const destination = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    });
+    const write = jest.spyOn(destination, 'write');
+    const metadataError = new Error('original response rejected metadata');
+
+    await expect(
+      pipeline(
+        Readable.from([
+          Buffer.concat([framed.prefix, framed.metadata, framed.body]),
+        ]),
+        new ResponseFrameDecoder({
+          onMetadata: () => {
+            throw metadataError;
+          },
+        }),
+        destination,
+      ),
+    ).rejects.toThrow(metadataError.message);
+
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('streams the first body bytes before source EOF', async () => {
+    const framed = createFrame();
+    const source = new Readable({ read() {} });
+    const received: Buffer[] = [];
+    let firstWrite!: () => void;
+    const firstWriteSeen = new Promise<void>(
+      (resolve) => (firstWrite = resolve),
+    );
+    const running = pipeline(
+      source,
+      new ResponseFrameDecoder(),
+      new Writable({
+        write(chunk, _encoding, callback) {
+          received.push(chunk);
+          firstWrite();
+          callback();
+        },
+      }),
+    );
+
+    source.push(Buffer.concat([framed.prefix, framed.metadata, framed.body]));
+    await firstWriteSeen;
+    expect(Buffer.concat(received)).toEqual(framed.body);
+    expect(source.readableEnded).toBe(false);
+
+    source.push(null);
+    await running;
+  });
+
+  it('lets pipeline apply destination backpressure to the source', async () => {
+    const framed = createFrame(Buffer.alloc(0));
+    const bodyChunk = Buffer.alloc(64 * 1024);
+    const totalBodyChunks = 100;
+    let emittedBodyChunks = 0;
+    let releaseFirstWrite!: () => void;
+    const firstWriteBlocked = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+    let firstWrite = true;
+    const source = new Readable({
+      read() {
+        if (emittedBodyChunks === 0) {
+          this.push(Buffer.concat([framed.prefix, framed.metadata]));
+        }
+        while (emittedBodyChunks < totalBodyChunks) {
+          emittedBodyChunks += 1;
+          if (!this.push(bodyChunk)) {
+            return;
+          }
+        }
+        this.push(null);
+      },
+    });
+    const destination = new Writable({
+      highWaterMark: 1,
+      write(_chunk, _encoding, callback) {
+        if (firstWrite) {
+          firstWrite = false;
+          firstWriteBlocked.then(() => callback());
+        } else {
+          callback();
+        }
+      },
+    });
+
+    const running = pipeline(source, new ResponseFrameDecoder(), destination);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(emittedBodyChunks).toBeLessThan(totalBodyChunks);
+
+    releaseFirstWrite();
+    await running;
+    expect(emittedBodyChunks).toBe(totalBodyChunks);
+  });
+
+  it.each([1, 2, 3])(
+    'rejects a prefix truncated after %d byte(s)',
+    async (length) => {
+      const { prefix } = createFrame();
+      await expect(decode([prefix.subarray(0, length)])).rejects.toThrow(
+        `Incomplete metadata-length prefix: received ${length} of 4 bytes.`,
+      );
+    },
+  );
+
+  it('rejects truncated metadata', async () => {
+    const { prefix, metadata } = createFrame();
+    await expect(
+      decode([prefix, metadata.subarray(0, metadata.length - 2)]),
+    ).rejects.toThrow(
+      `Incomplete response metadata: received ${metadata.length - 2} of ${
+        metadata.length
+      } bytes.`,
+    );
+  });
+
+  it('rejects malformed metadata JSON', async () => {
+    const malformed = Buffer.from('{not json');
+    const prefix = Buffer.alloc(4);
+    prefix.writeUInt32LE(malformed.length);
+    await expect(decode([prefix, malformed])).rejects.toThrow(
+      'Malformed response metadata JSON.',
+    );
+  });
+
+  it('accepts existing internally generated metadata with no headers field', async () => {
+    const framed = createFrame(Buffer.from('blocked'), { status: 401 });
+
+    const result = await decode([
+      Buffer.concat([framed.prefix, framed.metadata, framed.body]),
+    ]);
+
+    expect(result.metadata).toHaveBeenCalledWith({ status: 401 });
+    expect(result.body).toEqual(framed.body);
+  });
+
+  it('rejects metadata without a valid HTTP status', async () => {
+    const framed = createFrame(Buffer.alloc(0), { headers: {} });
+    await expect(
+      decode([Buffer.concat([framed.prefix, framed.metadata])]),
+    ).rejects.toThrow('Response metadata must contain a valid status.');
+  });
+
+  it('rejects oversized metadata before buffering it', async () => {
+    const prefix = Buffer.alloc(4);
+    prefix.writeUInt32LE(11);
+    const decoder = new ResponseFrameDecoder({ maxMetadataBytes: 10 });
+    await expect(
+      pipeline(Readable.from([prefix]), decoder, new Writable({ write() {} })),
+    ).rejects.toThrow('exceeds the 10-byte limit');
+  });
+});

--- a/test/unit/lib/hybrid-sdk/http/response-frame-decoder.test.ts
+++ b/test/unit/lib/hybrid-sdk/http/response-frame-decoder.test.ts
@@ -1,6 +1,9 @@
-import { Readable, Writable } from 'stream';
-import { pipeline } from 'stream/promises';
-import { ResponseFrameDecoder } from '../../../../../lib/hybrid-sdk/http/response-frame-decoder';
+import { Readable, Writable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import {
+  ResponseFrameDecoder,
+  ResponseFrameError,
+} from '../../../../../lib/hybrid-sdk/http/response-frame-decoder';
 
 const createFrame = (
   body = Buffer.from('response body'),
@@ -32,220 +35,268 @@ const decode = async (chunks: Buffer[]) => {
   return { body: Buffer.concat(body), metadata, decoder };
 };
 
-describe('ResponseFrameDecoder', () => {
-  it.each([
-    ['1+3', [1, 3]],
-    ['2+2', [2, 2]],
-    ['3+1', [3, 1]],
-    ['1+1+1+1', [1, 1, 1, 1]],
-  ])('decodes a prefix fragmented as %s', async (_label, sizes) => {
-    const framed = createFrame();
-    let offset = 0;
-    const chunks = sizes.map((size) => {
-      const chunk = framed.prefix.subarray(offset, offset + size);
-      offset += size;
-      return chunk;
-    });
-    chunks.push(framed.metadata, framed.body);
+const decodeFailure = async (
+  decoding: Promise<unknown>,
+): Promise<ResponseFrameError> => {
+  try {
+    await decoding;
+    throw new Error('Expected response frame decoding to fail.');
+  } catch (error) {
+    expect(error).toBeInstanceOf(ResponseFrameError);
+    return error as ResponseFrameError;
+  }
+};
 
-    const result = await decode(chunks);
+describe('hybrid-sdk/http', () => {
+  describe('ResponseFrameDecoder', () => {
+    it.each([
+      ['1+3', [1, 3]],
+      ['2+2', [2, 2]],
+      ['3+1', [3, 1]],
+      ['1+1+1+1', [1, 1, 1, 1]],
+    ])(
+      'decodes the frame when the prefix arrives as %s',
+      async (_label, sizes) => {
+        const framed = createFrame();
+        let offset = 0;
+        const chunks = sizes.map((size) => {
+          const chunk = framed.prefix.subarray(offset, offset + size);
+          offset += size;
+          return chunk;
+        });
+        chunks.push(framed.metadata, framed.body);
 
-    expect(result.metadata).toHaveBeenCalledWith({
-      status: 200,
-      headers: { 'content-type': 'text/plain' },
-    });
-    expect(result.body).toEqual(framed.body);
-  });
+        const result = await decode(chunks);
 
-  it('decodes metadata fragmented through a UTF-8 code point', async () => {
-    const framed = createFrame(Buffer.from('body'), {
-      status: 206,
-      headers: { 'x-label': '日本語' },
-    });
-    const split = framed.metadata.indexOf(Buffer.from('日')) + 1;
-
-    const result = await decode([
-      Buffer.concat([framed.prefix, framed.metadata.subarray(0, split)]),
-      framed.metadata.subarray(split),
-      framed.body,
-    ]);
-
-    expect(result.metadata).toHaveBeenCalledWith({
-      status: 206,
-      headers: { 'x-label': '日本語' },
-    });
-    expect(result.body).toEqual(framed.body);
-  });
-
-  it('emits body bytes in the same chunk that completes metadata', async () => {
-    const framed = createFrame();
-    const split = framed.metadata.length - 3;
-    const firstBodyBytes = framed.body.subarray(0, 5);
-
-    const result = await decode([
-      Buffer.concat([framed.prefix, framed.metadata.subarray(0, split)]),
-      Buffer.concat([framed.metadata.subarray(split), firstBodyBytes]),
-      framed.body.subarray(5),
-    ]);
-
-    expect(result.body).toEqual(framed.body);
-  });
-
-  it('emits no body bytes when metadata application fails', async () => {
-    const framed = createFrame(Buffer.from('must-not-be-written'));
-    const destination = new Writable({
-      write(_chunk, _encoding, callback) {
-        callback();
+        expect(result.metadata).toHaveBeenCalledWith({
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        });
+        expect(result.body).toEqual(framed.body);
       },
-    });
-    const write = jest.spyOn(destination, 'write');
-    const metadataError = new Error('original response rejected metadata');
-
-    await expect(
-      pipeline(
-        Readable.from([
-          Buffer.concat([framed.prefix, framed.metadata, framed.body]),
-        ]),
-        new ResponseFrameDecoder({
-          onMetadata: () => {
-            throw metadataError;
-          },
-        }),
-        destination,
-      ),
-    ).rejects.toThrow(metadataError.message);
-
-    expect(write).not.toHaveBeenCalled();
-  });
-
-  it('streams the first body bytes before source EOF', async () => {
-    const framed = createFrame();
-    const source = new Readable({ read() {} });
-    const received: Buffer[] = [];
-    let firstWrite!: () => void;
-    const firstWriteSeen = new Promise<void>(
-      (resolve) => (firstWrite = resolve),
     );
-    const running = pipeline(
-      source,
-      new ResponseFrameDecoder(),
-      new Writable({
-        write(chunk, _encoding, callback) {
-          received.push(chunk);
-          firstWrite();
+
+    it('decodes metadata when a UTF-8 code point is split across chunks', async () => {
+      const framed = createFrame(Buffer.from('body'), {
+        status: 206,
+        headers: { 'x-label': '日本語' },
+      });
+      const split = framed.metadata.indexOf(Buffer.from('日')) + 1;
+
+      const result = await decode([
+        Buffer.concat([framed.prefix, framed.metadata.subarray(0, split)]),
+        framed.metadata.subarray(split),
+        framed.body,
+      ]);
+
+      expect(result.metadata).toHaveBeenCalledWith({
+        status: 206,
+        headers: { 'x-label': '日本語' },
+      });
+      expect(result.body).toEqual(framed.body);
+    });
+
+    it('forwards body bytes from the chunk that completes metadata', async () => {
+      const framed = createFrame();
+      const split = framed.metadata.length - 3;
+      const firstBodyBytes = framed.body.subarray(0, 5);
+
+      const result = await decode([
+        Buffer.concat([framed.prefix, framed.metadata.subarray(0, split)]),
+        Buffer.concat([framed.metadata.subarray(split), firstBodyBytes]),
+        framed.body.subarray(5),
+      ]);
+
+      expect(result.body).toEqual(framed.body);
+    });
+
+    it('does not forward body bytes when metadata application fails', async () => {
+      const framed = createFrame(Buffer.from('must-not-be-written'));
+      const destination = new Writable({
+        write(_chunk, _encoding, callback) {
           callback();
         },
-      }),
-    );
+      });
+      const write = jest.spyOn(destination, 'write');
+      const metadataError = new Error('original response rejected metadata');
 
-    source.push(Buffer.concat([framed.prefix, framed.metadata, framed.body]));
-    await firstWriteSeen;
-    expect(Buffer.concat(received)).toEqual(framed.body);
-    expect(source.readableEnded).toBe(false);
+      await expect(
+        pipeline(
+          Readable.from([
+            Buffer.concat([framed.prefix, framed.metadata, framed.body]),
+          ]),
+          new ResponseFrameDecoder({
+            onMetadata: () => {
+              throw metadataError;
+            },
+          }),
+          destination,
+        ),
+      ).rejects.toThrow(metadataError.message);
 
-    source.push(null);
-    await running;
-  });
-
-  it('lets pipeline apply destination backpressure to the source', async () => {
-    const framed = createFrame(Buffer.alloc(0));
-    const bodyChunk = Buffer.alloc(64 * 1024);
-    const totalBodyChunks = 100;
-    let emittedBodyChunks = 0;
-    let releaseFirstWrite!: () => void;
-    const firstWriteBlocked = new Promise<void>((resolve) => {
-      releaseFirstWrite = resolve;
-    });
-    let firstWrite = true;
-    const source = new Readable({
-      read() {
-        if (emittedBodyChunks === 0) {
-          this.push(Buffer.concat([framed.prefix, framed.metadata]));
-        }
-        while (emittedBodyChunks < totalBodyChunks) {
-          emittedBodyChunks += 1;
-          if (!this.push(bodyChunk)) {
-            return;
-          }
-        }
-        this.push(null);
-      },
-    });
-    const destination = new Writable({
-      highWaterMark: 1,
-      write(_chunk, _encoding, callback) {
-        if (firstWrite) {
-          firstWrite = false;
-          firstWriteBlocked.then(() => callback());
-        } else {
-          callback();
-        }
-      },
+      expect(write).not.toHaveBeenCalled();
     });
 
-    const running = pipeline(source, new ResponseFrameDecoder(), destination);
-    await new Promise((resolve) => setImmediate(resolve));
-    expect(emittedBodyChunks).toBeLessThan(totalBodyChunks);
-
-    releaseFirstWrite();
-    await running;
-    expect(emittedBodyChunks).toBe(totalBodyChunks);
-  });
-
-  it.each([1, 2, 3])(
-    'rejects a prefix truncated after %d byte(s)',
-    async (length) => {
-      const { prefix } = createFrame();
-      await expect(decode([prefix.subarray(0, length)])).rejects.toThrow(
-        `Incomplete metadata-length prefix: received ${length} of 4 bytes.`,
+    it('forwards body bytes before the source ends', async () => {
+      const framed = createFrame();
+      const source = new Readable({ read() {} });
+      const received: Buffer[] = [];
+      let firstWrite!: () => void;
+      const firstWriteSeen = new Promise<void>(
+        (resolve) => (firstWrite = resolve),
       );
-    },
-  );
+      const running = pipeline(
+        source,
+        new ResponseFrameDecoder(),
+        new Writable({
+          write(chunk, _encoding, callback) {
+            received.push(chunk);
+            firstWrite();
+            callback();
+          },
+        }),
+      );
 
-  it('rejects truncated metadata', async () => {
-    const { prefix, metadata } = createFrame();
-    await expect(
-      decode([prefix, metadata.subarray(0, metadata.length - 2)]),
-    ).rejects.toThrow(
-      `Incomplete response metadata: received ${metadata.length - 2} of ${
-        metadata.length
-      } bytes.`,
+      source.push(Buffer.concat([framed.prefix, framed.metadata, framed.body]));
+      await firstWriteSeen;
+      expect(Buffer.concat(received)).toEqual(framed.body);
+      expect(source.readableEnded).toBe(false);
+
+      source.push(null);
+      await running;
+    });
+
+    it('propagates destination backpressure to the source', async () => {
+      const framed = createFrame(Buffer.alloc(0));
+      const bodyChunk = Buffer.alloc(64 * 1024);
+      const totalBodyChunks = 100;
+      let emittedBodyChunks = 0;
+      let releaseFirstWrite!: () => void;
+      const firstWriteBlocked = new Promise<void>((resolve) => {
+        releaseFirstWrite = resolve;
+      });
+      let firstWrite = true;
+      const source = new Readable({
+        read() {
+          if (emittedBodyChunks === 0) {
+            this.push(Buffer.concat([framed.prefix, framed.metadata]));
+          }
+          while (emittedBodyChunks < totalBodyChunks) {
+            emittedBodyChunks += 1;
+            if (!this.push(bodyChunk)) {
+              return;
+            }
+          }
+          this.push(null);
+        },
+      });
+      const destination = new Writable({
+        highWaterMark: 1,
+        write(_chunk, _encoding, callback) {
+          if (firstWrite) {
+            firstWrite = false;
+            firstWriteBlocked.then(() => callback());
+          } else {
+            callback();
+          }
+        },
+      });
+
+      const running = pipeline(source, new ResponseFrameDecoder(), destination);
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(emittedBodyChunks).toBeLessThan(totalBodyChunks);
+
+      releaseFirstWrite();
+      await running;
+      expect(emittedBodyChunks).toBe(totalBodyChunks);
+    });
+
+    it.each([1, 2, 3])(
+      'rejects the frame when the prefix ends after %d byte(s)',
+      async (length) => {
+        const { prefix } = createFrame();
+        const error = await decodeFailure(decode([prefix.subarray(0, length)]));
+
+        expect(error).toMatchObject({
+          message: `Incomplete metadata-length prefix: received ${length} of 4 bytes.`,
+          diagnostics: {
+            failureReason: 'incomplete-prefix',
+            receivedPrefixBytes: length,
+            expectedPrefixBytes: 4,
+          },
+        });
+      },
     );
-  });
 
-  it('rejects malformed metadata JSON', async () => {
-    const malformed = Buffer.from('{not json');
-    const prefix = Buffer.alloc(4);
-    prefix.writeUInt32LE(malformed.length);
-    await expect(decode([prefix, malformed])).rejects.toThrow(
-      'Malformed response metadata JSON.',
-    );
-  });
+    it('rejects the frame when metadata is truncated', async () => {
+      const { prefix, metadata } = createFrame();
+      const error = await decodeFailure(
+        decode([prefix, metadata.subarray(0, metadata.length - 2)]),
+      );
 
-  it('accepts existing internally generated metadata with no headers field', async () => {
-    const framed = createFrame(Buffer.from('blocked'), { status: 401 });
+      expect(error).toMatchObject({
+        message: `Incomplete response metadata: received ${
+          metadata.length - 2
+        } of ${metadata.length} bytes.`,
+        diagnostics: {
+          failureReason: 'incomplete-metadata',
+          receivedMetadataBytes: metadata.length - 2,
+          expectedMetadataBytes: metadata.length,
+        },
+      });
+    });
 
-    const result = await decode([
-      Buffer.concat([framed.prefix, framed.metadata, framed.body]),
-    ]);
+    it('rejects the frame when metadata contains malformed JSON', async () => {
+      const malformed = Buffer.from('{not json');
+      const prefix = Buffer.alloc(4);
+      prefix.writeUInt32LE(malformed.length);
+      const error = await decodeFailure(decode([prefix, malformed]));
 
-    expect(result.metadata).toHaveBeenCalledWith({ status: 401 });
-    expect(result.body).toEqual(framed.body);
-  });
+      expect(error).toMatchObject({
+        message: 'Malformed response metadata JSON.',
+        diagnostics: { failureReason: 'malformed-metadata' },
+      });
+    });
 
-  it('rejects metadata without a valid HTTP status', async () => {
-    const framed = createFrame(Buffer.alloc(0), { headers: {} });
-    await expect(
-      decode([Buffer.concat([framed.prefix, framed.metadata])]),
-    ).rejects.toThrow('Response metadata must contain a valid status.');
-  });
+    it('accepts metadata when headers are omitted', async () => {
+      const framed = createFrame(Buffer.from('blocked'), { status: 401 });
 
-  it('rejects oversized metadata before buffering it', async () => {
-    const prefix = Buffer.alloc(4);
-    prefix.writeUInt32LE(11);
-    const decoder = new ResponseFrameDecoder({ maxMetadataBytes: 10 });
-    await expect(
-      pipeline(Readable.from([prefix]), decoder, new Writable({ write() {} })),
-    ).rejects.toThrow('exceeds the 10-byte limit');
+      const result = await decode([
+        Buffer.concat([framed.prefix, framed.metadata, framed.body]),
+      ]);
+
+      expect(result.metadata).toHaveBeenCalledWith({ status: 401 });
+      expect(result.body).toEqual(framed.body);
+    });
+
+    it('rejects metadata when the HTTP status is invalid', async () => {
+      const framed = createFrame(Buffer.alloc(0), { headers: {} });
+      const error = await decodeFailure(
+        decode([Buffer.concat([framed.prefix, framed.metadata])]),
+      );
+
+      expect(error).toMatchObject({
+        message: 'Response metadata must contain a valid status.',
+        diagnostics: { failureReason: 'invalid-metadata' },
+      });
+    });
+
+    it('rejects metadata before buffering when its declared length exceeds the limit', async () => {
+      const prefix = Buffer.alloc(4);
+      prefix.writeUInt32LE(11);
+      const decoder = new ResponseFrameDecoder({ maxMetadataBytes: 10 });
+      const error = await decodeFailure(
+        pipeline(
+          Readable.from([prefix]),
+          decoder,
+          new Writable({ write() {} }),
+        ),
+      );
+
+      expect(error).toMatchObject({
+        message: expect.stringContaining('exceeds the 10-byte limit'),
+        diagnostics: { failureReason: 'metadata-too-large' },
+      });
+    });
   });
 });

--- a/test/unit/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.test.ts
+++ b/test/unit/lib/hybrid-sdk/server/routesHandlers/postResponseHandler.test.ts
@@ -1,9 +1,11 @@
-import { EventEmitter } from 'events';
-import express from 'express';
-import http from 'http';
-import { AddressInfo } from 'net';
+import http from 'node:http';
+import { AddressInfo } from 'node:net';
+import { PassThrough, Writable } from 'node:stream';
+import express, { Response } from 'express';
 import { log } from '../../../../../../lib/logs/logger';
 import { handlePostResponse } from '../../../../../../lib/hybrid-sdk/server/routesHandlers/postResponseHandler';
+import { pendingResponseRegistry } from '../../../../../../lib/hybrid-sdk/http/server-post-stream-handler';
+import { getConfig } from '../../../../../../lib/hybrid-sdk/common/config/config';
 
 jest.mock('../../../../../../lib/logs/logger', () => ({
   log: {
@@ -15,30 +17,8 @@ jest.mock('../../../../../../lib/logs/logger', () => ({
   },
 }));
 
-const mockWriteStatusAndHeaders = jest.fn();
-const mockWriteChunk = jest.fn();
-const mockFinished = jest.fn();
-jest.mock(
-  '../../../../../../lib/hybrid-sdk/http/server-post-stream-handler',
-  () => ({
-    StreamResponseHandler: {
-      create: jest.fn(() => ({
-        writeStatusAndHeaders: mockWriteStatusAndHeaders,
-        writeChunk: mockWriteChunk,
-        finished: mockFinished,
-        destroy: jest.fn(),
-        streamResponse: {},
-      })),
-    },
-  }),
-);
-
 jest.mock('../../../../../../lib/hybrid-sdk/common/config/config', () => ({
   getConfig: jest.fn(() => ({ BROKER_SERVER_MANDATORY_AUTH_ENABLED: false })),
-}));
-
-jest.mock('../../../../../../lib/hybrid-sdk/common/utils/metrics', () => ({
-  incrementHttpRequestsTotal: jest.fn(),
 }));
 
 jest.mock('../../../../../../lib/hybrid-sdk/server/utils/token', () => ({
@@ -48,489 +28,646 @@ jest.mock('../../../../../../lib/hybrid-sdk/server/utils/token', () => ({
   })),
 }));
 
-const frameIoData = (obj: Record<string, unknown>): Buffer => {
-  const json = JSON.stringify(obj);
-  const length = Buffer.byteLength(json, 'utf8');
+const frame = (
+  metadata: Record<string, unknown>,
+  body = Buffer.alloc(0),
+): Buffer => {
+  const encodedMetadata = Buffer.from(JSON.stringify(metadata));
   const prefix = Buffer.alloc(4);
-  prefix.writeUInt32LE(length);
-  return Buffer.concat([prefix, Buffer.from(json, 'utf8')]);
+  prefix.writeUInt32LE(encodedMetadata.length);
+  return Buffer.concat([prefix, encodedMetadata, body]);
 };
 
-const validResponseFrame = () => {
+const framedParts = () => {
   const metadata = Buffer.from(
-    JSON.stringify({
-      status: 200,
-      headers: { 'content-type': 'text/plain' },
-    }),
-    'utf8',
+    JSON.stringify({ status: 206, headers: { 'x-spike': 'pipeline' } }),
   );
   const prefix = Buffer.alloc(4);
   prefix.writeUInt32LE(metadata.length);
-  return { prefix, metadata, body: Buffer.from('valid response body') };
+  return { prefix, metadata };
 };
 
 const createReqRes = () => {
-  const req = new EventEmitter() as any;
+  const req = new PassThrough() as any;
   req.params = { brokerToken: 'token', streamingId: 'stream-1' };
   req.headers = {};
   req.requestId = 'req-1';
-  req.pause = jest.fn();
-  req.resume = jest.fn();
   const res = {
+    headersSent: false,
+    destroyed: false,
     status: jest.fn().mockReturnThis(),
     json: jest.fn().mockReturnThis(),
   } as any;
   return { req, res };
 };
 
-describe('handlePostResponse — errorType logging', () => {
-  beforeEach(() => jest.clearAllMocks());
+const claimedPending = (destination: Writable = new PassThrough()) => {
+  destination.on('data', () => undefined);
+  return {
+    destination,
+    applyMetadata: jest.fn(),
+    complete: jest.fn(),
+    cancel: jest.fn(),
+  };
+};
 
-  it('logs errorType at info level when an error code accompanies a >299 status', () => {
-    const { req, res } = createReqRes();
-    handlePostResponse(req, res);
+describe('hybrid-sdk/server', () => {
+  describe('handlePostResponse()', () => {
+    let claimSpy: jest.SpyInstance;
 
-    req.emit(
-      'data',
-      frameIoData({
-        status: 401,
-        errorType: 'FILTER_BLOCKED',
-        headers: {},
-      }),
-    );
-    req.emit('end');
+    beforeEach(() => {
+      jest.clearAllMocks();
+      claimSpy = jest.spyOn(pendingResponseRegistry, 'claim');
+      (getConfig as jest.Mock).mockReturnValue({
+        BROKER_SERVER_MANDATORY_AUTH_ENABLED: false,
+      });
+    });
 
-    expect(log.info).toHaveBeenCalledWith(
-      expect.objectContaining({
-        responseStatus: 401,
-        errorType: 'FILTER_BLOCKED',
-      }),
-      'Handling response-data request - io bits',
-    );
-    expect(mockWriteStatusAndHeaders).toHaveBeenCalledWith(
-      expect.objectContaining({ status: 401, errorType: 'FILTER_BLOCKED' }),
-    );
-  });
+    afterEach(() => {
+      claimSpy.mockRestore();
+    });
 
-  it('carries a synthesized DOWNSTREAM_UNREACHABLE code on a 502', () => {
-    const { req, res } = createReqRes();
-    handlePostResponse(req, res);
-
-    req.emit(
-      'data',
-      frameIoData({
-        status: 502,
-        errorType: 'DOWNSTREAM_UNREACHABLE',
-        headers: {},
-      }),
-    );
-    req.emit('end');
-
-    expect(log.info).toHaveBeenCalledWith(
-      expect.objectContaining({
-        responseStatus: 502,
-        errorType: 'DOWNSTREAM_UNREACHABLE',
-      }),
-      'Handling response-data request - io bits',
-    );
-  });
-
-  it.each([
-    [401, 'DOWNSTREAM_UNAUTHORIZED'],
-    [429, 'DOWNSTREAM_RATE_LIMITED'],
-    [503, 'DOWNSTREAM_SERVER_ERROR'],
-  ])(
-    'logs a pass-through code on a downstream %d, status unchanged',
-    (status, errorType) => {
+    it('claims the pending response and acknowledges after delivery completes', async () => {
       const { req, res } = createReqRes();
-      handlePostResponse(req, res);
+      const received: Buffer[] = [];
+      const destination = new PassThrough();
+      destination.on('data', (chunk) => received.push(chunk));
+      const pending = claimedPending(destination);
+      claimSpy.mockReturnValue({
+        status: 'claimed',
+        pending,
+      });
 
-      req.emit('data', frameIoData({ status, errorType, headers: {} }));
-      req.emit('end');
+      const handling = handlePostResponse(req, res);
+      req.write(
+        frame(
+          {
+            status: 201,
+            headers: { 'content-type': 'application/octet-stream' },
+          },
+          Buffer.from('first'),
+        ),
+      );
+      req.end(Buffer.from('-second'));
+      await handling;
+
+      expect(pendingResponseRegistry.claim).toHaveBeenCalledWith('stream-1', {
+        brokerAppClientId: undefined,
+        enforceBrokerOwnership: false,
+      });
+      expect(pending.applyMetadata).toHaveBeenCalledWith({
+        status: 201,
+        headers: { 'content-type': 'application/octet-stream' },
+      });
+      expect(Buffer.concat(received).toString()).toBe('first-second');
+      expect(pending.complete).toHaveBeenCalledWith(12);
+      expect(pending.cancel).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({});
+      expect(pending.complete.mock.invocationCallOrder[0]).toBeLessThan(
+        res.status.mock.invocationCallOrder[0],
+      );
+      for (const logger of [log.debug, log.info, log.error]) {
+        for (const [context] of (logger as jest.Mock).mock.calls) {
+          expect(context).not.toHaveProperty('failureReason');
+          expect(context).not.toHaveProperty('receivedPrefixBytes');
+          expect(context).not.toHaveProperty('expectedPrefixBytes');
+          expect(context).not.toHaveProperty('receivedMetadataBytes');
+          expect(context).not.toHaveProperty('expectedMetadataBytes');
+        }
+      }
+    });
+
+    it('logs the error type at info level when the response status indicates an error', async () => {
+      const { req, res } = createReqRes();
+      const pending = claimedPending();
+      claimSpy.mockReturnValue({
+        status: 'claimed',
+        pending,
+      });
+
+      const handling = handlePostResponse(req, res);
+      req.end(
+        frame({
+          status: 502,
+          headers: {},
+          errorType: 'DOWNSTREAM_UNREACHABLE',
+        }),
+      );
+      await handling;
 
       expect(log.info).toHaveBeenCalledWith(
-        expect.objectContaining({ responseStatus: status, errorType }),
+        expect.objectContaining({
+          responseStatus: 502,
+          errorType: 'DOWNSTREAM_UNREACHABLE',
+        }),
         'Handling response-data request - io bits',
       );
-      expect(mockWriteStatusAndHeaders).toHaveBeenCalledWith(
-        expect.objectContaining({ status, errorType }),
+    });
+
+    it('waits for destination finalization before acknowledging', async () => {
+      const { req, res } = createReqRes();
+      let releaseFinal!: () => void;
+      const destination = new Writable({
+        write(_chunk, _encoding, callback) {
+          callback();
+        },
+        final(callback) {
+          releaseFinal = callback;
+        },
+      });
+      const pending = claimedPending(destination);
+      claimSpy.mockReturnValue({
+        status: 'claimed',
+        pending,
+      });
+
+      const handling = handlePostResponse(req, res);
+      req.end(frame({ status: 200 }, Buffer.from('body')));
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(pending.complete).not.toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+
+      releaseFinal();
+      await handling;
+      expect(pending.complete).toHaveBeenCalledWith(4);
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('cancels the claim and returns 500 when the source fails', async () => {
+      const { req, res } = createReqRes();
+      const pending = claimedPending();
+      claimSpy.mockReturnValue({
+        status: 'claimed',
+        pending,
+      });
+
+      const handling = handlePostResponse(req, res);
+      const sourceError = new Error('request aborted');
+      req.destroy(sourceError);
+      await handling;
+
+      expect(pending.cancel).toHaveBeenCalledWith(sourceError);
+      expect(pending.complete).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+
+    it('cancels the claim when the source closes prematurely', async () => {
+      const { req, res } = createReqRes();
+      const pending = claimedPending();
+      claimSpy.mockReturnValue({
+        status: 'claimed',
+        pending,
+      });
+
+      const handling = handlePostResponse(req, res);
+      req.write(Buffer.from([1, 2]));
+      req.destroy();
+      await handling;
+
+      expect(pending.cancel).toHaveBeenCalledWith(
+        expect.objectContaining({ code: 'ERR_STREAM_PREMATURE_CLOSE' }),
       );
-    },
-  );
+      expect(pending.complete).not.toHaveBeenCalled();
+    });
 
-  it('leaves errorType undefined for a normal 2xx response (debug branch)', () => {
-    const { req, res } = createReqRes();
-    handlePostResponse(req, res);
+    it('cancels the claim and returns 500 when the destination fails', async () => {
+      const { req, res } = createReqRes();
+      const destinationError = new Error('original response failed');
+      const destination = new Writable({
+        write(_chunk, _encoding, callback) {
+          callback(destinationError);
+        },
+      });
+      const pending = claimedPending(destination);
+      claimSpy.mockReturnValue({
+        status: 'claimed',
+        pending,
+      });
 
-    req.emit('data', frameIoData({ status: 200, headers: {} }));
-    req.emit('end');
+      const handling = handlePostResponse(req, res);
+      req.end(frame({ status: 200, headers: {} }, Buffer.from('body')));
+      await handling;
 
-    expect(log.info).not.toHaveBeenCalledWith(
-      expect.anything(),
-      'Handling response-data request - io bits',
-    );
-    expect(log.debug).toHaveBeenCalledWith(
-      expect.objectContaining({ responseStatus: 200, errorType: undefined }),
-      'Handling response-data request - io bits',
-    );
+      expect(pending.cancel).toHaveBeenCalledWith(destinationError);
+      expect(pending.complete).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(req.destroyed).toBe(true);
+    });
+
+    it('logs incomplete prefix diagnostics, cancels, and returns only the generic failure', async () => {
+      const { req, res } = createReqRes();
+      const pending = claimedPending();
+      claimSpy.mockReturnValue({
+        status: 'claimed',
+        pending,
+      });
+
+      const handling = handlePostResponse(req, res);
+      req.end(Buffer.from([1, 2, 3]));
+      await handling;
+
+      expect(log.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          failureReason: 'incomplete-prefix',
+          receivedPrefixBytes: 3,
+          expectedPrefixBytes: 4,
+          error: expect.any(Error),
+        }),
+        'Failed handling POST response stream pipeline.',
+      );
+      expect(pending.cancel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          diagnostics: {
+            failureReason: 'incomplete-prefix',
+            receivedPrefixBytes: 3,
+            expectedPrefixBytes: 4,
+          },
+        }),
+      );
+      expect(pending.complete).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledTimes(1);
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Failed to handle response stream.',
+      });
+      expect(res.json).not.toHaveBeenCalledWith(
+        expect.objectContaining({ failureReason: expect.any(String) }),
+      );
+    });
+
+    it('logs incomplete metadata diagnostics, cancels, and does not acknowledge success', async () => {
+      const { req, res } = createReqRes();
+      const pending = claimedPending();
+      claimSpy.mockReturnValue({
+        status: 'claimed',
+        pending,
+      });
+      const { prefix, metadata } = framedParts();
+      const receivedMetadataBytes = metadata.length - 2;
+
+      const handling = handlePostResponse(req, res);
+      req.end(
+        Buffer.concat([prefix, metadata.subarray(0, receivedMetadataBytes)]),
+      );
+      await handling;
+
+      expect(log.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          failureReason: 'incomplete-metadata',
+          receivedMetadataBytes,
+          expectedMetadataBytes: metadata.length,
+          error: expect.any(Error),
+        }),
+        'Failed handling POST response stream pipeline.',
+      );
+      expect(pending.cancel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          diagnostics: {
+            failureReason: 'incomplete-metadata',
+            receivedMetadataBytes,
+            expectedMetadataBytes: metadata.length,
+          },
+        }),
+      );
+      expect(pending.complete).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledTimes(1);
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Failed to handle response stream.',
+      });
+    });
+
+    it('returns 500 without reading the body when the response is already claimed', async () => {
+      const { req, res } = createReqRes();
+      claimSpy.mockReturnValue({
+        status: 'already-claimed',
+      });
+
+      await handlePostResponse(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Unable to find request matching streaming id.',
+      });
+    });
+
+    it('returns 401 when the JWT owner does not match the pending response owner', async () => {
+      (getConfig as jest.Mock).mockReturnValue({
+        BROKER_SERVER_MANDATORY_AUTH_ENABLED: true,
+      });
+      const { req, res } = createReqRes();
+      const encodedHeader = Buffer.from(
+        JSON.stringify({ alg: 'none' }),
+      ).toString('base64url');
+      const encodedPayload = Buffer.from(
+        JSON.stringify({ azp: 'broker-client-a' }),
+      ).toString('base64url');
+      req.headers.authorization = `Bearer ${encodedHeader}.${encodedPayload}.`;
+      claimSpy.mockReturnValue({
+        status: 'owner-mismatch',
+      });
+
+      await handlePostResponse(req, res);
+
+      expect(pendingResponseRegistry.claim).toHaveBeenCalledWith('stream-1', {
+        brokerAppClientId: 'broker-client-a',
+        enforceBrokerOwnership: true,
+      });
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid Broker client credentials.',
+      });
+    });
   });
 });
 
-describe('handlePostResponse — four-byte prefix fragmentation evidence', () => {
-  beforeEach(() => jest.clearAllMocks());
-
-  const driveFrame = (prefixFragmentSizes: number[]) => {
-    const { req, res } = createReqRes();
-    const { prefix, metadata, body } = validResponseFrame();
-    handlePostResponse(req, res);
-
-    let offset = 0;
-    for (const size of prefixFragmentSizes) {
-      req.emit('data', prefix.subarray(offset, offset + size));
-      offset += size;
-    }
-    expect(offset).toBe(prefix.length);
-    req.emit('data', metadata);
-    req.emit('data', body);
-    req.emit('end');
-
-    return { res, metadata, body };
-  };
-
-  it('accepts a valid frame when all four prefix bytes are in one data event', () => {
-    const { res, body } = driveFrame([4]);
-
-    expect(log.error).not.toHaveBeenCalledWith(
-      expect.anything(),
-      'Caught error handling data event for streaming HTTP response.',
-    );
-    expect(mockWriteStatusAndHeaders).toHaveBeenCalledWith({
-      status: 200,
-      headers: { 'content-type': 'text/plain' },
-    });
-    expect(mockWriteChunk).toHaveBeenCalledWith(body, expect.any(Function));
-    expect(mockFinished).toHaveBeenCalledTimes(1);
-    expect(res.status).toHaveBeenCalledWith(200);
-  });
-
-  it.each([
-    ['1+3', [1, 3]],
-    ['2+2', [2, 2]],
-    ['3+1', [3, 1]],
-    ['1+1+1+1', [1, 1, 1, 1]],
-    ['1+1+2', [1, 1, 2]],
-    ['1+2+1', [1, 2, 1]],
-    ['2+1+1', [2, 1, 1]],
-  ])(
-    'accepts a valid frame for %s prefix delivery',
-    (_label, fragmentSizes) => {
-      const { res, body } = driveFrame(fragmentSizes as number[]);
-
-      expect(log.error).not.toHaveBeenCalled();
-      expect(mockWriteStatusAndHeaders).toHaveBeenCalledWith({
-        status: 200,
-        headers: { 'content-type': 'text/plain' },
+describe('broker server API', () => {
+  describe('POST /response-data/:brokerToken/:streamingId', () => {
+    beforeEach(() => {
+      (getConfig as jest.Mock).mockReturnValue({
+        BROKER_SERVER_MANDATORY_AUTH_ENABLED: false,
       });
-      expect(mockWriteChunk).toHaveBeenCalledWith(body, expect.any(Function));
-      expect(mockFinished).toHaveBeenCalledTimes(1);
-      expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.json).toHaveBeenCalledWith({});
-    },
-  );
-
-  it('reads the declared metadata size after a fragmented prefix', () => {
-    const { metadata } = driveFrame([1, 3]);
-
-    expect(log.debug).toHaveBeenCalledWith(
-      expect.objectContaining({ statusAndHeadersSize: metadata.length }),
-      'Request metadata size read from stream.',
-    );
-    expect(mockWriteStatusAndHeaders).toHaveBeenCalledWith({
-      status: 200,
-      headers: { 'content-type': 'text/plain' },
     });
-  });
 
-  it.each([1, 2, 3])(
-    'logs an incomplete metadata-length prefix when the request ends after %d byte(s)',
-    (receivedPrefixBytes) => {
-      const { req, res } = createReqRes();
-      const { prefix } = validResponseFrame();
-      handlePostResponse(req, res);
-
-      req.emit('data', prefix.subarray(0, receivedPrefixBytes));
-      req.emit('end');
-
-      const framingErrors = (log.error as jest.Mock).mock.calls.filter(
-        ([, message]) =>
-          message ===
-          'Incomplete metadata-length prefix at end of streaming HTTP response.',
+    it('forwards body bytes before the POST request ends and acknowledges after delivery', async () => {
+      const streamingID = `stream-${Date.now()}`;
+      const received: Buffer[] = [];
+      let firstBodySeen!: () => void;
+      const firstBody = new Promise<void>(
+        (resolve) => (firstBodySeen = resolve),
       );
-      expect(log.error).toHaveBeenCalledTimes(1);
-      expect(framingErrors).toHaveLength(1);
-      expect(framingErrors[0][0]).toMatchObject({
-        hashedToken: 'hashed',
-        maskedToken: 'masked',
-        streamingID: 'stream-1',
-        requestId: 'req-1',
-        receivedPrefixBytes,
-        expectedPrefixBytes: 4,
-        error: {
-          message: `Incomplete metadata-length prefix: received ${receivedPrefixBytes} of 4 bytes.`,
+      const originalResponse = Object.assign(
+        new Writable({
+          write(chunk, _encoding, callback) {
+            received.push(chunk);
+            firstBodySeen();
+            callback();
+          },
+        }),
+        {
+          status: jest.fn().mockReturnThis(),
+          set: jest.fn().mockReturnThis(),
         },
+      );
+      pendingResponseRegistry.register(streamingID, {
+        response: originalResponse as any,
+        brokerAppClientId: null,
       });
-      expect(mockWriteStatusAndHeaders).not.toHaveBeenCalled();
-      expect(mockWriteChunk).not.toHaveBeenCalled();
-      expect(mockFinished).toHaveBeenCalledTimes(1);
-      expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.json).toHaveBeenCalledWith({});
-    },
-  );
 
-  it('logs incomplete response metadata when the request ends before the declared metadata size', () => {
-    const { req, res } = createReqRes();
-    const expectedMetadataBytes = 100;
-    const receivedMetadataBytes = 50;
-    const prefix = Buffer.alloc(4);
-    prefix.writeUInt32LE(expectedMetadataBytes);
-    handlePostResponse(req, res);
+      const app = express();
+      app.post('/response-data/:brokerToken/:streamingId', handlePostResponse);
+      const server = http.createServer(app);
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+          server.off('error', reject);
+          resolve();
+        });
+      });
 
-    req.emit('data', prefix);
-    req.emit('data', Buffer.alloc(receivedMetadataBytes));
-    req.emit('end');
+      try {
+        const { port } = server.address() as AddressInfo;
+        let acknowledgementReceived = false;
+        const acknowledgement = new Promise<{ status: number; body: string }>(
+          (resolve, reject) => {
+            const request = http.request(
+              {
+                host: '127.0.0.1',
+                port,
+                method: 'POST',
+                path: `/response-data/token/${streamingID}`,
+              },
+              (response) => {
+                const responseBody: Buffer[] = [];
+                response.on('data', (chunk) => responseBody.push(chunk));
+                response.on('end', () => {
+                  acknowledgementReceived = true;
+                  resolve({
+                    status: response.statusCode!,
+                    body: Buffer.concat(responseBody).toString(),
+                  });
+                });
+              },
+            );
+            request.on('error', reject);
 
-    const framingErrors = (log.error as jest.Mock).mock.calls.filter(
-      ([, message]) =>
-        message ===
-        'Incomplete response metadata at end of streaming HTTP response.',
-    );
-    expect(log.error).toHaveBeenCalledTimes(1);
-    expect(framingErrors).toHaveLength(1);
-    expect(framingErrors[0][0]).toMatchObject({
-      hashedToken: 'hashed',
-      maskedToken: 'masked',
-      streamingID: 'stream-1',
-      requestId: 'req-1',
-      receivedMetadataBytes,
-      expectedMetadataBytes,
-      error: {
-        message: `Incomplete response metadata: received ${receivedMetadataBytes} of ${expectedMetadataBytes} bytes.`,
+            const { prefix, metadata } = framedParts();
+            request.write(prefix.subarray(0, 1));
+            request.write(prefix.subarray(1));
+            request.write(metadata.subarray(0, 5));
+            request.write(
+              Buffer.concat([
+                metadata.subarray(5),
+                Buffer.from('body-before-eof'),
+              ]),
+            );
+
+            firstBody.then(() => {
+              expect(acknowledgementReceived).toBe(false);
+              request.end(Buffer.from('-after-eof'));
+            }, reject);
+          },
+        );
+
+        await expect(acknowledgement).resolves.toEqual({
+          status: 200,
+          body: '{}',
+        });
+        expect(Buffer.concat(received).toString()).toBe(
+          'body-before-eof-after-eof',
+        );
+        expect(originalResponse.status).toHaveBeenCalledWith(206);
+        expect(originalResponse.set).toHaveBeenCalledWith({
+          'x-spike': 'pipeline',
+        });
+      } finally {
+        await new Promise<void>((resolve, reject) =>
+          server.close((error) => (error ? reject(error) : resolve())),
+        );
+      }
+    });
+
+    it.each([
+      ['incomplete prefix', () => Buffer.from([1, 2, 3])],
+      [
+        'incomplete metadata',
+        () => {
+          const { prefix, metadata } = framedParts();
+          return Buffer.concat([prefix, metadata.subarray(0, 7)]);
+        },
+      ],
+    ])(
+      'returns only the generic HTTP failure for %s framing',
+      async (label, createPayload) => {
+        const streamingID = `${label.replace(' ', '-')}-${Date.now()}`;
+        const originalResponse = Object.assign(new PassThrough(), {
+          status: jest.fn().mockReturnThis(),
+          set: jest.fn().mockReturnThis(),
+        });
+        originalResponse.on('data', () => undefined);
+        originalResponse.on('error', () => undefined);
+        pendingResponseRegistry.register(streamingID, {
+          response: originalResponse as any,
+          brokerAppClientId: null,
+        });
+
+        const app = express();
+        app.post(
+          '/response-data/:brokerToken/:streamingId',
+          handlePostResponse,
+        );
+        const server = http.createServer(app);
+        await new Promise<void>((resolve, reject) => {
+          server.once('error', reject);
+          server.listen(0, '127.0.0.1', () => {
+            server.off('error', reject);
+            resolve();
+          });
+        });
+
+        try {
+          const { port } = server.address() as AddressInfo;
+          const result = await new Promise<{ status: number; body: string }>(
+            (resolve, reject) => {
+              const request = http.request(
+                {
+                  host: '127.0.0.1',
+                  port,
+                  method: 'POST',
+                  path: `/response-data/token/${streamingID}`,
+                },
+                (response) => {
+                  const responseBody: Buffer[] = [];
+                  response.on('data', (chunk) => responseBody.push(chunk));
+                  response.on('end', () =>
+                    resolve({
+                      status: response.statusCode!,
+                      body: Buffer.concat(responseBody).toString(),
+                    }),
+                  );
+                },
+              );
+              request.once('error', reject);
+              request.end(createPayload());
+            },
+          );
+
+          expect(result).toEqual({
+            status: 500,
+            body: '{"message":"Failed to handle response stream."}',
+          });
+          expect(originalResponse.destroyed).toBe(true);
+          expect(pendingResponseRegistry.claim(streamingID)).toEqual({
+            status: 'not-found',
+          });
+        } finally {
+          pendingResponseRegistry.cancel(streamingID);
+          await new Promise<void>((resolve, reject) =>
+            server.close((error) => (error ? reject(error) : resolve())),
+          );
+        }
       },
-    });
-    expect(mockWriteStatusAndHeaders).not.toHaveBeenCalled();
-    expect(mockWriteChunk).not.toHaveBeenCalled();
-    expect(mockFinished).toHaveBeenCalledTimes(1);
-    expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({});
-  });
-
-  it('does not classify a zero-byte request as a truncated prefix', () => {
-    const { req, res } = createReqRes();
-    handlePostResponse(req, res);
-
-    req.emit('end');
-
-    expect(log.error).not.toHaveBeenCalled();
-    expect(mockWriteStatusAndHeaders).not.toHaveBeenCalled();
-    expect(mockWriteChunk).not.toHaveBeenCalled();
-    expect(mockFinished).toHaveBeenCalledTimes(1);
-    expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({});
-  });
-
-  it('parses a complete prefix, metadata, and body from one data event', () => {
-    const { req, res } = createReqRes();
-    const { prefix, metadata, body } = validResponseFrame();
-    handlePostResponse(req, res);
-
-    req.emit('data', Buffer.concat([prefix, metadata, body]));
-    req.emit('end');
-
-    expect(log.error).not.toHaveBeenCalled();
-    expect(mockWriteStatusAndHeaders).toHaveBeenCalledWith({
-      status: 200,
-      headers: { 'content-type': 'text/plain' },
-    });
-    expect(mockWriteChunk).toHaveBeenCalledTimes(1);
-    expect(mockWriteChunk).toHaveBeenCalledWith(body, expect.any(Function));
-    expect(mockFinished).toHaveBeenCalledTimes(1);
-    expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({});
-  });
-
-  it('parses metadata fragmented inside a multibyte UTF-8 value', () => {
-    const { req, res } = createReqRes();
-    const headers = {
-      'content-type': 'text/plain; charset=utf-8',
-      'x-response-label': '日本語',
-    };
-    const metadata = Buffer.from(JSON.stringify({ status: 206, headers }));
-    const prefix = Buffer.alloc(4);
-    prefix.writeUInt32LE(metadata.length);
-    const body = Buffer.from('exact UTF-8 response body');
-    const multibyteValue = Buffer.from('日');
-    const codePointStart = metadata.indexOf(multibyteValue);
-    expect(codePointStart).toBeGreaterThan(-1);
-    const splitPosition = codePointStart + 1;
-    handlePostResponse(req, res);
-
-    req.emit(
-      'data',
-      Buffer.concat([prefix, metadata.subarray(0, splitPosition)]),
     );
-    req.emit('data', Buffer.concat([metadata.subarray(splitPosition), body]));
-    req.emit('end');
 
-    expect(log.error).not.toHaveBeenCalled();
-    expect(mockWriteStatusAndHeaders).toHaveBeenCalledWith({
-      status: 206,
-      headers,
-    });
-    const forwardedBody = Buffer.concat(
-      mockWriteChunk.mock.calls.map(([chunk]) => chunk),
-    );
-    expect(forwardedBody).toEqual(body);
-    expect(mockFinished).toHaveBeenCalledTimes(1);
-    expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({});
-  });
-
-  it('continues into metadata when the prefix-completing event contains both', () => {
-    const { req, res } = createReqRes();
-    const { prefix, metadata, body } = validResponseFrame();
-    handlePostResponse(req, res);
-
-    req.emit('data', prefix.subarray(0, 2));
-    req.emit(
-      'data',
-      Buffer.concat([prefix.subarray(2), metadata.subarray(0, 7)]),
-    );
-    req.emit('data', metadata.subarray(7));
-    req.emit('data', body);
-    req.emit('end');
-
-    expect(log.error).not.toHaveBeenCalledWith(
-      expect.anything(),
-      'Caught error handling data event for streaming HTTP response.',
-    );
-    expect(mockWriteStatusAndHeaders).toHaveBeenCalledWith({
-      status: 200,
-      headers: { 'content-type': 'text/plain' },
-    });
-    expect(mockWriteChunk).toHaveBeenCalledWith(body, expect.any(Function));
-    expect(mockFinished).toHaveBeenCalledTimes(1);
-    expect(res.status).toHaveBeenCalledWith(200);
-  });
-
-  it('forwards body bytes from the event that completes metadata', () => {
-    const { req, res } = createReqRes();
-    const { prefix, metadata, body } = validResponseFrame();
-    const metadataTailLength = 3;
-    const firstBodyLength = 5;
-    handlePostResponse(req, res);
-
-    req.emit(
-      'data',
-      Buffer.concat([
-        prefix,
-        metadata.subarray(0, metadata.length - metadataTailLength),
-      ]),
-    );
-    req.emit(
-      'data',
-      Buffer.concat([
-        metadata.subarray(metadata.length - metadataTailLength),
-        body.subarray(0, firstBodyLength),
-      ]),
-    );
-    req.emit('data', body.subarray(firstBodyLength));
-    req.emit('end');
-
-    expect(log.error).not.toHaveBeenCalledWith(
-      expect.anything(),
-      'Caught error handling data event for streaming HTTP response.',
-    );
-    expect(mockWriteStatusAndHeaders).toHaveBeenCalledWith({
-      status: 200,
-      headers: { 'content-type': 'text/plain' },
-    });
-    const forwardedBody = Buffer.concat(
-      mockWriteChunk.mock.calls.map(([chunk]) => chunk),
-    );
-    expect(forwardedBody).toEqual(body);
-    expect(mockWriteChunk.mock.calls[0][0]).toEqual(
-      body.subarray(0, firstBodyLength),
-    );
-    expect(mockFinished).toHaveBeenCalledTimes(1);
-    expect(res.status).toHaveBeenCalledWith(200);
-  });
-
-  it('reproduces 1+3 prefix delivery through a real chunked HTTP request', async () => {
-    const app = express();
-    let transferEncoding: string | undefined;
-    app.use((req, _res, next) => {
-      transferEncoding = req.headers['transfer-encoding'];
-      next();
-    });
-    app.post('/response-data/:brokerToken/:streamingId', handlePostResponse);
-    const server = http.createServer(app);
-    await new Promise<void>((resolve, reject) => {
-      server.once('error', reject);
-      server.listen(0, '127.0.0.1', () => {
-        server.off('error', reject);
-        resolve();
+    it('aborts delivery without forwarding body bytes when response headers are already committed', async () => {
+      const streamingID = `committed-${Date.now()}`;
+      let originalResponse!: Response;
+      let registered!: () => void;
+      const registration = new Promise<void>(
+        (resolve) => (registered = resolve),
+      );
+      const app = express();
+      app.get('/original', (_req, res) => {
+        originalResponse = res;
+        pendingResponseRegistry.register(streamingID, {
+          response: res,
+          brokerAppClientId: null,
+        });
+        registered();
       });
-    });
+      app.post('/response-data/:brokerToken/:streamingId', handlePostResponse);
+      const server = http.createServer(app);
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+          server.off('error', reject);
+          resolve();
+        });
+      });
 
-    try {
-      const { port } = server.address() as AddressInfo;
-      const { prefix, metadata, body } = validResponseFrame();
-      const responseStatus = new Promise<number | undefined>(
-        (resolve, reject) => {
+      try {
+        const { port } = server.address() as AddressInfo;
+        const originalBody: Buffer[] = [];
+        const originalResult = new Promise<{
+          status: number;
+          aborted: boolean;
+        }>((resolve, reject) => {
+          const request = http.get(
+            { host: '127.0.0.1', port, path: '/original' },
+            (response) => {
+              response.on('data', (chunk) => originalBody.push(chunk));
+              response.once('aborted', () =>
+                resolve({ status: response.statusCode!, aborted: true }),
+              );
+              response.once('end', () =>
+                resolve({ status: response.statusCode!, aborted: false }),
+              );
+              response.on('error', () => undefined);
+            },
+          );
+          request.once('error', reject);
+        });
+        await registration;
+        originalResponse.flushHeaders();
+        expect(originalResponse.headersSent).toBe(true);
+
+        const postResult = new Promise<
+          { type: 'response'; status: number; body: string } | { type: 'error' }
+        >((resolve) => {
           const request = http.request(
             {
               host: '127.0.0.1',
               port,
               method: 'POST',
-              path: '/response-data/token/stream-1',
-              headers: {
-                'content-type': 'application/vnd.broker.stream+octet-stream',
-              },
+              path: `/response-data/token/${streamingID}`,
             },
             (response) => {
-              response.resume();
-              response.on('end', () => resolve(response.statusCode));
+              const responseBody: Buffer[] = [];
+              response.on('data', (chunk) => responseBody.push(chunk));
+              response.on('end', () =>
+                resolve({
+                  type: 'response',
+                  status: response.statusCode!,
+                  body: Buffer.concat(responseBody).toString(),
+                }),
+              );
             },
           );
-          request.on('error', reject);
-          request.write(prefix.subarray(0, 1));
-          request.write(prefix.subarray(1));
-          request.write(metadata);
-          request.end(body);
-        },
-      );
+          request.once('error', () => resolve({ type: 'error' }));
+          request.end(
+            frame({ status: 500 }, Buffer.from('must-not-be-forwarded')),
+          );
+        });
 
-      await expect(responseStatus).resolves.toBe(200);
-      expect(transferEncoding).toBe('chunked');
-
-      const receivedLengths = (log.trace as jest.Mock).mock.calls
-        .filter(([, message]) => message === 'Received data event.')
-        .map(([context]) => context.dataLength);
-      expect(receivedLengths).toEqual([1, 3, metadata.length, body.length]);
-      expect(log.error).not.toHaveBeenCalled();
-      expect(mockWriteStatusAndHeaders).toHaveBeenCalledWith({
-        status: 200,
-        headers: { 'content-type': 'text/plain' },
-      });
-      const forwardedBody = Buffer.concat(
-        mockWriteChunk.mock.calls.map(([chunk]) => chunk),
-      );
-      expect(forwardedBody).toEqual(body);
-      expect(mockFinished).toHaveBeenCalledTimes(1);
-    } finally {
-      await new Promise<void>((resolve, reject) =>
-        server.close((error) => (error ? reject(error) : resolve())),
-      );
-    }
+        const postOutcome = await postResult;
+        if (postOutcome.type === 'response') {
+          expect(postOutcome.status).not.toBe(200);
+        }
+        await expect(originalResult).resolves.toEqual({
+          status: 200,
+          aborted: true,
+        });
+        expect(originalBody).toEqual([]);
+        expect(pendingResponseRegistry.claim(streamingID)).toEqual({
+          status: 'not-found',
+        });
+      } finally {
+        await new Promise<void>((resolve, reject) =>
+          server.close((error) => (error ? reject(error) : resolve())),
+        );
+      }
+    });
   });
 });


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/main/.github/CONTRIBUTING.md) rules

### What does this PR do?
This spike modernizes how Broker Server delivers streamed responses posted back by Broker Client.

Previously, pending responses, metadata decoding, stream buffering, ownership checks, cleanup, and metrics were spread across several handlers. The POST path also manually consumed `data` events and coordinated backpressure around an intermediate `PassThrough`.

This change introduces explicit framing and pending-response abstractions, then uses Node.js pipelines to connect response sources to the original HTTP response.

```
  Original HTTP request
          │
          ▼
  PendingResponseRegistry.register()
          │
          ├── POST delivery
          │     request → ResponseFrameDecoder → original HTTP response
          │
          └── legacy WebSocket delivery
                callback chunks → PassThrough → original HTTP response
```

Only one delivery path can claim a pending response.

### Changes

#### Response frame decoder

Introduces `ResponseFrameDecoder`, which decodes the existing response format:

> `4-byte little-endian metadata length | JSON metadata | body bytes`

The decoder:

  - handles fragmented length prefixes
  - handles metadata split across chunks and UTF-8 code points
  - applies metadata before forwarding body bytes
  - streams body bytes without waiting for source EOF
  - participates in pipeline backpressure
  - Rejects incomplete or malformed framing
  - validates response status, headers, and errorType
  - applies a defensive 1 MiB metadata limit

The wire format itself is unchanged.

#### Pending-response registry

Replaces the shared stream-store representation with `PendingResponseRegistry`.

The registry:

  - registers the original HTTP response as the destination
  - grants a one-shot claim to either POST or legacy WebSocket delivery
  - verifies Broker or legacy connection ownership before consuming a claim
  - distinguishes missing, already-claimed, and owner-mismatch outcomes
  - rejects duplicate registrations
  - handles requester disconnects and response errors
  - expires unclaimed registrations
  - allows an already-claimed delivery to complete after its registration TTL
  - makes completion and cancellation idempotent
  - records response-size metrics after successful completion

#### POST response delivery

`handlePostResponse()` now uses:

> `POST request → ResponseFrameDecoder → original HTTP response`

It:

  - claims the pending response before consuming the POST body
  - applies decoded status and headers to the original response
  - waits for final destination delivery before acknowledging the POST
  - returns `200 {}` only after successful delivery
  - cancels the claim on source, framing, metadata, or destination failure
  - preserves JWT azp ownership validation

#### Legacy WebSocket compatibility

The legacy callback-based response path now uses the same pending-response registry.

A `PassThrough` adapts WebSocket chunks into a pipeline while preserving:

  - the existing callback protocol
  - response metadata application
  - response-size metrics
  - legacy connection ownership
  - protection against POST and WebSocket delivery claiming the same response

The legacy protocol does not provide a drain acknowledgement, so its existing buffering limitation remains.

#### Request registration

The WebSocket request path now registers the original HTTP response directly.

If the requester has already disconnected, registration returns destination-unavailable and no WebSocket request is sent.