### PR TITLE
fix: do not relay downstream framing headers on streamed responses

### DIFF
--- a/lib/hybrid-sdk/LegacyStreamResponseHandler.ts
+++ b/lib/hybrid-sdk/LegacyStreamResponseHandler.ts
@@ -1,6 +1,7 @@
 import {
   streamsStore,
   StreamResponse,
+  stripConnectionScopedHeaders,
 } from './http/server-post-stream-handler';
 import { log as logger } from '../logs/logger';
 import { observeResponseSize } from './common/utils/metrics';
@@ -17,7 +18,14 @@ export const legacyStreamResponseHandler = (token) => {
 
       if (streamBuffer) {
         if (ioResponse) {
-          response.status(ioResponse.status).set(ioResponse.headers);
+          response
+            .status(ioResponse.status)
+            .set(
+              stripConnectionScopedHeaders(
+                ioResponse.headers,
+                response.req?.method,
+              ),
+            );
         }
         if (chunk) {
           streamSize += chunk.length;

--- a/lib/hybrid-sdk/http/server-post-stream-handler.ts
+++ b/lib/hybrid-sdk/http/server-post-stream-handler.ts
@@ -11,6 +11,23 @@ export const streamsStore = new NodeCache({
   useClones: false,
 });
 
+/**
+ * Headers that describe the downstream connection rather than the entity, and
+ * so must not be copied onto the connection we are answering on.
+ *
+ * Content-Length is the load-bearing one: when RES_BODY_URL_SUB is configured
+ * the Broker Client rewrites URLs in the response body as it streams, which
+ * changes the body length. Forwarding the downstream Content-Length then
+ * declares a length we do not send, the response is truncated at that
+ * boundary and the socket is left unusable.
+ */
+const CONNECTION_SCOPED_HEADERS = [
+  'content-length',
+  'transfer-encoding',
+  'connection',
+  'keep-alive',
+];
+
 export interface StreamResponse {
   streamBuffer: stream.PassThrough;
   response: Response;
@@ -53,7 +70,12 @@ export class StreamResponseHandler {
   writeStatusAndHeaders = (statusAndHeaders) => {
     this.streamResponse.response
       .status(statusAndHeaders.status)
-      .set(statusAndHeaders.headers);
+      .set(
+        stripConnectionScopedHeaders(
+          statusAndHeaders.headers,
+          this.streamResponse.response.req?.method,
+        ),
+      );
   };
 
   writeChunk = (chunk, waitForDrainCb) => {
@@ -77,3 +99,28 @@ export class StreamResponseHandler {
     streamsStore.del(this.streamingID);
   };
 }
+
+/**
+ * Returns a copy of the downstream headers with connection-scoped headers
+ * removed, so Node frames the relayed response from what we actually write.
+ *
+ * A HEAD response carries no body, so its Content-Length describes the entity
+ * and is kept.
+ */
+export const stripConnectionScopedHeaders = (
+  headers: Record<string, unknown> = {},
+  requestMethod?: string,
+): Record<string, unknown> => {
+  const isHeadRequest = requestMethod?.toUpperCase() === 'HEAD';
+  const sanitized: Record<string, unknown> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    const normalized = name.toLowerCase();
+    if (CONNECTION_SCOPED_HEADERS.includes(normalized)) {
+      if (!(normalized === 'content-length' && isHeadRequest)) {
+        continue;
+      }
+    }
+    sanitized[name] = value;
+  }
+  return sanitized;
+};

--- a/test/functional/server-client.test.ts
+++ b/test/functional/server-client.test.ts
@@ -431,13 +431,20 @@ describe('proxy requests originating from behind the broker server', () => {
     expect(response.headers).not.toHaveProperty('content-length');
   });
 
-  it('content-length is set without chunked http', async () => {
+  // The relay streams the response and may rewrite it in flight when
+  // RES_BODY_URL_SUB is set, so it cannot vouch for the downstream
+  // Content-Length and no longer forwards it. Node frames what we send.
+  it('content-length is not forwarded from the downstream response', async () => {
     const response = await axiosClient.post(
       `http://localhost:${bs.port}/broker/${brokerToken}/echo-headers`,
       {},
     );
 
-    expect(response.headers).toHaveProperty('content-length');
+    expect(response.status).toEqual(200);
+    expect(response.headers).not.toHaveProperty('content-length');
+    expect(response.headers).toHaveProperty('transfer-encoding', 'chunked');
+    // The body still arrives whole.
+    expect(response.data).toHaveProperty('host');
   });
 
   it('auth header is replaced when url contains token', async () => {

--- a/test/unit/lib/hybrid-sdk/http/server-post-stream-handler.test.ts
+++ b/test/unit/lib/hybrid-sdk/http/server-post-stream-handler.test.ts
@@ -1,0 +1,49 @@
+import { stripConnectionScopedHeaders } from '../../../../../lib/hybrid-sdk/http/server-post-stream-handler';
+
+describe('stripConnectionScopedHeaders', () => {
+  const downstreamHeaders = {
+    'content-type': 'application/json',
+    'content-length': '1024',
+    'transfer-encoding': 'chunked',
+    connection: 'keep-alive',
+    'keep-alive': 'timeout=5',
+    etag: 'abc123',
+  };
+
+  it('drops connection-scoped headers and keeps entity headers', () => {
+    const headers = stripConnectionScopedHeaders(downstreamHeaders, 'GET');
+
+    expect(headers).toEqual({
+      'content-type': 'application/json',
+      etag: 'abc123',
+    });
+  });
+
+  it('does not mutate the headers it was given', () => {
+    const original = { ...downstreamHeaders };
+
+    stripConnectionScopedHeaders(downstreamHeaders, 'GET');
+
+    expect(downstreamHeaders).toEqual(original);
+  });
+
+  it('keeps Content-Length on a HEAD response, which has no body', () => {
+    const headers = stripConnectionScopedHeaders(downstreamHeaders, 'head');
+
+    expect(headers['content-length']).toEqual('1024');
+    expect(headers['transfer-encoding']).toBeUndefined();
+  });
+
+  it('matches header names case insensitively', () => {
+    const headers = stripConnectionScopedHeaders(
+      { 'Content-Length': '1024', 'Content-Type': 'application/json' },
+      'GET',
+    );
+
+    expect(headers).toEqual({ 'Content-Type': 'application/json' });
+  });
+
+  it('tolerates a missing header object and an unknown method', () => {
+    expect(stripConnectionScopedHeaders(undefined, undefined)).toEqual({});
+  });
+});

--- a/test/unit/lib/hybrid-sdk/http/streamed-response-framing.test.ts
+++ b/test/unit/lib/hybrid-sdk/http/streamed-response-framing.test.ts
@@ -1,0 +1,162 @@
+import express from 'express';
+import http from 'http';
+import stream from 'stream';
+import { AddressInfo } from 'net';
+import { handlePostResponse } from '../../../../../lib/hybrid-sdk/server/routesHandlers/postResponseHandler';
+import { streamsStore } from '../../../../../lib/hybrid-sdk/http/server-post-stream-handler';
+
+jest.mock('../../../../../lib/logs/logger', () => ({
+  log: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    trace: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+jest.mock('../../../../../lib/hybrid-sdk/common/config/config', () => ({
+  getConfig: jest.fn(() => ({ BROKER_SERVER_MANDATORY_AUTH_ENABLED: false })),
+}));
+
+jest.mock('../../../../../lib/hybrid-sdk/common/utils/metrics', () => ({
+  incrementHttpRequestsTotal: jest.fn(),
+  observeResponseSize: jest.fn(),
+}));
+
+jest.mock('../../../../../lib/hybrid-sdk/server/utils/token', () => ({
+  getDesensitizedToken: jest.fn(() => ({
+    hashedToken: 'hashed',
+    maskedToken: 'masked',
+  })),
+}));
+
+const frame = (metadata: Record<string, unknown>, body: string): Buffer => {
+  const json = Buffer.from(JSON.stringify(metadata), 'utf8');
+  const prefix = Buffer.alloc(4);
+  prefix.writeUInt32LE(json.length);
+  return Buffer.concat([prefix, json, Buffer.from(body, 'utf8')]);
+};
+
+// The Broker Client rewrites URLs in the body as it streams when
+// RES_BODY_URL_SUB is set, so the relayed body no longer matches the length
+// the downstream declared.
+const DOWNSTREAM_BODY = '{"tarball":"http://short.example"}';
+const REWRITTEN_BODY =
+  '{"tarball":"http://internal-broker-server-next/broker/a-much-longer-token"}';
+
+describe('streamed response framing', () => {
+  let server: http.Server;
+  let port: number;
+
+  beforeAll(async () => {
+    const app = express();
+
+    // Stands in for clientRequestHelpers.makeWebsocketRequestWithStreamingResponse
+    app.get('/relay/:streamingId', (req, res) => {
+      const streamBuffer = new stream.PassThrough({ highWaterMark: 1048576 });
+      streamsStore.set(req.params.streamingId, {
+        response: res,
+        streamBuffer,
+        streamSize: 0,
+        brokerAppClientId: null,
+      });
+      streamBuffer.pipe(res);
+    });
+
+    app.post('/response-data/:brokerToken/:streamingId', handlePostResponse);
+
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, resolve);
+    });
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  const relay = (
+    streamingId: string,
+    metadata: Record<string, unknown>,
+    body: string,
+    method = 'GET',
+  ) =>
+    new Promise<{
+      status?: number;
+      headers: http.IncomingHttpHeaders;
+      body: string;
+    }>((resolve, reject) => {
+      const waiting = http.request(
+        { port, path: `/relay/${streamingId}`, method },
+        (res) => {
+          let received = '';
+          res.setEncoding('utf8');
+          res.on('data', (chunk) => (received += chunk));
+          res.on('end', () =>
+            resolve({
+              status: res.statusCode,
+              headers: res.headers,
+              body: received,
+            }),
+          );
+        },
+      );
+      waiting.on('error', reject);
+      waiting.end();
+
+      // Give the GET time to register its stream, then post the response.
+      setTimeout(() => {
+        const post = http.request(
+          {
+            port,
+            path: `/response-data/a-token/${streamingId}`,
+            method: 'POST',
+          },
+          (res) => res.resume(),
+        );
+        post.on('error', reject);
+        post.end(frame(metadata, body));
+      }, 50);
+    });
+
+  it('delivers a body that is longer than the downstream Content-Length', async () => {
+    const res = await relay(
+      'stream-longer-body',
+      {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          'content-length': `${DOWNSTREAM_BODY.length}`,
+        },
+      },
+      REWRITTEN_BODY,
+    );
+
+    expect(res.status).toEqual(200);
+    expect(res.body).toEqual(REWRITTEN_BODY);
+    expect(res.headers['content-length']).toBeUndefined();
+    expect(res.headers['transfer-encoding']).toEqual('chunked');
+  });
+
+  it('does not relay connection-scoped headers from the downstream', async () => {
+    const res = await relay(
+      'stream-hop-by-hop',
+      {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          'content-length': '5',
+          'transfer-encoding': 'chunked',
+          connection: 'keep-alive',
+          etag: 'abc123',
+        },
+      },
+      REWRITTEN_BODY,
+    );
+
+    expect(res.body).toEqual(REWRITTEN_BODY);
+    expect(res.headers['etag']).toEqual('abc123');
+    expect(res.headers['content-type']).toContain('json');
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/main/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Stops the streamed response relay copying the downstream `Content-Length` onto the connection we are answering on.

**Fixes truncated responses on brokered registry traffic.** With `RES_BODY_URL_SUB` configured the client rewrites URLs in the body as it streams, so the body no longer matches the length the downstream declared. Node truncates at that boundary and writes the surplus onto the socket, leaving it unusable. On OSM-3915 every rewritten npm metadata response came back short and the requester failed with ECONNRESET.

**Strips the connection-scoped headers.** `Content-Length`, `Transfer-Encoding`, `Connection`, `Keep-Alive`. They describe the downstream connection, not ours. `Content-Length` survives on HEAD, where it describes the entity.

**Changes an asserted contract, so please push back if you disagree.** `content-length is set without chunked http` asserted the relay forwards the downstream length. That is the behaviour causing the bug, so the test now asserts chunked framing and no `Content-Length`. Relayed responses that previously carried a length will be chunked.

#### Where should the reviewer start?

`lib/hybrid-sdk/http/server-post-stream-handler.ts`. `LegacyStreamResponseHandler` carried the same copy.

#### How should this be manually tested?

`test/unit/lib/hybrid-sdk/http/streamed-response-framing.test.ts` drives the real relay. Both cases fail on main with `Parse Error: Expected HTTP/`, the production symptom.

#### Any background context you want to provide?

Server side only, so it ships on deploy with no client upgrade. One pre-existing defect alongside this, not introduced here and not the cause of OSM-3915: with `RES_BODY_URL_SUB` set the relay returns an empty 200, because the ioData length prefix shares the buffer the substitution transform reads and takes a UTF-8 round trip. Harness and mechanism in #1223.

