### PR TITLE
fix: drop stale response content length after URL substitution

### DIFF
--- a/lib/hybrid-sdk/common/utils/response-body-url-substitution.ts
+++ b/lib/hybrid-sdk/common/utils/response-body-url-substitution.ts
@@ -1,0 +1,28 @@
+import { isJson } from './json';
+
+/**
+ * RES_BODY_URL_SUB can change response byte length, so applicable responses
+ * cannot retain the downstream Content-Length as authoritative metadata.
+ * Streaming senders must decide before knowing whether a literal URL matched;
+ * applicability is therefore enough to invalidate the downstream length
+ * without buffering. Buffered senders may replace it with the known final
+ * transformed byte length.
+ */
+export const getResponseBodyUrlSubstitutionPolicy = (
+  config,
+  responseHeaders,
+) => {
+  const applies = Boolean(config.RES_BODY_URL_SUB) && isJson(responseHeaders);
+  if (!applies) {
+    return { applies, headers: responseHeaders };
+  }
+
+  const headers = { ...responseHeaders };
+  for (const name of Object.keys(headers)) {
+    if (name.toLowerCase() === 'content-length') {
+      delete headers[name];
+    }
+  }
+
+  return { applies, headers };
+};

--- a/lib/hybrid-sdk/http/downstream-post-stream-to-server.ts
+++ b/lib/hybrid-sdk/http/downstream-post-stream-to-server.ts
@@ -17,6 +17,7 @@ import { addServerIdAndRoleQS } from './utils';
 import { getConfig } from '../common/config/config';
 import type { ExtendedLogContext } from '../common/types/log';
 import { replaceUrlPartialChunk } from '../common/utils/replace-vars';
+import { getResponseBodyUrlSubstitutionPolicy } from '../common/utils/response-body-url-substitution';
 import { classifyDownstreamStatus } from '../common/types/telemetry';
 import { performance } from 'node:perf_hooks';
 
@@ -541,11 +542,14 @@ class BrokerServerPostResponseHandler {
           'response received, setting up stream to Broker Server',
         );
       }
-      const isResponseJson = isJson(response.headers);
+      const substitutionPolicy = getResponseBodyUrlSubstitutionPolicy(
+        config,
+        response.headers,
+      );
       const errorType = classifyDownstreamStatus(status);
       const ioData = JSON.stringify({
         status,
-        headers: response.headers,
+        headers: substitutionPolicy.headers,
         errorType,
       });
 
@@ -567,7 +571,7 @@ class BrokerServerPostResponseHandler {
             { chunkLength: chunk.length, httpBody },
             'writing data to buffer',
           );
