### PR TITLE
test: add a reproducible RES_BODY_URL_SUB relay harness

### DIFF
--- a/test/functional/res-body-url-sub.test.ts
+++ b/test/functional/res-body-url-sub.test.ts
@@ -1,0 +1,89 @@
+import path from 'path';
+import { axiosClient } from '../setup/axios-client';
+import {
+  BrokerClient,
+  closeBrokerClient,
+  createBrokerClient,
+} from '../setup/broker-client';
+import {
+  BrokerServer,
+  closeBrokerServer,
+  createBrokerServer,
+  waitForBrokerClientConnections,
+} from '../setup/broker-server';
+import { TestWebServer, createTestWebServer } from '../setup/test-web-server';
+
+const fixtures = path.resolve(__dirname, '..', 'fixtures');
+const serverAccept = path.join(fixtures, 'server', 'filters.json');
+const clientAccept = path.join(fixtures, 'client', 'filters.json');
+
+// Matches the tarball URLs the fixture route serves, so every substitution
+// makes the body longer than the Content-Length the downstream declared.
+const RES_BODY_URL_SUB = 'http://private-registry.internal:8000/artifactory';
+const FIXTURE = '/test-blob-param/json-url-substitution';
+
+describe('RES_BODY_URL_SUB response rewriting', () => {
+  let tws: TestWebServer;
+  let bs: BrokerServer;
+  let bc: BrokerClient;
+  let brokerToken: string;
+
+  beforeAll(async () => {
+    const PORT = 9999;
+    process.env.BROKER_SERVER_URL = `http://localhost:${PORT}`;
+
+    tws = await createTestWebServer();
+    bs = await createBrokerServer({ port: PORT, filters: serverAccept });
+    bc = await createBrokerClient({
+      brokerServerUrl: `http://localhost:${bs.port}`,
+      brokerToken: 'broker-token-12345',
+      filters: clientAccept,
+      resBodyUrlSub: RES_BODY_URL_SUB,
+      type: 'client',
+    });
+
+    const connData = await waitForBrokerClientConnections(bs, 2);
+    const primaryIndex = connData.metadataArray[0]['role'] == 'primary' ? 0 : 1;
+    brokerToken = connData.brokerTokens[primaryIndex];
+  });
+
+  afterAll(async () => {
+    await tws.server.close();
+    await closeBrokerClient(bc);
+    await closeBrokerServer(bs);
+    delete process.env.BROKER_SERVER_URL;
+  });
+
+  it('serves a fixture whose rewritten body outgrows its Content-Length', async () => {
+    const origin = await axiosClient.get(
+      `http://localhost:${tws.port}${FIXTURE}`,
+      { transformResponse: (data) => data },
+    );
+
+    const body = origin.data as string;
+    expect(origin.headers['content-length']).toEqual(
+      `${Buffer.byteLength(body, 'utf8')}`,
+    );
+    expect(body.split(RES_BODY_URL_SUB).length - 1).toEqual(20);
+  });
+
+  // Currently fails before the body is ever relayed: the 4-byte little-endian
+  // ioData length prefix is written into the same buffer the substitution
+  // transform reads, so `Buffer.from(chunk).toString()` puts it through a UTF-8
+  // round trip. Any prefix byte >= 0x80 becomes U+FFFD, the Broker Server reads
+  // a bogus metadata length and the requester gets an empty 200.
+  it.failing('relays the rewritten body intact', async () => {
+    const relayed = await axiosClient.get(
+      `http://localhost:${bs.port}/broker/${brokerToken}${FIXTURE}`,
+      { transformResponse: (data) => data },
+    );
+
+    const body = (relayed.data ?? '') as string;
+    expect(relayed.status).toEqual(200);
+    expect(body).not.toEqual('');
+    expect(body).not.toContain(RES_BODY_URL_SUB);
+    expect(body).toContain('/broker/');
+    expect(() => JSON.parse(body)).not.toThrow();
+    expect(JSON.parse(body).versions).toHaveLength(20);
+  });
+});

--- a/test/setup/broker-client.ts
+++ b/test/setup/broker-client.ts
@@ -20,6 +20,7 @@ interface CreateBrokerClientOptions {
   filters?: string;
   passwordPool?: Array<string>;
   port?: number;
+  resBodyUrlSub?: string;
   type?: string;
   universalBrokerEnabled?: string;
 }
@@ -74,6 +75,7 @@ export const createBrokerClient = async (
         ? params.passwordPool.join(',')
         : undefined,
       BROKER_TYPE: params.type ? params.type : undefined,
+      RES_BODY_URL_SUB: params.resBodyUrlSub ?? undefined,
       removeXForwardedHeaders: 'true',
       universalBrokerEnabled: params.universalBrokerEnabled ?? false,
     },

--- a/test/setup/test-web-server.ts
+++ b/test/setup/test-web-server.ts
@@ -162,6 +162,27 @@ const applyEchoRoutes = (app: Express) => {
     },
   );
 
