### PR TITLE
fix: drop Content-Length when the client rewrites the response body

### DIFF
--- a/lib/hybrid-sdk/http/downstream-post-stream-to-server.ts
+++ b/lib/hybrid-sdk/http/downstream-post-stream-to-server.ts
@@ -542,10 +542,12 @@ class BrokerServerPostResponseHandler {
         );
       }
       const isResponseJson = isJson(response.headers);
+      const willRewriteBody =
+        Boolean(config.RES_BODY_URL_SUB) && isResponseJson;
       const errorType = classifyDownstreamStatus(status);
       const ioData = JSON.stringify({
         status,
-        headers: response.headers,
+        headers: headersForRelay(response.headers, willRewriteBody),
         errorType,
       });
 
@@ -638,6 +640,24 @@ class BrokerServerPostResponseHandler {
     this.#buffer.write(JSON.stringify(body));
     this.#buffer.end();
   }
+}
+
+/**
+ * The URL substitution below rewrites the body as it streams, which changes its
+ * length, so the downstream Content-Length stops describing what we send. Drop
+ * it and let the Broker Server frame the relayed response.
+ */
+export function headersForRelay(responseHeaders, bodyWillBeRewritten: boolean) {
+  if (!bodyWillBeRewritten) {
+    return responseHeaders;
+  }
+  const headers = { ...responseHeaders };
+  for (const name of Object.keys(headers)) {
+    if (name.toLowerCase() === 'content-length') {
+      delete headers[name];
+    }
+  }
+  return headers;
 }
 
 function isJson(responseHeaders) {

--- a/lib/hybrid-sdk/responseSenders.ts
+++ b/lib/hybrid-sdk/responseSenders.ts
@@ -1,4 +1,7 @@
-import { BrokerServerPostResponseHandler } from './http/downstream-post-stream-to-server';
+import {
+  BrokerServerPostResponseHandler,
+  headersForRelay,
+} from './http/downstream-post-stream-to-server';
 import { legacyStreaming } from './requestsHelper';
 import { log as logger } from '../logs/logger';
 import { IncomingMessage } from 'node:http';
@@ -97,6 +100,9 @@ export class HybridResponseHandler {
     if (this.config.RES_BODY_URL_SUB && isJson(response.headers)) {
       const replaced = replaceUrlPartialChunk(response.body, null, this.config);
       response.body = replaced.newChunk;
+      // The substitution changed the body length, so the downstream
+      // Content-Length no longer describes what we send.
+      response.headers = headersForRelay(response.headers, true);
     }
     const status = (response && response.statusCode) || 500;
     logResponse(logContext, status, response, this.config);

--- a/test/unit/lib/hybrid-sdk/http/headers-for-relay.test.ts
+++ b/test/unit/lib/hybrid-sdk/http/headers-for-relay.test.ts
@@ -1,0 +1,34 @@
+import { headersForRelay } from '../../../../../lib/hybrid-sdk/http/downstream-post-stream-to-server';
+
+describe('headersForRelay', () => {
+  const downstreamHeaders = {
+    'content-type': 'application/json',
+    'content-length': '1024',
+    etag: 'abc123',
+  };
+
+  it('drops Content-Length when the body will be rewritten', () => {
+    expect(headersForRelay(downstreamHeaders, true)).toEqual({
+      'content-type': 'application/json',
+      etag: 'abc123',
+    });
+  });
+
+  it('leaves the headers untouched when the body is relayed as is', () => {
+    expect(headersForRelay(downstreamHeaders, false)).toBe(downstreamHeaders);
+  });
+
+  it('does not mutate the headers it was given', () => {
+    const original = { ...downstreamHeaders };
+
+    headersForRelay(downstreamHeaders, true);
+
+    expect(downstreamHeaders).toEqual(original);
+  });
+
+  it('matches the header name case insensitively', () => {
+    expect(
+      headersForRelay({ 'Content-Length': '1024', ETag: 'abc123' }, true),
+    ).toEqual({ ETag: 'abc123' });
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/main/.github/CONTRIBUTING.md) rules

Stacked on #1221, review that first.

#### What does this PR do?

Stops the Broker Client sending a `Content-Length` it already knows is wrong.

**Drops the header when the body will be rewritten.** `RES_BODY_URL_SUB` rewrites URLs in the response body as it streams, which changes its length, but the client passed the downstream headers to the Broker Server unchanged. Same treatment on the non-streaming websocket path, where the substitution is applied to the whole body at once.

#### Where should the reviewer start?

`headersForRelay` in `lib/hybrid-sdk/http/downstream-post-stream-to-server.ts`. Headers are returned untouched when no substitution is configured, so behaviour is unchanged for everyone else.

#### How should this be manually tested?

`test/unit/lib/hybrid-sdk/http/headers-for-relay.test.ts`.

#### Any background context you want to provide?

#1221 makes the server stop trusting that header, which is what actually fixes OSM-3915 and needs no client upgrade. This is belt and braces on the client, so it can take its time through a release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted header sanitization on an optional URL-substitution path; default relay behavior is unchanged when rewriting is off.
> 
> **Overview**
> When **`RES_BODY_URL_SUB`** rewrites URLs in JSON response bodies, the relayed payload no longer matches the downstream **`Content-Length`**. This PR strips that header before the Broker Client forwards status/headers to the Broker Server, so the server is not told an incorrect body size.
> 
> A shared **`headersForRelay`** helper removes **`Content-Length`** (case-insensitive, without mutating the original header object) only when a rewrite will happen; otherwise headers pass through unchanged. It is wired into the **streaming POST-to-server** path when building the initial ioData, and into the **non-streaming** path in **`responseSenders`** after **`replaceUrlPartialChunk`** runs on the full body.
> 
> Unit tests cover the strip/no-op, immutability, and case-insensitive matching behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce7e872180a3e5f587651349900360ff06f54d34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->