-          if (config.RES_BODY_URL_SUB && isResponseJson) {
+          if (substitutionPolicy.applies) {
             const { newChunk, partial } = replaceUrlPartialChunk(
               Buffer.from(chunk).toString(),
               prevPartialChunk,
@@ -583,7 +587,7 @@ class BrokerServerPostResponseHandler {
 
       if (
         (config && config.LOG_ENABLE_BODY === 'true') ||
-        (config.RES_BODY_URL_SUB && isResponseJson)
+        substitutionPolicy.applies
       ) {
         this.#logger.debug('Pipelining with body logging on or Body replace ');
         await pipeline(
@@ -638,10 +642,6 @@ class BrokerServerPostResponseHandler {
     this.#buffer.write(JSON.stringify(body));
     this.#buffer.end();
   }
-}
-
-function isJson(responseHeaders) {
-  return responseHeaders['content-type']?.includes('json') || false;
 }
 
 function readBody(response: http.IncomingMessage): Promise<string> {

--- a/lib/hybrid-sdk/requestsHelper.ts
+++ b/lib/hybrid-sdk/requestsHelper.ts
@@ -1,28 +1,35 @@
 import { log as logger } from '../logs/logger';
 import { logError, logResponse } from '../logs/log';
-import { isJson } from './common/utils/json';
 import { replaceUrlPartialChunk } from './common/utils/replace-vars';
+import { getResponseBodyUrlSubstitutionPolicy } from './common/utils/response-body-url-substitution';
 
-export const legacyStreaming = (logContext, rqst, config, io, streamingID) => {
+export const legacyStreaming = (
+  logContext,
+  response,
+  config,
+  io,
+  streamingID,
+) => {
   let prevPartialChunk;
-  let isResponseJson;
   logger.info(
     logContext,
     'Server did not advertise received-post-streams capability - falling back to legacy streaming.',
   );
   // Fall back to older streaming method if somehow connected to older server version
-  rqst
-    .on('response', (response) => {
-      const status = (response && response.statusCode) || 500;
-      logResponse(logContext, status, response, config);
-      isResponseJson = isJson(response.headers);
-      io.send('chunk', streamingID, '', false, {
-        status,
-        headers: response.headers,
-      });
-    })
+  const status = (response && response.statusCode) || 500;
+  logResponse(logContext, status, response, config);
+  const substitutionPolicy = getResponseBodyUrlSubstitutionPolicy(
+    config,
+    response.headers,
+  );
+  io.send('chunk', streamingID, '', false, {
+    status,
+    headers: substitutionPolicy.headers,
+  });
+
+  response
     .on('data', (chunk) => {
-      if (config.RES_BODY_URL_SUB && isResponseJson) {
+      if (substitutionPolicy.applies) {
         const { newChunk, partial } = replaceUrlPartialChunk(
           Buffer.from(chunk).toString(),
           prevPartialChunk,

--- a/lib/hybrid-sdk/responseSenders.ts
+++ b/lib/hybrid-sdk/responseSenders.ts
@@ -3,8 +3,8 @@ import { legacyStreaming } from './requestsHelper';
 import { log as logger } from '../logs/logger';
 import { IncomingMessage } from 'node:http';
 import { logError, logResponse } from '../logs/log';
-import { isJson } from './common/utils/json';
 import { replaceUrlPartialChunk } from './common/utils/replace-vars';
+import { getResponseBodyUrlSubstitutionPolicy } from './common/utils/response-body-url-substitution';
 import { RequestMetadata } from './types';
 import { WebSocketConnection } from './client/types/client';
 import { WebSocketServer } from './server/types/socket';
@@ -94,9 +94,23 @@ export class HybridResponseHandler {
       });
     }
 
-    if (this.config.RES_BODY_URL_SUB && isJson(response.headers)) {
+    const substitutionPolicy = getResponseBodyUrlSubstitutionPolicy(
+      this.config,
+      response.headers,
+    );
+    if (substitutionPolicy.applies) {
+      const hadContentLength = Object.keys(response.headers).some(
+        (name) => name.toLowerCase() === 'content-length',
+      );
       const replaced = replaceUrlPartialChunk(response.body, null, this.config);
       response.body = replaced.newChunk;
+      response.headers = substitutionPolicy.headers;
+      if (hadContentLength) {
+        response.headers['content-length'] = `${Buffer.byteLength(
+          response.body,
+          'utf8',
+        )}`;
+      }
     }
     const status = (response && response.statusCode) || 500;
     logResponse(logContext, status, response, this.config);

--- a/test/functional/res-body-url-sub-content-length.test.ts
+++ b/test/functional/res-body-url-sub-content-length.test.ts
@@ -1,0 +1,101 @@
+import path from 'path';
+import { axiosClient } from '../setup/axios-client';
+import {
+  BrokerClient,
+  closeBrokerClient,
+  createBrokerClient,
+} from '../setup/broker-client';
+import {
+  BrokerServer,
+  closeBrokerServer,
+  createBrokerServer,
+  waitForBrokerClientConnections,
+} from '../setup/broker-server';
+import { TestWebServer, createTestWebServer } from '../setup/test-web-server';
+
+const fixtures = path.resolve(__dirname, '..', 'fixtures');
+const serverAccept = path.join(fixtures, 'server', 'filters.json');
+const clientAccept = path.join(fixtures, 'client', 'filters.json');
+const responseUrl = 'http://private-registry.internal:8000/artifactory';
+const fixturePath = '/test-blob-param/json-url-substitution';
+
+describe('broker server API', () => {
+  describe('fixed Client with unchanged Broker Server', () => {
+    describe('response body URL substitution', () => {
+      let testWebServer: TestWebServer;
+      let brokerServer: BrokerServer;
+      let brokerClient: BrokerClient;
+      let brokerToken: string;
+
+      beforeAll(async () => {
+        const brokerServerPort = 9999;
+        process.env.BROKER_SERVER_URL = `http://localhost:${brokerServerPort}`;
+
+        testWebServer = await createTestWebServer();
+        brokerServer = await createBrokerServer({
+          port: brokerServerPort,
+          filters: serverAccept,
+        });
+        brokerClient = await createBrokerClient({
+          brokerServerUrl: `http://localhost:${brokerServer.port}`,
+          brokerToken: 'broker-token-12345',
+          filters: clientAccept,
+          resBodyUrlSub: responseUrl,
+          type: 'client',
+        });
+
+        const connections = await waitForBrokerClientConnections(
+          brokerServer,
+          2,
+        );
+        const primaryIndex =
+          connections.metadataArray[0]['role'] === 'primary' ? 0 : 1;
+        brokerToken = connections.brokerTokens[primaryIndex];
+      });
+
+      afterAll(async () => {
+        await testWebServer.server.close();
+        await closeBrokerClient(brokerClient);
+        await closeBrokerServer(brokerServer);
+        delete process.env.BROKER_SERVER_URL;
+      });
+
+      it('returns complete transformed JSON with requester-visible chunked framing', async () => {
+        const origin = await axiosClient.get(
+          `http://localhost:${testWebServer.port}${fixturePath}`,
+          { transformResponse: (body) => body },
+        );
+        const originalBody = origin.data as string;
+        const replacementUrl =
+          'http://internal-broker-server-next/broker/broker-token-12345';
+        const expectedBody = originalBody.replaceAll(
+          responseUrl,
+          replacementUrl,
+        );
+
+        expect(origin.headers['content-length']).toBe(
+          `${Buffer.byteLength(originalBody, 'utf8')}`,
+        );
+        expect(Buffer.byteLength(expectedBody, 'utf8')).not.toBe(
+          Buffer.byteLength(originalBody, 'utf8'),
+        );
+
+        const relayed = await axiosClient.get(
+          `http://localhost:${brokerServer.port}/broker/${brokerToken}${fixturePath}`,
+          { transformResponse: (body) => body },
+        );
+
+        expect(relayed.status).toBe(200);
+        expect(relayed.headers).not.toHaveProperty('content-length');
+        expect(relayed.headers['transfer-encoding']).toBe('chunked');
+        expect(relayed.headers['x-regression-header']).toBe('preserved');
+        expect(relayed.data).toBe(expectedBody);
+        expect(Buffer.byteLength(relayed.data, 'utf8')).toBe(
+          Buffer.byteLength(expectedBody, 'utf8'),
+        );
+        expect(() => JSON.parse(relayed.data)).not.toThrow();
+        expect(JSON.parse(relayed.data).versions).toHaveLength(20);
+      });
+    });
+  });
+});

--- a/test/setup/broker-client.ts
+++ b/test/setup/broker-client.ts
@@ -20,6 +20,7 @@ interface CreateBrokerClientOptions {
   filters?: string;
   passwordPool?: Array<string>;
   port?: number;
+  resBodyUrlSub?: string;
   type?: string;
   universalBrokerEnabled?: string;
 }
@@ -74,6 +75,7 @@ export const createBrokerClient = async (
         ? params.passwordPool.join(',')
         : undefined,
       BROKER_TYPE: params.type ? params.type : undefined,
+      RES_BODY_URL_SUB: params.resBodyUrlSub ?? undefined,
       removeXForwardedHeaders: 'true',
       universalBrokerEnabled: params.universalBrokerEnabled ?? false,
     },

--- a/test/setup/test-web-server.ts
+++ b/test/setup/test-web-server.ts
@@ -163,6 +163,29 @@ const applyEchoRoutes = (app: Express) => {
   );
 
   echoRouter.get(
+    '/test-blob-param/json-url-substitution',
+    (_: express.Request, resp: express.Response) => {
+      const body = JSON.stringify({
+        versions: Array.from({ length: 20 }, (_unused, index) => ({
+          version: `1.0.${index}`,
+          dist: {
+            tarball: `http://private-registry.internal:8000/artifactory/api/npm/repo/pkg/-/pkg-1.0.${index}.tgz`,
+          },
+        })),
+      });
+      resp.setHeader('cache-control', 'no-transform');
+      resp.setHeader('content-type', 'application/json');
+      resp.setHeader('content-length', `${Buffer.byteLength(body, 'utf8')}`);
+      resp.setHeader('x-regression-header', 'preserved');
+      // Keep the Broker metadata frame in a UTF-8-safe length range. The
+      // separate framing issue is outside this Content-Length regression.
+      resp.setHeader('x-test-padding', 'x'.repeat(100));
+      resp.status(200);
+      resp.end(body);
+    },
+  );
+
+  echoRouter.get(
     '/test-blob-param/:param',
     (req: express.Request, resp: express.Response) => {
       const size = parseInt(req.params.param, 10);

--- a/test/unit/lib/hybrid-sdk/http/response-body-url-substitution.test.ts
+++ b/test/unit/lib/hybrid-sdk/http/response-body-url-substitution.test.ts
@@ -1,0 +1,193 @@
+import http from 'node:http';
+import { AddressInfo, Socket } from 'node:net';
+
+import { setConfig } from '../../../../../lib/hybrid-sdk/common/config/config';
+import { BrokerServerPostResponseHandler } from '../../../../../lib/hybrid-sdk/http/downstream-post-stream-to-server';
+
+describe('hybrid-sdk/http', () => {
+  describe('BrokerServerPostResponseHandler', () => {
+    describe('response body URL substitution', () => {
+      const responseUrl = 'http://private-registry.example/artifactory';
+      const replacementUrl =
+        'http://internal-broker-server-next/broker/test-broker-token';
+      const originalBody = JSON.stringify({
+        tarball: `${responseUrl}/pkg.tgz`,
+      });
+      const transformedBody = JSON.stringify({
+        tarball: `${replacementUrl}/pkg.tgz`,
+      });
+      let brokerServer: http.Server;
+      let brokerServerUrl: string;
+      let requestBodyPromise: Promise<Buffer>;
+
+      beforeEach(async () => {
+        let resolveRequestBody: (body: Buffer) => void;
+        requestBodyPromise = new Promise<Buffer>((resolve) => {
+          resolveRequestBody = resolve;
+        });
+        brokerServer = http.createServer((request, response) => {
+          const chunks: Buffer[] = [];
+          request.on('data', (chunk) => chunks.push(chunk));
+          request.on('end', () => {
+            resolveRequestBody(Buffer.concat(chunks));
+            response.writeHead(200);
+            response.end('OK');
+          });
+        });
+        await new Promise<void>((resolve, reject) => {
+          brokerServer.once('error', reject);
+          brokerServer.listen(0, '127.0.0.1', () => {
+            brokerServer.off('error', reject);
+            resolve();
+          });
+        });
+        const address = brokerServer.address() as AddressInfo;
+        brokerServerUrl = `http://127.0.0.1:${address.port}`;
+      });
+
+      afterEach(async () => {
+        if (!brokerServer.listening) {
+          return;
+        }
+        await new Promise<void>((resolve, reject) => {
+          brokerServer.close((error) => (error ? reject(error) : resolve()));
+        });
+      });
+
+      async function relay(
+        config: Record<string, any>,
+        contentType = 'application/json',
+        body = originalBody,
+        contentLengthHeader = 'content-length',
+      ) {
+        setConfig({
+          brokerServerUrl,
+          universalBrokerEnabled: false,
+          universalBrokerGa: false,
+          ...config,
+        });
+        const handler = new BrokerServerPostResponseHandler(
+          {} as any,
+          configWithServerUrl(config),
+          'test-broker-token',
+          123,
+          'test-request-id',
+          'primary',
+        );
+        const socket = new Socket();
+        const downstreamResponse = new http.IncomingMessage(socket);
+        downstreamResponse.statusCode = 207;
+        const downstreamHeaders = {
+          'content-type': contentType,
+          [contentLengthHeader]: `${Buffer.byteLength(body, 'utf8')}`,
+          'x-downstream-header': 'preserved',
+        };
+        downstreamResponse.headers = downstreamHeaders;
+
+        const forwardPromise = handler.forwardRequest(
+          downstreamResponse,
+          'test-streaming-id',
+        );
+        process.nextTick(() => {
+          downstreamResponse.push(body);
+          downstreamResponse.push(null);
+        });
+        await forwardPromise;
+        const requestBody = await requestBodyPromise;
+        socket.destroy();
+
+        const metadataLength = requestBody.readUInt32LE(0);
+        const metadataEnd = 4 + metadataLength;
+        return {
+          body: requestBody.subarray(metadataEnd).toString('utf8'),
+          downstreamHeaders,
+          metadata: JSON.parse(
+            requestBody.subarray(4, metadataEnd).toString('utf8'),
+          ),
+        };
+      }
+
+      function configWithServerUrl(config: Record<string, any>) {
+        return {
+          brokerServerUrl,
+          universalBrokerEnabled: false,
+          universalBrokerGa: false,
+          ...config,
+        };
+      }
+
+      it('removes stale content length and streams the transformed body', async () => {
+        const relayed = await relay(
+          {
+            RES_BODY_URL_SUB: responseUrl,
+            BROKER_TOKEN: 'test-broker-token',
+          },
+          'application/json',
+          originalBody,
+          'Content-Length',
+        );
+
+        expect(relayed.metadata).toEqual({
+          status: 207,
+          headers: {
+            'content-type': 'application/json',
+            'x-downstream-header': 'preserved',
+          },
+        });
+        expect(relayed.body).toBe(transformedBody);
+        expect(Buffer.byteLength(relayed.body, 'utf8')).not.toBe(
+          Buffer.byteLength(originalBody, 'utf8'),
+        );
+        expect(relayed.downstreamHeaders).toEqual({
+          'content-type': 'application/json',
+          'Content-Length': `${Buffer.byteLength(originalBody, 'utf8')}`,
+          'x-downstream-header': 'preserved',
+        });
+      });
+
+      it('preserves fixed-length metadata and body without configuration', async () => {
+        const relayed = await relay({});
+
+        expect(relayed.metadata).toEqual({
+          status: 207,
+          headers: relayed.downstreamHeaders,
+        });
+        expect(relayed.body).toBe(originalBody);
+      });
+
+      it('preserves fixed-length metadata and body for a non-JSON response', async () => {
+        const relayed = await relay(
+          {
+            RES_BODY_URL_SUB: responseUrl,
+            BROKER_TOKEN: 'test-broker-token',
+          },
+          'text/plain',
+        );
+
+        expect(relayed.metadata).toEqual({
+          status: 207,
+          headers: relayed.downstreamHeaders,
+        });
+        expect(relayed.body).toBe(originalBody);
+      });
+
+      it('removes content length before an eligible body with no matching URL', async () => {
+        const bodyWithoutMatch = JSON.stringify({ message: 'no URL here' });
+        const relayed = await relay(
+          {
+            RES_BODY_URL_SUB: responseUrl,
+            BROKER_TOKEN: 'test-broker-token',
+          },
+          'application/json',
+          bodyWithoutMatch,
+        );
+
+        expect(relayed.metadata.headers).toEqual({
+          'content-type': 'application/json',
+          'x-downstream-header': 'preserved',
+        });
+        expect(relayed.body).toBe(bodyWithoutMatch);
+      });
+    });
+  });
+});

--- a/test/unit/lib/hybrid-sdk/requestsHelper.test.ts
+++ b/test/unit/lib/hybrid-sdk/requestsHelper.test.ts
@@ -8,6 +8,8 @@
 
 import { log as logger } from '../../../../lib/logs/logger';
 import { legacyStreaming } from '../../../../lib/hybrid-sdk/requestsHelper';
+import { EventEmitter } from 'node:events';
+import { HybridResponseHandler } from '../../../../lib/hybrid-sdk/responseSenders';
 
 jest.mock('../../../../lib/logs/logger');
 
@@ -35,5 +37,152 @@ describe('legacyStreaming — capability-fallback log level', () => {
       expect.anything(),
       'Server did not advertise received-post-streams capability - falling back to legacy streaming.',
     );
+  });
+});
+
+describe('hybrid-sdk/client', () => {
+  describe('legacyStreaming', () => {
+    describe('response body URL substitution', () => {
+      const responseUrl = 'http://private-registry.example/artifactory';
+      const replacementUrl =
+        'http://internal-broker-server-next/broker/test-broker-token';
+      const originalBody = JSON.stringify({
+        tarball: `${responseUrl}/pkg.tgz`,
+      });
+      const transformedBody = JSON.stringify({
+        tarball: `${replacementUrl}/pkg.tgz`,
+      });
+
+      const relayLegacyStreamingResponse = (
+        config,
+        contentType = 'application/json',
+        body = originalBody,
+        contentLengthHeader = 'content-length',
+      ) => {
+        const response = new EventEmitter() as EventEmitter & {
+          statusCode: number;
+          headers: Record<string, string>;
+        };
+        const websocketConnection = { send: jest.fn() };
+        const headers = {
+          'content-type': contentType,
+          [contentLengthHeader]: `${Buffer.byteLength(body)}`,
+          'x-downstream-header': 'preserved',
+        };
+        const handler = new HybridResponseHandler(
+          {
+            connectionIdentifier: 'test-broker-token',
+            payloadStreamingId: 'stream-1',
+            requestId: 'request-1',
+          } as any,
+          websocketConnection as any,
+          undefined as any,
+          config,
+          logContext,
+        );
+
+        // With a streaming ID and no receive-post-streams capability this
+        // selects the production legacy websocket sender with the already
+        // received IncomingMessage shape used by makeStreamingRequestToDownstream.
+        response.statusCode = 206;
+        response.headers = headers;
+        handler.streamDataResponse(response as any);
+        response.emit('data', Buffer.from(body));
+        response.emit('end');
+
+        return { headers, websocketConnection };
+      };
+
+      it('removes stale content length and streams the transformed body', () => {
+        const { headers, websocketConnection } = relayLegacyStreamingResponse(
+          {
+            RES_BODY_URL_SUB: responseUrl,
+            BROKER_TOKEN: 'test-broker-token',
+          },
+          'application/json',
+          originalBody,
+          'CONTENT-LENGTH',
+        );
+
+        expect(websocketConnection.send.mock.calls[0]).toEqual([
+          'chunk',
+          'stream-1',
+          '',
+          false,
+          {
+            status: 206,
+            headers: {
+              'content-type': 'application/json',
+              'snyk-request-id': 'request-1',
+              'x-broker-ws-response': 'true',
+              'x-downstream-header': 'preserved',
+            },
+          },
+        ]);
+        expect(websocketConnection.send.mock.calls[1]).toEqual([
+          'chunk',
+          'stream-1',
+          transformedBody,
+          false,
+        ]);
+        expect(Buffer.byteLength(transformedBody)).not.toBe(
+          Buffer.byteLength(originalBody),
+        );
+        expect(headers['CONTENT-LENGTH']).toBe(
+          `${Buffer.byteLength(originalBody)}`,
+        );
+      });
+
+      it('preserves fixed-length metadata and body without configuration', () => {
+        const { headers, websocketConnection } = relayLegacyStreamingResponse(
+          {},
+        );
+
+        expect(websocketConnection.send.mock.calls[0][4]).toEqual({
+          status: 206,
+          headers,
+        });
+        expect(websocketConnection.send.mock.calls[1][2]).toEqual(
+          Buffer.from(originalBody),
+        );
+      });
+
+      it('removes content length before an eligible body with no matching URL', () => {
+        const bodyWithoutMatch = JSON.stringify({ message: 'no URL here' });
+        const { websocketConnection } = relayLegacyStreamingResponse(
+          {
+            RES_BODY_URL_SUB: responseUrl,
+            BROKER_TOKEN: 'test-broker-token',
+          },
+          'application/json',
+          bodyWithoutMatch,
+        );
+
+        expect(
+          websocketConnection.send.mock.calls[0][4].headers,
+        ).not.toHaveProperty('content-length');
+        expect(websocketConnection.send.mock.calls[1][2]).toBe(
+          bodyWithoutMatch,
+        );
+      });
+
+      it('preserves fixed-length metadata and body for a non-JSON response', () => {
+        const { headers, websocketConnection } = relayLegacyStreamingResponse(
+          {
+            RES_BODY_URL_SUB: responseUrl,
+            BROKER_TOKEN: 'test-broker-token',
+          },
+          'text/plain',
+        );
+
+        expect(websocketConnection.send.mock.calls[0][4]).toEqual({
+          status: 206,
+          headers,
+        });
+        expect(websocketConnection.send.mock.calls[1][2]).toEqual(
+          Buffer.from(originalBody),
+        );
+      });
+    });
   });
 });

--- a/test/unit/lib/hybrid-sdk/responseSenders.test.ts
+++ b/test/unit/lib/hybrid-sdk/responseSenders.test.ts
@@ -78,6 +78,213 @@ describe('HybridResponseHandler.sendDataResponse — downstream relay classifica
   );
 });
 
+describe('hybrid-sdk/client', () => {
+  describe('HybridResponseHandler', () => {
+    describe('buffered websocket response body URL substitution', () => {
+      const responseUrl = 'http://private-registry.example/artifactory';
+      const replacementUrl =
+        'http://internal-broker-server-next/broker/test-broker-token';
+      const originalBody = JSON.stringify({
+        tarball: `${responseUrl}/pkg.tgz`,
+        location: 'München',
+      });
+      const transformedBody = JSON.stringify({
+        tarball: `${replacementUrl}/pkg.tgz`,
+        location: 'München',
+      });
+
+      const sendBufferedResponse = (
+        config,
+        contentType = 'application/json',
+        body = originalBody,
+        contentLengthHeader = 'content-length',
+        additionalHeaders = {},
+      ) => {
+        const websocketResponseHandler = jest.fn();
+        const handler = new HybridResponseHandler(
+          {
+            connectionIdentifier: 'test-broker-token',
+            requestId: 'request-1',
+          } as any,
+          {} as any,
+          websocketResponseHandler,
+          { socketMaxResponseLength: '20971520', ...config } as any,
+          {} as any,
+        );
+        const headers = {
+          'content-type': contentType,
+          [contentLengthHeader]: `${Buffer.byteLength(body, 'utf8')}`,
+          'x-downstream-header': 'preserved',
+          ...additionalHeaders,
+        };
+
+        handler.sendDataResponse({ statusCode: 201, body, headers }, {});
+
+        return { headers, websocketResponseHandler };
+      };
+
+      it('recomputes content length from the complete transformed body', () => {
+        const { headers, websocketResponseHandler } = sendBufferedResponse(
+          {
+            RES_BODY_URL_SUB: responseUrl,
+            BROKER_TOKEN: 'test-broker-token',
+          },
+          'application/json',
+          originalBody,
+          'Content-Length',
+        );
+
+        expect(websocketResponseHandler).toHaveBeenCalledWith({
+          status: 201,
+          body: transformedBody,
+          headers: {
+            'content-type': 'application/json',
+            'content-length': `${Buffer.byteLength(transformedBody, 'utf8')}`,
+            'x-downstream-header': 'preserved',
+            'snyk-request-id': 'request-1',
+            'x-broker-ws-response': 'true',
+          },
+        });
+        expect(Buffer.byteLength(transformedBody, 'utf8')).not.toBe(
+          Buffer.byteLength(originalBody, 'utf8'),
+        );
+        expect(headers['Content-Length']).toBe(
+          `${Buffer.byteLength(originalBody, 'utf8')}`,
+        );
+        expect(headers).not.toHaveProperty('snyk-request-id');
+      });
+
+      it('collapses differently cased source lengths into one transformed byte length', () => {
+        const { headers, websocketResponseHandler } = sendBufferedResponse(
+          {
+            RES_BODY_URL_SUB: responseUrl,
+            BROKER_TOKEN: 'test-broker-token',
+          },
+          'application/json',
+          originalBody,
+          'Content-Length',
+          {
+            'content-length': `${Buffer.byteLength(originalBody, 'utf8')}`,
+            'CONTENT-LENGTH': `${Buffer.byteLength(originalBody, 'utf8')}`,
+          },
+        );
+
+        const relayed = websocketResponseHandler.mock.calls[0][0];
+        expect(relayed.headers).toEqual({
+          'content-type': 'application/json',
+          'content-length': `${Buffer.byteLength(transformedBody, 'utf8')}`,
+          'x-downstream-header': 'preserved',
+          'snyk-request-id': 'request-1',
+          'x-broker-ws-response': 'true',
+        });
+        expect(headers).toEqual({
+          'content-type': 'application/json',
+          'Content-Length': `${Buffer.byteLength(originalBody, 'utf8')}`,
+          'content-length': `${Buffer.byteLength(originalBody, 'utf8')}`,
+          'CONTENT-LENGTH': `${Buffer.byteLength(originalBody, 'utf8')}`,
+          'x-downstream-header': 'preserved',
+        });
+      });
+
+      it('preserves fixed-length metadata and body without configuration', () => {
+        const { websocketResponseHandler } = sendBufferedResponse({});
+
+        expect(websocketResponseHandler).toHaveBeenCalledWith(
+          expect.objectContaining({
+            body: originalBody,
+            headers: expect.objectContaining({
+              'content-length': `${Buffer.byteLength(originalBody, 'utf8')}`,
+              'x-downstream-header': 'preserved',
+            }),
+          }),
+        );
+      });
+
+      it('preserves fixed-length metadata and body for a non-JSON response', () => {
+        const { websocketResponseHandler } = sendBufferedResponse(
+          {
+            RES_BODY_URL_SUB: responseUrl,
+            BROKER_TOKEN: 'test-broker-token',
+          },
+          'text/plain',
+        );
+
+        expect(websocketResponseHandler).toHaveBeenCalledWith(
+          expect.objectContaining({
+            body: originalBody,
+            headers: expect.objectContaining({
+              'content-length': `${Buffer.byteLength(originalBody, 'utf8')}`,
+              'x-downstream-header': 'preserved',
+            }),
+          }),
+        );
+      });
+
+      it('retains the exact length for an eligible body with no matching URL', () => {
+        const bodyWithoutMatch = JSON.stringify({
+          message: 'no URL here',
+          location: 'München',
+        });
+        const { websocketResponseHandler } = sendBufferedResponse(
+          {
+            RES_BODY_URL_SUB: responseUrl,
+            BROKER_TOKEN: 'test-broker-token',
+          },
+          'application/json',
+          bodyWithoutMatch,
+        );
+
+        expect(websocketResponseHandler).toHaveBeenCalledWith(
+          expect.objectContaining({
+            body: bodyWithoutMatch,
+            headers: expect.objectContaining({
+              'content-length': `${Buffer.byteLength(
+                bodyWithoutMatch,
+                'utf8',
+              )}`,
+            }),
+          }),
+        );
+      });
+
+      it('keeps content length absent when transformed metadata had no fixed length', () => {
+        const websocketResponseHandler = jest.fn();
+        const handler = new HybridResponseHandler(
+          {
+            connectionIdentifier: 'test-broker-token',
+            requestId: 'request-1',
+          } as any,
+          {} as any,
+          websocketResponseHandler,
+          {
+            socketMaxResponseLength: '20971520',
+            RES_BODY_URL_SUB: responseUrl,
+            BROKER_TOKEN: 'test-broker-token',
+          } as any,
+          {} as any,
+        );
+
+        handler.sendDataResponse(
+          {
+            statusCode: 201,
+            body: originalBody,
+            headers: {
+              'content-type': 'application/json',
+              'transfer-encoding': 'chunked',
+            },
+          },
+          {},
+        );
+
+        const relayed = websocketResponseHandler.mock.calls[0][0];
+        expect(relayed.body).toBe(transformedBody);
+        expect(relayed.headers).not.toHaveProperty('content-length');
+        expect(relayed.headers['transfer-encoding']).toBe('chunked');
+      });
+    });
+  });
+});
+
 describe('HybridResponseHandler — send-back failure emits a joinable client-error', () => {
   beforeEach(() => (emitError as jest.Mock).mockClear());
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/broker/blob/main/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR fixes stale `Content-Length` metadata when `RES_BODY_URL_SUB` rewrites json response bodies.

When the response body changes size, the downstream `Content-Length` is no longer valid. This can cause the reconstructed response to be truncated.

  - remove `Content-Length` for streaming responses when `RES_BODY_URL_SUB` applies
  - recompute `Content-Length` for buffered responses when the final transformed size is known
  - preserve existing behavior when response body URL substitution does not apply
  - cover post streaming, legacy websocket streaming, and buffered websocket paths

Closes #1222.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes response header and body relay semantics on all JSON paths when RES_BODY_URL_SUB is enabled; incorrect handling could still truncate bodies or confuse clients, but behavior is narrowly scoped and heavily tested.
> 
> **Overview**
> Fixes **stale `Content-Length`** when **`RES_BODY_URL_SUB`** rewrites JSON response bodies (URLs can change byte size and truncate relayed responses).
> 
> Introduces **`getResponseBodyUrlSubstitutionPolicy`**, which applies when substitution is configured and the response is JSON: it strips all **`Content-Length`** header variants from forwarded metadata. **Streaming** paths (HTTP POST back to the broker server and legacy WebSocket streaming) use that policy up front so length is not trusted before the body is transformed; **buffered** WebSocket responses still rewrite the body, then **recompute** `Content-Length` from the final UTF-8 body when the downstream response had a fixed length.
> 
> **`legacyStreaming`** now accepts the downstream **`response`** directly instead of attaching to a request’s `response` event. Unit and functional tests cover post-streaming, legacy streaming, buffered relay, and end-to-end broker behavior (chunked framing when length is dropped).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03e0e22d22eddc5e79839a13ec92a553a87a81aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->