+  // JSON whose URLs grow when RES_BODY_URL_SUB rewrites them, served with an
+  // explicit Content-Length. no-transform keeps the compression middleware out.
+  echoRouter.get(
+    '/test-blob-param/json-url-substitution',
+    (_: express.Request, resp: express.Response) => {
+      const body = JSON.stringify({
+        versions: Array.from({ length: 20 }, (_unused, i) => ({
+          version: `1.0.${i}`,
+          dist: {
+            tarball: `http://private-registry.internal:8000/artifactory/api/npm/repo/pkg/-/pkg-1.0.${i}.tgz`,
+          },
+        })),
+      });
+      resp.setHeader('cache-control', 'no-transform');
+      resp.setHeader('content-type', 'application/json');
+      resp.setHeader('content-length', `${Buffer.byteLength(body, 'utf8')}`);
+      resp.status(200);
+      resp.end(body);
+    },
+  );
+
   echoRouter.get(
     '/test-blob-param/:param',
     (req: express.Request, resp: express.Response) => {

--- a/test/unit/lib/hybrid-sdk/http/io-data-framing.test.ts
+++ b/test/unit/lib/hybrid-sdk/http/io-data-framing.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The Broker Client frames a streamed response as a 4-byte little-endian
+ * length prefix, then the ioData (status and headers) JSON, then the body.
+ *
+ * When RES_BODY_URL_SUB is configured the substitution transform sits in the
+ * same pipeline and reads every chunk as `Buffer.from(chunk).toString()`, so
+ * the prefix takes a UTF-8 round trip along with the body. These tests pin how
+ * that round trip behaves, because it decides whether the Broker Server can
+ * read the frame at all.
+ */
+describe('ioData length prefix framing', () => {
+  const prefixFor = (length: number): Buffer => {
+    const prefix = Buffer.alloc(4);
+    prefix.writeUInt32LE(length);
+    return prefix;
+  };
+
+  const afterUtf8RoundTrip = (buf: Buffer): Buffer =>
+    Buffer.from(Buffer.from(buf).toString(), 'utf8');
+
+  it.each([515, 516, 519, 521, 538])(
+    'survives a UTF-8 round trip when every prefix byte is below 0x80 (%i)',
+    (length) => {
+      const prefix = prefixFor(length);
+
+      const roundTripped = afterUtf8RoundTrip(prefix);
+
+      expect(roundTripped).toEqual(prefix);
+      expect(roundTripped.readUInt32LE()).toEqual(length);
+    },
+  );
+
+  it.each([128, 205, 255, 1000])(
+    'is corrupted by a UTF-8 round trip once a prefix byte reaches 0x80 (%i)',
+    (length) => {
+      const prefix = prefixFor(length);
+
+      const roundTripped = afterUtf8RoundTrip(prefix);
+
+      // U+FFFD replaces the unmappable byte, so the prefix grows and the
+      // Broker Server reads a metadata length that was never sent.
+      expect(roundTripped).not.toEqual(prefix);
+      expect(roundTripped.length).toBeGreaterThan(prefix.length);
+      expect(roundTripped.readUInt32LE()).not.toEqual(length);
+    },
+  );
+
+  it('corrupts roughly half of all possible ioData lengths', () => {
+    const corrupted = Array.from(
+      { length: 4096 },
+      (_unused, length) => length,
+    ).filter(
+      (length) =>
+        !afterUtf8RoundTrip(prefixFor(length)).equals(prefixFor(length)),
+    ).length;
+
+    expect(corrupted).toEqual(2048);
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/main/.github/CONTRIBUTING.md) rules

Tests only, no behaviour change. Branched off `main` so it runs against current Broker as well as #1221.

#### What does this PR do?

Gives `RES_BODY_URL_SUB` the end-to-end coverage it never had, which is why two defects on that path went unnoticed.

**Adds a deterministic upstream fixture.** `GET /test-blob-param/json-url-substitution` serves npm-style metadata with an explicit `Content-Length` and 20 tarball URLs that grow by 21 bytes each when substituted, plus a `resBodyUrlSub` option on the functional Broker Client.

**Records the relay failure.** The relay test is `it.failing`: with `RES_BODY_URL_SUB` set the requester gets an empty 200. The 4-byte ioData length prefix is written into the same buffer the substitution transform reads, so it takes a UTF-8 round trip and any byte at or above `0x80` becomes U+FFFD. The Broker Server then reads a metadata length that was never sent. `io-data-framing.test.ts` pins the mechanism: half of all ioData lengths corrupt.

#### Where should the reviewer start?

`test/unit/lib/hybrid-sdk/http/io-data-framing.test.ts`, then the fixture route.

#### How should this be manually tested?

`jest functional/res-body-url-sub` and `jest io-data-framing`.

#### Any background context you want to provide?

Separate from the truncation in #1221. Drop `.failing` once the framing is fixed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes (fixtures, harness options, and failing expectations); no production code paths are modified.
> 
> **Overview**
> **Adds end-to-end and unit coverage for `RES_BODY_URL_SUB` without changing Broker runtime behavior.** The goal is to reproduce relay failures that previously had no automated tests.
> 
> A new test web route serves npm-style JSON with 20 private-registry tarball URLs, explicit `Content-Length`, and `no-transform` so URL substitution reliably lengthens the body. Functional test setup can pass `resBodyUrlSub` into the broker client (wired to `RES_BODY_URL_SUB`).
> 
> `res-body-url-sub.test.ts` checks the fixture directly, then uses **`it.failing`** on the broker relay: with substitution enabled, clients currently get an empty **200** because the ioData length prefix is UTF-8–round-tripped through the same transform as the body (bytes ≥ `0x80` become U+FFFD and corrupt framing). **`io-data-framing.test.ts`** documents that mechanism and that about half of metadata lengths corrupt under that round trip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c680404a0215aa6c5e2556acf9de7b3839f2549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->